### PR TITLE
Introduce codebase linting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,21 +13,13 @@ jobs:
     steps:
       - checkout
 
-      # Gex tools
       - restore_cache:
           keys:
-            - gex-tools-{{ checksum "tools.go" }}
+            - go-mod-v1-{{ checksum "go.sum" }}-{{ checksum "tools.go" }}
+
       - run:
           name: Install gex
           command: go get github.com/izumin5210/gex/cmd/gex && make setup
-      - save_cache:
-          key: gex-tools-{{ checksum "tools.go" }}
-          paths:
-            - "/go/bin/gex"
-
-      - restore_cache:
-          keys:
-            - go-mod-v1-{{ checksum "go.sum" }}
 
       - run:
           name: Lint project
@@ -37,6 +29,6 @@ jobs:
           command: go test -cover ./...
 
       - save_cache:
-          key: go-mod-v1-{{ checksum "go.sum" }}
+          key: go-mod-v1-{{ checksum "go.sum" }}-{{ checksum "tools.go" }}
           paths:
             - "/go/pkg/mod"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,30 @@ jobs:
     working_directory: /go/src/github.com/tadoku/api
     steps:
       - checkout
+
+      # Gex tools
+      - restore_cache:
+          keys:
+            - gex-tools-{{ checksum "tools.go" }}
+      - run:
+          name: Install gex
+          command: go get github.com/izumin5210/gex/cmd/gex && make setup
+      - save_cache:
+          key: gex-tools-{{ checksum "tools.go" }}
+          paths:
+            - "/go/bin/gex"
+
       - restore_cache:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
+
       - run:
           name: Lint project
           command: make lint
       - run:
           name: Run tests
           command: go test -cover ./...
+
       - save_cache:
           key: go-mod-v1-{{ checksum "go.sum" }}
           paths:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ jobs:
           keys:
             - go-mod-v1-{{ checksum "go.sum" }}
       - run:
+          name: Lint project
+          command: make lint
+      - run:
           name: Run tests
           command: go test -cover ./...
       - save_cache:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 SHELL := /bin/bash -Eeuo pipefail
 
 .PHONY: all
-all: setup gen migrate test
+all: setup gen lint migrate test
 
 .PHONY: setup
 setup:
@@ -11,6 +11,10 @@ setup:
 .PHONY: gen
 gen:
 	@go generate ./...
+
+.PHONY: lint
+lint:
+	gex golint ./...
 
 .PHONY: migrate
 migrate:

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ gen:
 
 .PHONY: lint
 lint:
-	gex golint ./...
+	gex golint -set_exit_status ./...
 
 .PHONY: migrate
 migrate:

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@
 $ make all
 ```
 
+### Lint project
+
+```sh
+$ make lint
+```
+
 ### Run tests
 
 ```sh

--- a/domain/preferences.go
+++ b/domain/preferences.go
@@ -1,3 +1,4 @@
 package domain
 
+// Preferences holds user specific preferences like timezone and privacy
 type Preferences struct{}

--- a/domain/role.go
+++ b/domain/role.go
@@ -1,7 +1,9 @@
 package domain
 
+// Role is an enum with the access level of a user
 type Role int
 
