### PR TITLE
Role based routes

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -132,9 +132,9 @@ func (d *serverDependencies) Router() services.Router {
 
 func (d *serverDependencies) routes() []services.Route {
 	return []services.Route{
-		{Method: http.MethodGet, Path: "/ping", HandlerFunc: d.Services().Health.Ping, Restricted: true},
-		{Method: http.MethodPost, Path: "/login", HandlerFunc: d.Services().Session.Login, Restricted: false},
-		{Method: http.MethodPost, Path: "/register", HandlerFunc: d.Services().Session.Register, Restricted: false},
+		{Method: http.MethodGet, Path: "/ping", HandlerFunc: d.Services().Health.Ping},
+		{Method: http.MethodPost, Path: "/login", HandlerFunc: d.Services().Session.Login},
+		{Method: http.MethodPost, Path: "/register", HandlerFunc: d.Services().Session.Register},
 	}
 }
 

--- a/domain/role.go
+++ b/domain/role.go
@@ -5,7 +5,8 @@ type Role int
 
 // These are all the possible values for Role
 const (
-	RoleDisabled Role = iota
+	RoleGuest Role = iota
+	RoleDisabled
 	RoleUser
 	RoleAdmin
 )

--- a/domain/user.go
+++ b/domain/user.go
@@ -22,6 +22,11 @@ func (u *User) NeedsHashing() bool {
 	return u.Password != "" && !u.isPasswordHashed
 }
 
+// IsAdmin returns true when the user has the administration role
+func (u *User) IsAdmin() bool {
+	return u.Role == RoleAdmin
+}
+
 // MarshalJSON prevents the password from being exported into something client-facing
 func (Password) MarshalJSON() ([]byte, error) {
 	return []byte(`""`), nil

--- a/go.mod
+++ b/go.mod
@@ -11,17 +11,12 @@ require (
 	github.com/jmoiron/sqlx v1.2.0
 	github.com/joho/godotenv v1.3.0 // indirect
 	github.com/kelseyhightower/envconfig v1.3.0 // indirect
-	github.com/labstack/echo v3.3.5+incompatible
-	github.com/labstack/gommon v0.2.8 // indirect
+	github.com/labstack/echo/v4 v4.0.0
 	github.com/lib/pq v1.0.0
-	github.com/mattn/go-colorable v0.0.9 // indirect
-	github.com/mattn/go-isatty v0.0.4 // indirect
 	github.com/mattn/go-zglob v0.0.1 // indirect
 	github.com/pkg/errors v0.8.1 // indirect
 	github.com/srvc/fail v3.1.0+incompatible
 	github.com/stretchr/testify v1.3.0
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 // indirect
-	golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b
+	golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664
 	gopkg.in/yaml.v2 v2.2.2 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,8 @@ github.com/kelseyhightower/envconfig v1.3.0 h1:IvRS4f2VcIQy6j4ORGIf9145T/AsUB+oY
 github.com/kelseyhightower/envconfig v1.3.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa3axMbJDNb//FQX6Gg=
 github.com/labstack/echo v3.3.5+incompatible h1:Y3vG4kINVWNQN8Y6Jdur8uLat7fSLV5n5yLE8n+JbF4=
 github.com/labstack/echo v3.3.5+incompatible/go.mod h1:0INS7j/VjnFxD4E2wkz67b8cVwCLbBmJyDaka6Cmk1s=
+github.com/labstack/echo/v4 v4.0.0 h1:q1GH+caIXPP7H2StPIdzy/ez9CO0EepqYeUg6vi9SWM=
+github.com/labstack/echo/v4 v4.0.0/go.mod h1:tZv7nai5buKSg5h/8E6zz4LsD/Dqh9/91Mvs7Z5Zyno=
 github.com/labstack/gommon v0.2.8 h1:JvRqmeZcfrHC5u6uVleB4NxxNbzx6gpbJiQknDbKQu0=
 github.com/labstack/gommon v0.2.8/go.mod h1:/tj9csK2iPSBvn+3NLM9e52usepMtrd5ilFYA+wQNJ4=
 github.com/lib/pq v1.0.0 h1:X5PMW56eZitiTeO7tKzZxFCSpbFZJtkMMooicw2us9A=
@@ -49,6 +51,9 @@ github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4 h1:gKMu1Bf6QI
 github.com/valyala/fasttemplate v0.0.0-20170224212429-dcecefd839c4/go.mod h1:50wTf68f99/Zt14pr046Tgt3Lp2vLyFZKzbFXTOabXw=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b h1:Elez2XeF2p9uyVj0yEUDqQ56NFcDtcBNkYP7yv8YbUE=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664 h1:YbZJ76lQ1BqNhVe7dKTSB67wDrc2VPRR75IyGyyPDX8=
+golang.org/x/crypto v0.0.0-20190130090550-b01c7a725664/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/infra/context.go
+++ b/infra/context.go
@@ -18,7 +18,7 @@ type context struct {
 
 func (c context) User() (*domain.User, error) {
 	claims := c.Claims()
-	if claims.User != nil {
+	if claims != nil && claims.User != nil {
 		return claims.User, nil
 	}
 
@@ -27,7 +27,10 @@ func (c context) User() (*domain.User, error) {
 
 func (c context) Claims() *usecases.SessionClaims {
 	if token, ok := c.Get("user").(*jwt.Token); ok {
-		return &token.Claims.(*jwtClaims).SessionClaims
+		claims := token.Claims.(*jwtClaims)
+		if claims != nil {
+			return &claims.SessionClaims
+		}
 	}
 	return nil
 }

--- a/infra/context.go
+++ b/infra/context.go
@@ -1,8 +1,6 @@
 package infra
 
 import (
-	"fmt"
-
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo"
 	"github.com/srvc/fail"
@@ -29,7 +27,6 @@ func (c context) User() (*domain.User, error) {
 
 func (c context) Claims() *usecases.SessionClaims {
 	if token, ok := c.Get("user").(*jwt.Token); ok {
-		fmt.Println(token.Claims)
 		return &token.Claims.(*jwtClaims).SessionClaims
 	}
 	return nil

--- a/infra/context.go
+++ b/infra/context.go
@@ -2,7 +2,7 @@ package infra
 
 import (
 	jwt "github.com/dgrijalva/jwt-go"
-	"github.com/labstack/echo"
+	"github.com/labstack/echo/v4"
 	"github.com/srvc/fail"
 
 	"github.com/tadoku/api/domain"

--- a/infra/router.go
+++ b/infra/router.go
@@ -4,8 +4,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/interfaces/services"

--- a/infra/router.go
+++ b/infra/router.go
@@ -48,6 +48,11 @@ func newJWTMiddleware(secret string) echo.MiddlewareFunc {
 }
 
 func isRoleAllowed(c echo.Context, minRole domain.Role) bool {
+	// By default we assume that guests have access to everything
+	if minRole == 0 {
+		return true
+	}
+
 	ctx := &context{c}
 	u, err := ctx.User()
 	if err != nil {

--- a/infra/router.go
+++ b/infra/router.go
@@ -49,7 +49,7 @@ func newJWTMiddleware(secret string) echo.MiddlewareFunc {
 
 func isRoleAllowed(c echo.Context, minRole domain.Role) bool {
 	// By default we assume that guests have access to everything
-	if minRole == 0 {
+	if minRole == domain.RoleGuest {
 		return true
 	}
 
@@ -68,15 +68,14 @@ func isRoleAllowed(c echo.Context, minRole domain.Role) bool {
 
 func wrap(r services.Route, restrict echo.MiddlewareFunc) echo.HandlerFunc {
 	handler := func(c echo.Context) error {
-		// @TODO: find out if we can do this nicer with a middleware
-		if !isRoleAllowed(c, r.RoleRestriction) {
+		if !isRoleAllowed(c, r.MinRole) {
 			return c.NoContent(http.StatusForbidden)
 		}
 
 		return r.HandlerFunc(&context{c})
 	}
 
-	if r.Restricted {
+	if r.MinRole > domain.RoleGuest {
 		handler = restrict(handler)
 	}
 

--- a/infra/router_test.go
+++ b/infra/router_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/labstack/echo"
-	"github.com/labstack/echo/middleware"
+	"github.com/labstack/echo/v4"
+	"github.com/labstack/echo/v4/middleware"
 	"github.com/stretchr/testify/assert"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/infra"

--- a/interfaces/services/router.go
+++ b/interfaces/services/router.go
@@ -2,6 +2,8 @@ package services
 
 import (
 	"net/http"
+
+	"github.com/tadoku/api/domain"
 )
 
 // Router takes care of all the routing
@@ -15,8 +17,9 @@ type HandlerFunc func(Context) error
 
 // Route is a definition of a route
 type Route struct {
-	Method      string
-	Path        string
-	HandlerFunc HandlerFunc
-	Restricted  bool
+	Method          string
+	Path            string
+	HandlerFunc     HandlerFunc
+	Restricted      bool
+	RoleRestriction domain.Role
 }

--- a/interfaces/services/router.go
+++ b/interfaces/services/router.go
@@ -17,9 +17,8 @@ type HandlerFunc func(Context) error
 
 // Route is a definition of a route
 type Route struct {
-	Method          string
-	Path            string
-	HandlerFunc     HandlerFunc
-	Restricted      bool
-	RoleRestriction domain.Role
+	Method      string
+	Path        string
+	HandlerFunc HandlerFunc
+	MinRole     domain.Role
 }

--- a/usecases/role_authenticator.go
+++ b/usecases/role_authenticator.go
@@ -1,0 +1,43 @@
+package usecases
+
+import (
+	"github.com/srvc/fail"
+
+	"github.com/tadoku/api/domain"
+)
+
+var (
+	// ErrRoleAuthenticatorMissingUser there is no user to check against
+	ErrRoleAuthenticatorMissingUser = fail.Errorf("user is missing, nobody to check against")
+	// ErrInsufficientAccess is triggered when a user has a lower role than required
+	ErrInsufficientAccess = fail.Errorf("user has insufficient privileges")
+)
+
+// RoleAuthenticator contains all business logic for accessing resources
+type RoleAuthenticator interface {
+	IsAllowed(user *domain.User, minRole domain.Role) error
+}
+
+type roleAuthenticator struct{}
+
+// NewRoleAuthenticator instantiates a new role authenticator
+func NewRoleAuthenticator() RoleAuthenticator {
+	return &roleAuthenticator{}
+}
+
+// IsAllowed checks if a user has sufficient privileges to access a resource
+func (ra *roleAuthenticator) IsAllowed(user *domain.User, minRole domain.Role) error {
+	if minRole <= domain.RoleGuest {
+		return nil
+	}
+
+	if user == nil {
+		return ErrRoleAuthenticatorMissingUser
+	}
+
+	if user.Role < minRole {
+		return ErrInsufficientAccess
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Why

To resolve https://github.com/tadoku/api/issues/30
To resolve https://github.com/tadoku/api/issues/32

## What

- [x] Refactor routes to use a minimum role vs just restricted
- [x] Added guest role to account for routes where authentication is not needed
- [x] Missing JWT tokens now return a `http.StatusUnauthorized` instead of `http.StatusBadRequest`
- [x] Implement `RoleAuthenticator`
- [x] Update echo to v4 so it works properly with go modules (bit unrelated, but ehh...)