### PR TITLE
Improve test clarity

### DIFF
--- a/interfaces/services/contest_service_test.go
+++ b/interfaces/services/contest_service_test.go
@@ -49,7 +49,7 @@ func TestContestService_Update(t *testing.T) {
 	ctx := services.NewMockContext(ctrl)
 	ctx.EXPECT().NoContent(204)
 	ctx.EXPECT().Bind(gomock.Any()).Return(nil).SetArg(0, *contest)
-	ctx.EXPECT().BindID(gomock.Any()).Return(nil)
+	ctx.EXPECT().BindID(&contest.ID).Return(nil)
 
 	i := usecases.NewMockContestInteractor(ctrl)
 	i.EXPECT().UpdateContest(*contest).Return(nil)

--- a/interfaces/services/ranking_service_test.go
+++ b/interfaces/services/ranking_service_test.go
@@ -26,7 +26,7 @@ func TestRankingService_Create(t *testing.T) {
 	ctx.EXPECT().Bind(gomock.Any()).Return(nil).SetArg(0, *payload)
 
 	i := usecases.NewMockRankingInteractor(ctrl)
-	i.EXPECT().CreateRanking(uint64(1), uint64(1), gomock.Any()).Return(nil)
+	i.EXPECT().CreateRanking(uint64(1), uint64(1), payload.Languages).Return(nil)
 
 	s := services.NewRankingService(i)
 	err := s.Create(ctx)

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -41,7 +41,9 @@ func TestRankingInteractor_CreateRanking(t *testing.T) {
 		contestRepo.EXPECT().GetOpenContests().Return([]uint64{1}, nil)
 		userRepo.EXPECT().FindByID(uint64(1)).Return(domain.User{ID: 1}, nil)
 		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(uint64(1), uint64(1)).Return(nil, nil)
-		rankingRepo.EXPECT().Store(gomock.Any()).Return(nil).Times(3) // Japanese, English, and Global
+		rankingRepo.EXPECT().Store(domain.Ranking{ContestID: contestID, UserID: userID, Language: languages[0], Amount: 0}).Return(nil)
+		rankingRepo.EXPECT().Store(domain.Ranking{ContestID: contestID, UserID: userID, Language: languages[1], Amount: 0}).Return(nil)
+		rankingRepo.EXPECT().Store(domain.Ranking{ContestID: contestID, UserID: userID, Language: domain.Global, Amount: 0}).Return(nil)
 
 		err := interactor.CreateRanking(userID, contestID, languages)
 
@@ -56,7 +58,7 @@ func TestRankingInteractor_CreateRanking(t *testing.T) {
 		contestRepo.EXPECT().GetOpenContests().Return([]uint64{1}, nil)
 		userRepo.EXPECT().FindByID(uint64(1)).Return(domain.User{ID: 1}, nil)
 		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(uint64(1), uint64(1)).Return(domain.LanguageCodes{domain.English, domain.Global}, nil)
-		rankingRepo.EXPECT().Store(gomock.Any()).Return(nil).Times(1) // Chinese
+		rankingRepo.EXPECT().Store(domain.Ranking{ContestID: contestID, UserID: userID, Language: languages[0], Amount: 0}).Return(nil)
 
 		err := interactor.CreateRanking(userID, contestID, languages)
 

--- a/usecases/session_interactor_test.go
+++ b/usecases/session_interactor_test.go
@@ -11,6 +11,8 @@ import (
 	gomock "github.com/golang/mock/gomock"
 )
 
+var sessionLength = time.Hour * 1
+
 func setupUserTest(t *testing.T) (
 	*gomock.Controller,
 	*usecases.MockUserRepository,
@@ -25,7 +27,7 @@ func setupUserTest(t *testing.T) (
 	jwtGen := usecases.NewMockJWTGenerator(ctrl)
 
 	interactor := usecases.NewSessionInteractor(
-		repo, pwHasher, jwtGen, time.Hour*1,
+		repo, pwHasher, jwtGen, sessionLength,
 	)
 
 	return ctrl, repo, pwHasher, jwtGen, interactor
@@ -60,7 +62,7 @@ func TestSessionInteractor_CreateSession(t *testing.T) {
 		dbUser := domain.User{ID: 1, Email: "foo@bar.com", Password: "foobar"}
 		repo.EXPECT().FindByEmail("foo@bar.com").Return(dbUser, nil)
 		pwHasher.EXPECT().Compare(dbUser.Password, "foobar").Return(true)
-		jwtGen.EXPECT().NewToken(gomock.Any(), usecases.SessionClaims{User: &dbUser}).Return("token", nil)
+		jwtGen.EXPECT().NewToken(sessionLength, usecases.SessionClaims{User: &dbUser}).Return("token", nil)
 
 		sessionUser, token, err := interactor.CreateSession("foo@bar.com", "foobar")
 		assert.NoError(t, err)


### PR DESCRIPTION
## Why

`gomock.Any()` usage should be avoided as much as possible as it makes tests less specific and clear.

## What

- [x] Replace any `gomock.Any()` with the correct, specific arguments