### PR TITLE
Update contest endpoint

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -137,6 +137,7 @@ func (d *serverDependencies) routes() []services.Route {
 		{Method: http.MethodPost, Path: "/login", HandlerFunc: d.Services().Session.Login},
 		{Method: http.MethodPost, Path: "/register", HandlerFunc: d.Services().Session.Register},
 		{Method: http.MethodPost, Path: "/contests", HandlerFunc: d.Services().Contest.Create, MinRole: domain.RoleAdmin},
+		{Method: http.MethodPut, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Update, MinRole: domain.RoleAdmin},
 	}
 }
 

--- a/domain/contest.go
+++ b/domain/contest.go
@@ -11,7 +11,7 @@ type Contest struct {
 	ID    uint64    `json:"id" db:"id"`
 	Start time.Time `json:"start" db:"start" valid:"required"`
 	End   time.Time `json:"end" db:"end" valid:"required"`
-	Open  bool      `json:"open" db:"open" valid:"required"`
+	Open  bool      `json:"open" db:"open"`
 }
 
 // Contests is a collection of contests

--- a/infra/context.go
+++ b/infra/context.go
@@ -1,6 +1,8 @@
 package infra
 
 import (
+	"strconv"
+
 	jwt "github.com/dgrijalva/jwt-go"
 	"github.com/labstack/echo/v4"
 	"github.com/srvc/fail"
@@ -33,4 +35,18 @@ func (c context) Claims() *usecases.SessionClaims {
 		}
 	}
 	return nil
+}
+
+func (c context) GetID() (uint64, error) {
+	idFromRoute := c.Param("id")
+	id, err := strconv.ParseUint(idFromRoute, 10, 64)
+
+	return id, fail.Wrap(err)
+}
+
+func (c context) BindID(id *uint64) error {
+	value, err := c.GetID()
+	*id = value
+
+	return fail.Wrap(err)
 }

--- a/infra/router.go
+++ b/infra/router.go
@@ -46,6 +46,8 @@ func newEcho(
 			e.GET(route.Path, wrap(route, m))
 		case http.MethodPost:
 			e.POST(route.Path, wrap(route, m))
+		case http.MethodPut:
+			e.PUT(route.Path, wrap(route, m))
 		default:
 			log.Fatalf("HTTP verb %v is not supported", route.Method)
 		}

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -21,8 +21,7 @@ func (r *contestRepository) Store(contest domain.Contest) error {
 		return r.create(contest)
 	}
 
