### PR TITLE
Prevent global from being a language that can be logged

### DIFF
--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -96,10 +96,13 @@ func (r *rankingRepository) GetAllLanguagesForContestAndUser(contestID uint64, u
 	query := `
 		select language_code
 		from rankings
-		where contest_id = $1 and user_id = $2
+		where
+			contest_id = $1
+			and user_id = $2
+			and language_code != $3
 	`
 
-	err := r.sqlHandler.Select(&codes, query, contestID, userID)
+	err := r.sqlHandler.Select(&codes, query, contestID, userID, domain.Global)
 	if err != nil {
 		return nil, err
 	}

--- a/interfaces/repositories/ranking_repository_test.go
+++ b/interfaces/repositories/ranking_repository_test.go
@@ -90,10 +90,9 @@ func TestRankingRepository_GetAllLanguagesForContestAndUser(t *testing.T) {
 	{
 		languages, err := repo.GetAllLanguagesForContestAndUser(1, 1)
 		assert.NoError(t, err)
-		assert.Equal(t, len(languages), 3)
+		assert.Equal(t, len(languages), 2)
 		assert.Equal(t, languages[0], domain.Japanese)
 		assert.Equal(t, languages[1], domain.Chinese)
-		assert.Equal(t, languages[2], domain.Global)
 	}
 
 	{

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -28,7 +28,7 @@ var ErrGlobalIsASystemLanguage = fail.New("global is a system language and canno
 // ErrInvalidContestLog for when an invalid contest is given
 var ErrInvalidContestLog = fail.New("invalid contest log supplied")
 
-// ErrContestLanguageNotSignedUp for when a user tries to log an entry for a contest with a langauge they're not signed up for
+// ErrContestLanguageNotSignedUp for when a user tries to log an entry for a contest with a language they're not signed up for
 var ErrContestLanguageNotSignedUp = fail.New("user has not signed up for given language")
 
 // RankingInteractor contains all business logic for rankings

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -192,6 +192,24 @@ func TestRankingInteractor_CreateLog(t *testing.T) {
 		err := interactor.CreateLog(log)
 		assert.EqualError(t, err, usecases.ErrContestLanguageNotSignedUp.Error())
 	}
+
+	// Test global is not accepted as a language
+	{
+		log := domain.ContestLog{
+			ContestID: contestID,
+			UserID:    userID,
+			Language:  domain.Global,
+			Amount:    10,
+			MediumID:  domain.MediumManga,
+		}
+
+		validator.EXPECT().Validate(log).Return(true, nil)
+		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.Japanese}, nil)
+
+		err := interactor.CreateLog(log)
+		assert.EqualError(t, err, usecases.ErrContestLanguageNotSignedUp.Error())
+	}
 }
 
 func TestRankingInteractor_UpdateRankings(t *testing.T) {


### PR DESCRIPTION
## Why

To fix #45 

## What

- [x] Don't see global as a language the user is registered with