+// These are all the possible values for Role
 const (
 	RoleDisabled Role = iota
 	RoleUser

--- a/domain/user.go
+++ b/domain/user.go
@@ -1,5 +1,6 @@
 package domain
 
+// User holds everything related to a user's account data
 type User struct {
 	ID          uint64      `json:"id" db:"id"`
 	Email       string      `json:"email" db:"email"`
@@ -9,4 +10,5 @@ type User struct {
 	Preferences Preferences `json:"preferences" db:"preferences"`
 }
 
+// Users is a collection of users
 type Users []User

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,9 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
 	golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc // indirect
+	golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1
 	golang.org/x/sys v0.0.0-20190109145017-48ac38b7c8cb // indirect
+	golang.org/x/tools v0.0.0-20190114222345-bf090417da8b // indirect
+	google.golang.org/appengine v1.4.0 // indirect
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/go-sql-driver/mysql v1.4.0 h1:7LxgVwFb2hIQtMm87NdgAVfXjnt4OePseqT1tKx
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
+github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/jmoiron/sqlx v1.2.0 h1:41Ip0zITnmWNR/vHV+S4m+VoUivnWY5E4OJfLZjCJMA=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
@@ -44,8 +45,16 @@ github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QI
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc h1:F5tKCVGp+MUAHhKp5MZtGqAlGX3+oCsiL1Q629FL90M=
 golang.org/x/crypto v0.0.0-20190103213133-ff983b9c42bc/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1 h1:rJm0LuqUjoDhSk2zO9ISMSToQxGz7Os2jRiOL8AWu4c=
+golang.org/x/lint v0.0.0-20181217174547-8f45f776aaf1/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
+golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/sys v0.0.0-20190109145017-48ac38b7c8cb h1:1w588/yEchbPNpa9sEvOcMZYbWHedwJjg4VOAdDHWHk=
 golang.org/x/sys v0.0.0-20190109145017-48ac38b7c8cb/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190114222345-bf090417da8b h1:qMK98NmNCRVDIYFycQ5yVRkvgDUFfdP8Ip4KqmDEB7g=
+golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
+google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
+google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=

--- a/infra/rdb.go
+++ b/infra/rdb.go
@@ -2,11 +2,14 @@ package infra
 
 import (
 	"github.com/jmoiron/sqlx"
+	// Postgres driver that's used to connect to the db
 	_ "github.com/lib/pq"
 )
 
+// RDB is a relational database connection pool
 type RDB = sqlx.DB
 
+// NewRDB creates a new relational database connection pool
 func NewRDB(URL string, maxIdleConns, maxOpenConns int) (*RDB, error) {
 	db, err := sqlx.Open("postgres", URL)
 	if err != nil {

--- a/interfaces/services/context.go
+++ b/interfaces/services/context.go
@@ -4,6 +4,7 @@ package services
 
 // based on https://github.com/labstack/echo/blob/a2d4cb9c7a629e2ee21861501690741d2374de10/context.go
 
+// Context is a subset of the echo framework context, so we are not directly depending on it
 type Context interface {
 	// Get retrieves data from the context.
 	Get(key string) interface{}

--- a/interfaces/services/health_service.go
+++ b/interfaces/services/health_service.go
@@ -4,10 +4,13 @@ import (
 	"net/http"
 )
 
+// HealthService is responsible for metrics about the health of the service
 type HealthService interface {
+	// Ping is only used to see if the service is online, it doesn't do any health checks
 	Ping(ctx Context) error
 }
 
+// NewHealthService initializer
 func NewHealthService() HealthService {
 	return &healthService{}
 }

--- a/interfaces/services/session_service.go
+++ b/interfaces/services/session_service.go
@@ -4,11 +4,14 @@ import (
 	"net/http"
 )
 
+// SessionService is responsible for anything user related when they're not logged in such as
+// logging in, registering, resetting passwords, requesting new tokens, etc...
 type SessionService interface {
 	Login(ctx Context) error
 	Register(ctx Context) error
 }
 
+// NewSessionService initializer
 func NewSessionService() SessionService {
 	return &sessionService{}
 }

--- a/tools.go
+++ b/tools.go
@@ -7,4 +7,5 @@ package tools
 // tool dependencies
 import (
 	_ "github.com/golang/mock/mockgen"
+	_ "golang.org/x/lint/golint"
 )


### PR DESCRIPTION
## Why

To ensure a consistent style for this repository. 

## What

I've only added `golint` so far. I intend to add a couple more linters such as `errwrap` and `unparam` in a separate PR later when I have the time.

- [x] Add `golint` to gex tools
- [x] Add linting to makefile & readme
- [x] Add linting to CircleCI
- [x] Fix existing linting violations