### PR TITLE
Refactor database media and languages

### DIFF
--- a/domain/contest_log.go
+++ b/domain/contest_log.go
@@ -1,0 +1,20 @@
+package domain
+
+import (
+	"time"
+)
+
+// ContestLog contains a single entry in a contest for a user
+type ContestLog struct {
+	ID        uint64       `json:"id" db:"id"`
+	ContestID uint64       `json:"contest_id" db:"contest_id" valid:"required"`
+	UserID    uint64       `json:"user_id" db:"user_id" valid:"required"`
+	Language  LanguageCode `json:"language_code" db:"language_code" valid:"required"`
+	Amount    float32      `json:"amount" db:"amount" valid:"required"`
+	CreatedAt time.Time    `json:"created_at" db:"created_at"`
+	UpdatedAt time.Time    `json:"updated_at" db:"updated_at"`
+	DeletedAt *time.Time   `json:"deleted_at" db:"deleted_at"`
+}
+
+// ContestLogs is a collection of ContestLog
+type ContestLogs []ContestLog

--- a/domain/language.go
+++ b/domain/language.go
@@ -1,0 +1,7 @@
+package domain
+
+// Language contains a language name and code
+type Language struct {
+	Code LanguageCode
+	Name string
+}

--- a/domain/language.go
+++ b/domain/language.go
@@ -1,7 +1,29 @@
 package domain
 
-// Language contains a language name and code
+// Language contains a language Name and code
 type Language struct {
 	Code LanguageCode
 	Name string
+}
+
+// Languages is a collection of languages
+type Languages []Language
+
+// AllLanguages is an array with all possible languages
+var AllLanguages = Languages{
+	Language{Code: Chinese, Name: "Chinese"},
+	Language{Code: Dutch, Name: "Dutch"},
+	Language{Code: English, Name: "English"},
+	Language{Code: French, Name: "French"},
+	Language{Code: German, Name: "German"},
+	Language{Code: Greek, Name: "Greek"},
+	Language{Code: Irish, Name: "Irish"},
+	Language{Code: Italian, Name: "Italian"},
+	Language{Code: Japanese, Name: "Japanese"},
+	Language{Code: Korean, Name: "Korean"},
+	Language{Code: Portuguese, Name: "Portuguese"},
+	Language{Code: Russian, Name: "Russian"},
+	Language{Code: Spanish, Name: "Spanish"},
+	Language{Code: Swedish, Name: "Swedish"},
+	Language{Code: Turkish, Name: "Turkish"},
 }

