### PR TITLE
Add support for configurable router ports

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -26,6 +26,7 @@ func NewServerDependencies() ServerDependencies {
 }
 
 type serverDependencies struct {
+	Port                 string `envconfig:"app_port", valid:"required"`
 	DatabaseURL          string `envconfig:"database_url" valid:"required"`
 	DatabaseMaxIdleConns int    `envconfig:"database_max_idle_conns" valid:"required"`
 	DatabaseMaxOpenConns int    `envconfig:"database_max_open_conns" valid:"required"`
@@ -82,7 +83,7 @@ func (d *serverDependencies) SessionService() services.SessionService {
 func (d *serverDependencies) Router() services.Router {
 	holder := &d.router
 	holder.once.Do(func() {
-		holder.result = infra.NewRouter(d.routes()...)
+		holder.result = infra.NewRouter(d.Port, d.routes()...)
 	})
 	return holder.result
 }
@@ -116,6 +117,5 @@ func (d *serverDependencies) RDB() *infra.RDB {
 // RunServer starts the actual API server
 func RunServer(d ServerDependencies) error {
 	router := d.Router()
-	router.Start(":1234")
-	return nil
+	return router.StartListening()
 }

--- a/infra/router.go
+++ b/infra/router.go
@@ -11,6 +11,7 @@ import (
 
 // NewRouter instantiates a router
 func NewRouter(
+	port string,
 	routes ...services.Route,
 ) services.Router {
 	e := echo.New()
@@ -26,11 +27,20 @@ func NewRouter(
 		}
 	}
 
-	return e
+	return router{e, port}
 }
 
 func wrap(h services.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {
 		return h(c)
 	}
+}
+
+type router struct {
+	*echo.Echo
+	port string
+}
+
+func (r router) StartListening() error {
+	return r.Start(":" + r.port)
 }

--- a/interfaces/services/router.go
+++ b/interfaces/services/router.go
@@ -2,7 +2,7 @@ package services
 
 // Router takes care of all the routing
 type Router interface {
-	Start(address string) error
+	StartListening() error
 }
 
 // HandlerFunc of the router


### PR DESCRIPTION
## Why

The port was still hardcoded despite it being configured in the dotenv.

## What

- [x] Refactor the router so the port doesn't need to be mentioned anymore
- [x] Test if it actually runs on the configured port