-	// TODO: implement update
-	return fail.Errorf("not yet implemented")
+	return r.update(contest)
 }
 
 func (r *contestRepository) create(contest domain.Contest) error {
@@ -30,6 +29,17 @@ func (r *contestRepository) create(contest domain.Contest) error {
 		insert into contests
 		(start, "end", open)
 		values (:start, :end, :open)
+	`
+
+	_, err := r.sqlHandler.NamedExecute(query, contest)
+	return fail.Wrap(err)
+}
+
+func (r *contestRepository) update(contest domain.Contest) error {
+	query := `
+		update contests
+		set start = :start, "end" = :end, open = :open
+		where id = :id
 	`
 
 	_, err := r.sqlHandler.NamedExecute(query, contest)

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -36,18 +36,18 @@ func (r *contestRepository) create(contest domain.Contest) error {
 	return fail.Wrap(err)
 }
 
-func (r *contestRepository) HasOpenContests() (bool, error) {
+func (r *contestRepository) GetOpenContests() ([]uint64, error) {
 	query := `
-		select count(id)
+		select id
 		from contests
 		where open = true
 	`
 
-	var cnt int
-	err := r.sqlHandler.Get(&cnt, query)
+	var ids []uint64
+	err := r.sqlHandler.Select(&ids, query)
 	if err != nil {
-		return false, fail.Wrap(err)
+		return nil, fail.Wrap(err)
 	}
 
-	return cnt > 0, nil
+	return ids, nil
 }

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -25,6 +25,17 @@ func TestContestRepository_StoreContest(t *testing.T) {
 		err := repo.Store(*contest)
 		assert.Nil(t, err)
 	}
+
+	{
+		updatedContest := &domain.Contest{
+			ID:    1,
+			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2019, 1, 30, 0, 0, 0, 0, time.UTC),
+			Open:  false,
+		}
+		err := repo.Store(*updatedContest)
+		assert.Nil(t, err)
+	}
 }
 
 func TestContestRepository_GetOpenContests(t *testing.T) {

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/tadoku/api/interfaces/repositories"
 )
 
-func TestUserRepository_StoreContest(t *testing.T) {
+func TestContestRepository_StoreContest(t *testing.T) {
 	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
@@ -27,7 +27,7 @@ func TestUserRepository_StoreContest(t *testing.T) {
 	}
 }
 
-func TestUserRepository_HasOpenContests(t *testing.T) {
+func TestContestRepository_GetOpenContests(t *testing.T) {
 	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
@@ -35,15 +35,15 @@ func TestUserRepository_HasOpenContests(t *testing.T) {
 	repo := repositories.NewContestRepository(sqlHandler)
 
 	{
-		hasOpen, err := repo.HasOpenContests()
+		ids, err := repo.GetOpenContests()
 		assert.Nil(t, err)
-		assert.False(t, hasOpen, "no open contests should exist")
+		assert.Empty(t, ids, "no open contests should exist")
 
 		err = repo.Store(domain.Contest{Start: time.Now(), End: time.Now(), Open: true})
 		assert.Nil(t, err)
 
-		hasOpen, err = repo.HasOpenContests()
-		assert.True(t, hasOpen, "an open contest should exist")
+		ids, err = repo.GetOpenContests()
+		assert.Equal(t, 1, len(ids), "an open contest should exist")
 		assert.Nil(t, err)
 	}
 }

--- a/interfaces/services/contest_service.go
+++ b/interfaces/services/contest_service.go
@@ -11,6 +11,7 @@ import (
 // ContestService is responsible for managing contests
 type ContestService interface {
 	Create(ctx Context) error
+	Update(ctx Context) error
 }
 
 // NewContestService initializer
@@ -35,4 +36,19 @@ func (s *contestService) Create(ctx Context) error {
 	}
 
 	return ctx.NoContent(http.StatusCreated)
+}
+
+func (s *contestService) Update(ctx Context) error {
+	contest := &domain.Contest{}
+	if err := ctx.Bind(contest); err != nil {
+		return fail.Wrap(err)
+	}
+
+	ctx.BindID(&contest.ID)
+
+	if err := s.ContestInteractor.UpdateContest(*contest); err != nil {
+		return fail.Wrap(err)
+	}
+
+	return ctx.NoContent(http.StatusNoContent)
 }

--- a/interfaces/services/contest_service_test.go
+++ b/interfaces/services/contest_service_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/tadoku/api/usecases"
 )
 
-func TestSessionService_Create(t *testing.T) {
+func TestContestService_Create(t *testing.T) {
 	contest := &domain.Contest{
 		Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
 		End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
@@ -31,6 +31,31 @@ func TestSessionService_Create(t *testing.T) {
 
 	s := services.NewContestService(i)
 	err := s.Create(ctx)
+
+	assert.NoError(t, err)
+}
+
+func TestContestService_Update(t *testing.T) {
+	contest := &domain.Contest{
+		ID:    1,
+		Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
+		Open:  true,
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := services.NewMockContext(ctrl)
+	ctx.EXPECT().NoContent(204)
+	ctx.EXPECT().Bind(gomock.Any()).Return(nil).SetArg(0, *contest)
+	ctx.EXPECT().BindID(gomock.Any()).Return(nil)
+
+	i := usecases.NewMockContestInteractor(ctrl)
+	i.EXPECT().UpdateContest(*contest).Return(nil)
+
+	s := services.NewContestService(i)
+	err := s.Update(ctx)
 
 	assert.NoError(t, err)
 }

--- a/interfaces/services/context.go
+++ b/interfaces/services/context.go
@@ -35,4 +35,9 @@ type Context interface {
 
 	// User gets the current logged in user
 	User() (*domain.User, error)
+
+	// GetID gets the current id in the route
+	GetID() (uint64, error)
+
+	BindID(*uint64) error
 }

--- a/interfaces/services/context_mock.go
+++ b/interfaces/services/context_mock.go
@@ -144,3 +144,32 @@ func (mr *MockContextMockRecorder) User() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "User", reflect.TypeOf((*MockContext)(nil).User))
 }
+
+// GetID mocks base method
+func (m *MockContext) GetID() (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetID")
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetID indicates an expected call of GetID
+func (mr *MockContextMockRecorder) GetID() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetID", reflect.TypeOf((*MockContext)(nil).GetID))
+}
+
+// BindID mocks base method
+func (m *MockContext) BindID(arg0 *uint64) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BindID", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// BindID indicates an expected call of BindID
+func (mr *MockContextMockRecorder) BindID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BindID", reflect.TypeOf((*MockContext)(nil).BindID), arg0)
+}

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -44,12 +44,16 @@ func (si *contestInteractor) CreateContest(contest domain.Contest) error {
 	}
 
 	if contest.Open {
-		hasOpen, err := si.contestRepository.HasOpenContests()
+		ids, err := si.contestRepository.GetOpenContests()
 		if err != nil {
 			return fail.Wrap(err)
 		}
-		if hasOpen {
-			return ErrOpenContestAlreadyExists
+		if len(ids) > 0 {
+			for _, id := range ids {
+				if id != contest.ID {
+					return ErrOpenContestAlreadyExists
+				}
+			}
 		}
 	}
 

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -13,9 +13,13 @@ var ErrInvalidContest = fail.New("invalid contest supplied")
 // ErrOpenContestAlreadyExists for when you try to create a second contest that's open
 var ErrOpenContestAlreadyExists = fail.New("an open contest already exists, only one can exist at a time")
 
+// ErrContestIDMissing for when you try to update a contest without id
+var ErrContestIDMissing = fail.New("a contest id is required when updating")
+
 // ContestInteractor contains all business logic for contests
 type ContestInteractor interface {
 	CreateContest(contest domain.Contest) error
+	UpdateContest(contest domain.Contest) error
 }
 
 // NewContestInteractor instantiates ContestInteractor with all dependencies
@@ -36,9 +40,21 @@ type contestInteractor struct {
 
 func (si *contestInteractor) CreateContest(contest domain.Contest) error {
 	if contest.ID != 0 {
-		return fail.Errorf("user with an id (%v) could not be created", contest.ID)
+		return fail.Errorf("contest with id (%v) could not be created", contest.ID)
 	}
 
+	return si.saveContest(contest)
+}
+
+func (si *contestInteractor) UpdateContest(contest domain.Contest) error {
+	if contest.ID == 0 {
+		return ErrContestIDMissing
+	}
+
+	return si.saveContest(contest)
+}
+
+func (si *contestInteractor) saveContest(contest domain.Contest) error {
 	if _, err := si.validator.Validate(contest); err != nil {
 		return ErrInvalidContest
 	}

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -16,6 +16,9 @@ var ErrOpenContestAlreadyExists = fail.New("an open contest already exists, only
 // ErrContestIDMissing for when you try to update a contest without id
 var ErrContestIDMissing = fail.New("a contest id is required when updating")
 
+// ErrCreateContestHasID for when you try to create a contest with a given id
+var ErrCreateContestHasID = fail.New("a contest can't have an id when being created")
+
 // ContestInteractor contains all business logic for contests
 type ContestInteractor interface {
 	CreateContest(contest domain.Contest) error
@@ -40,7 +43,7 @@ type contestInteractor struct {
 
 func (si *contestInteractor) CreateContest(contest domain.Contest) error {
 	if contest.ID != 0 {
-		return fail.Errorf("contest with id (%v) could not be created", contest.ID)
+		return ErrCreateContestHasID
 	}
 
 	return si.saveContest(contest)

--- a/usecases/contest_interactor_mock.go
+++ b/usecases/contest_interactor_mock.go
@@ -46,3 +46,17 @@ func (mr *MockContestInteractorMockRecorder) CreateContest(contest interface{}) 
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateContest", reflect.TypeOf((*MockContestInteractor)(nil).CreateContest), contest)
 }
+
+// UpdateContest mocks base method
+func (m *MockContestInteractor) UpdateContest(contest domain.Contest) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateContest", contest)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateContest indicates an expected call of UpdateContest
+func (mr *MockContestInteractorMockRecorder) UpdateContest(contest interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContest", reflect.TypeOf((*MockContestInteractor)(nil).UpdateContest), contest)
+}

--- a/usecases/contest_interactor_test.go
+++ b/usecases/contest_interactor_test.go
@@ -38,7 +38,7 @@ func TestSessionInteractor_CreateContest(t *testing.T) {
 		}
 
 		repo.EXPECT().Store(contest)
-		repo.EXPECT().HasOpenContests().Return(false, nil)
+		repo.EXPECT().GetOpenContests().Return(nil, nil)
 		validator.EXPECT().Validate(contest).Return(true, nil)
 
 		err := interactor.CreateContest(contest)
@@ -53,7 +53,7 @@ func TestSessionInteractor_CreateContest(t *testing.T) {
 			Open:  true,
 		}
 
-		repo.EXPECT().HasOpenContests().Return(true, usecases.ErrOpenContestAlreadyExists)
+		repo.EXPECT().GetOpenContests().Return([]uint64{1}, usecases.ErrOpenContestAlreadyExists)
 		validator.EXPECT().Validate(contest).Return(true, nil)
 
 		err := interactor.CreateContest(contest)

--- a/usecases/contest_interactor_test.go
+++ b/usecases/contest_interactor_test.go
@@ -26,7 +26,7 @@ func setupContestTest(t *testing.T) (
 	return ctrl, repo, validator, interactor
 }
 
-func TestSessionInteractor_CreateContest(t *testing.T) {
+func TestContestInteractor_CreateContest(t *testing.T) {
 	ctrl, repo, validator, interactor := setupContestTest(t)
 	defer ctrl.Finish()
 
@@ -73,5 +73,38 @@ func TestSessionInteractor_CreateContest(t *testing.T) {
 		err := interactor.CreateContest(contest)
 
 		assert.Error(t, err)
+	}
+}
+
+func TestContestInteractor_UpdateContest(t *testing.T) {
+	ctrl, repo, validator, interactor := setupContestTest(t)
+	defer ctrl.Finish()
+
+	{
+		contest := domain.Contest{
+			ID:    1,
+			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
+			Open:  false,
+		}
+
+		repo.EXPECT().Store(contest)
+		validator.EXPECT().Validate(contest).Return(true, nil)
+
+		err := interactor.UpdateContest(contest)
+
+		assert.NoError(t, err)
+	}
+
+	{
+		contest := domain.Contest{
+			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
+			Open:  false,
+		}
+
+		err := interactor.UpdateContest(contest)
+
+		assert.Error(t, err, usecases.ErrContestIDMissing)
 	}
 }

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -16,5 +16,5 @@ type UserRepository interface {
 // ContestRepository handles Contest related interactions
 type ContestRepository interface {
 	Store(contest domain.Contest) error
-	HasOpenContests() (bool, error)
+	GetOpenContests() ([]uint64, error)
 }

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -114,17 +114,17 @@ func (mr *MockContestRepositoryMockRecorder) Store(contest interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Store", reflect.TypeOf((*MockContestRepository)(nil).Store), contest)
 }
 
-// HasOpenContests mocks base method
-func (m *MockContestRepository) HasOpenContests() (bool, error) {
+// GetOpenContests mocks base method
+func (m *MockContestRepository) GetOpenContests() ([]uint64, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "HasOpenContests")
-	ret0, _ := ret[0].(bool)
+	ret := m.ctrl.Call(m, "GetOpenContests")
+	ret0, _ := ret[0].([]uint64)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// HasOpenContests indicates an expected call of HasOpenContests
-func (mr *MockContestRepositoryMockRecorder) HasOpenContests() *gomock.Call {
+// GetOpenContests indicates an expected call of GetOpenContests
+func (mr *MockContestRepositoryMockRecorder) GetOpenContests() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasOpenContests", reflect.TypeOf((*MockContestRepository)(nil).HasOpenContests))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenContests", reflect.TypeOf((*MockContestRepository)(nil).GetOpenContests))
 }


### PR DESCRIPTION
## Why

To resolve #25 

## What

- [x] For authenticated users with `Admin` role only
- [x] Route: `PUT /contest/:id`
- [x] Should return `204` with no content on success
- [x] Should error when end date is before start date
- [x] Only one contest can be active at a given time
- [x] Contest can't be open after the end date