--- a/domain/language_code.go
+++ b/domain/language_code.go
@@ -33,8 +33,8 @@ const (
 // LanguageCodes is a collection of language codes
 type LanguageCodes []LanguageCode
 
-// AllLanguages is an array with all possible languages
-var AllLanguages = LanguageCodes{
+// AllLanguageCodes is an array with all possible language codes
+var AllLanguageCodes = LanguageCodes{
 	Global,
 	Chinese,
 	Dutch,
@@ -69,7 +69,7 @@ var ErrInvalidLanguage = fail.New("supplied language is not supported")
 
 // Validate a language code
 func (code LanguageCode) Validate() (bool, error) {
-	for _, possibleCode := range AllLanguages {
+	for _, possibleCode := range AllLanguageCodes {
 		if possibleCode == code {
 			return true, nil
 		}

--- a/domain/language_test.go
+++ b/domain/language_test.go
@@ -1,0 +1,13 @@
+package domain
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLanguage_AllLanguagesDoesNotContainGlobal(t *testing.T) {
+	for _, l := range AllLanguages {
+		assert.NotEqual(t, Global, l.Code, "language database should not contain a language with the global code")
+	}
+}

--- a/domain/medium.go
+++ b/domain/medium.go
@@ -1,0 +1,23 @@
+package domain
+
+// Medium knows how the score for a medium should be calculated
+type Medium struct {
+	Description string  `json:"description" db:"description"`
+	Points      float32 `json:"points" db:"points"`
+}
+
+// Mediums is a collection of media
+type Mediums map[uint64]Medium
+
+// AllMediums is an array with all existing media
+var AllMediums = Mediums{
+	1: Medium{Description: "Book", Points: 1},
+	2: Medium{Description: "Manga", Points: 0.2},
+	3: Medium{Description: "Net", Points: 1},
+	4: Medium{Description: "Full game", Points: 0.1667},
+	5: Medium{Description: "Game", Points: 0.05},
+	6: Medium{Description: "Lyric", Points: 1},
+	7: Medium{Description: "Subs", Points: 0.2},
+	8: Medium{Description: "News", Points: 1},
+	9: Medium{Description: "Sentences", Points: 0.05},
+}

--- a/migrations/201901281844_contest_down.sql
+++ b/migrations/201901281844_contest_down.sql
@@ -1,6 +1,5 @@
 drop table contests cascade;
 drop table contest_logs cascade;
-drop table languages cascade;
 
 drop sequence if exists contest_seq;
 drop sequence if exists contest_log_seq;

--- a/migrations/201901281844_contest_down.sql
+++ b/migrations/201901281844_contest_down.sql
@@ -1,8 +1,8 @@
 drop table contests cascade;
+drop table contest_logs cascade;
 drop table mediums cascade;
 drop table languages cascade;
-drop table logs cascade;
 
 drop sequence if exists contest_seq;
 drop sequence if exists medium_seq;
-drop sequence if exists log_seq;
+drop sequence if exists contest_log_seq;

--- a/migrations/201901281844_contest_down.sql
+++ b/migrations/201901281844_contest_down.sql
@@ -1,8 +1,6 @@
 drop table contests cascade;
 drop table contest_logs cascade;
-drop table mediums cascade;
 drop table languages cascade;
 
 drop sequence if exists contest_seq;
-drop sequence if exists medium_seq;
 drop sequence if exists contest_log_seq;

--- a/migrations/201901281844_contest_up.sql
+++ b/migrations/201901281844_contest_up.sql
@@ -1,6 +1,6 @@
 create sequence contest_seq;
+create sequence contest_log_seq;
 create sequence medium_seq;
-create sequence log_seq;
 
 create table contests (
   id bigint check (id > 0) not null default nextval ('contest_seq'),
@@ -23,8 +23,8 @@ create table languages (
   primary key (iso_code)
 );
 
-create table logs (
-  id bigint check (id > 0) not null default nextval ('log_seq'),
+create table contest_logs (
+  id bigint check (id > 0) not null default nextval ('contest_log_seq'),
   contest_id bigint not null,
   user_id bigint not null,
   language_code varchar(3) not null,
@@ -36,11 +36,11 @@ create table logs (
   primary key (id)
 );
 
-create index logs_contest_id on logs(contest_id);
-create index logs_user_id on logs(user_id);
-create index logs_language_code on logs(language_code);
-create index logs_medium_id on logs(medium_id);
+create index content_logs_contest_id on contest_logs(contest_id);
+create index content_logs_user_id on contest_logs(user_id);
+create index content_logs_language_code on contest_logs(language_code);
+create index content_logs_medium_id on contest_logs(medium_id);
 
 alter sequence contest_seq restart with 1;
 alter sequence medium_seq restart with 1;
-alter sequence log_seq restart with 1;
+alter sequence contest_log_seq restart with 1;

--- a/migrations/201901281844_contest_up.sql
+++ b/migrations/201901281844_contest_up.sql
@@ -9,12 +9,6 @@ create table contests (
   primary key (id)
 );
 
-create table languages (
-  iso_code varchar(3) not null,
-  name varchar(50) not null,
-  primary key (iso_code)
-);
-
 create table contest_logs (
   id bigint check (id > 0) not null default nextval ('contest_log_seq'),
   contest_id bigint not null,

--- a/migrations/201901281844_contest_up.sql
+++ b/migrations/201901281844_contest_up.sql
@@ -1,19 +1,11 @@
 create sequence contest_seq;
 create sequence contest_log_seq;
-create sequence medium_seq;
 
 create table contests (
   id bigint check (id > 0) not null default nextval ('contest_seq'),
   start date not null,
   "end" date not null,
   open boolean not null default false,
-  primary key (id)
-);
-
-create table mediums (
-  id smallint check (id > 0) not null default nextval ('medium_seq'),
-  description text not null,
-  points float(2) not null,
   primary key (id)
 );
 
@@ -39,8 +31,6 @@ create table contest_logs (
 create index content_logs_contest_id on contest_logs(contest_id);
 create index content_logs_user_id on contest_logs(user_id);
 create index content_logs_language_code on contest_logs(language_code);
-create index content_logs_medium_id on contest_logs(medium_id);
 
 alter sequence contest_seq restart with 1;
-alter sequence medium_seq restart with 1;
 alter sequence contest_log_seq restart with 1;


### PR DESCRIPTION
## Why

There's no need to store the `Medium` and `Language` data in the database. They won't change often and aren't large in size. It'd be better to have these hardcoded so we don't need to bother with more complex queries.

## What

- [x] Rename `logs` to `contest_logs` in the database
- [x] Remove `languages` table
- [x] Remove `mediums` table
- [x] Add `AllLanguages` in-memory database
- [x] Add `AllMediums` in-memory database