### PR TITLE
Endpoint rankings

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -139,7 +139,7 @@ func (d *serverDependencies) routes() []services.Route {
 		{Method: http.MethodPost, Path: "/contests", HandlerFunc: d.Services().Contest.Create, MinRole: domain.RoleAdmin},
 		{Method: http.MethodPut, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Update, MinRole: domain.RoleAdmin},
 		{Method: http.MethodPost, Path: "/rankings", HandlerFunc: d.Services().Ranking.Create, MinRole: domain.RoleUser},
-		{Method: http.MethodGet, Path: "/rankings/:id", HandlerFunc: d.Services().Ranking.Get},
+		{Method: http.MethodGet, Path: "/rankings", HandlerFunc: d.Services().Ranking.Get},
 		{Method: http.MethodPost, Path: "/contest_logs", HandlerFunc: d.Services().ContestLog.Create, MinRole: domain.RoleUser},
 	}
 }

--- a/app/server.go
+++ b/app/server.go
@@ -139,6 +139,7 @@ func (d *serverDependencies) routes() []services.Route {
 		{Method: http.MethodPost, Path: "/contests", HandlerFunc: d.Services().Contest.Create, MinRole: domain.RoleAdmin},
 		{Method: http.MethodPut, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Update, MinRole: domain.RoleAdmin},
 		{Method: http.MethodPost, Path: "/rankings", HandlerFunc: d.Services().Ranking.Create, MinRole: domain.RoleUser},
+		{Method: http.MethodGet, Path: "/rankings/:id", HandlerFunc: d.Services().Ranking.Get},
 		{Method: http.MethodPost, Path: "/contest_logs", HandlerFunc: d.Services().ContestLog.Create, MinRole: domain.RoleUser},
 	}
 }

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -76,7 +76,21 @@ func (r *rankingRepository) RankingsForContest(
 	contestID uint64,
 	languageCode domain.LanguageCode,
 ) (domain.Rankings, error) {
-	return nil, nil
+	var rankings []domain.Ranking
+
+	query := `
+		select id, contest_id, user_id, language_code, amount, created_at, updated_at
+		from rankings
+		where contest_id = $1 and language_code = $2
+		order by id asc
+	`
+
+	err := r.sqlHandler.Select(&rankings, query, contestID, languageCode)
+	if err != nil {
+		return nil, err
+	}
+
+	return rankings, nil
 }
 
 func (r *rankingRepository) FindAll(contestID uint64, userID uint64) (domain.Rankings, error) {

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -82,7 +82,7 @@ func (r *rankingRepository) RankingsForContest(
 		select id, contest_id, user_id, language_code, amount, created_at, updated_at
 		from rankings
 		where contest_id = $1 and language_code = $2
-		order by id asc
+		order by amount desc, id asc
 	`
 
 	err := r.sqlHandler.Select(&rankings, query, contestID, languageCode)

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -72,6 +72,13 @@ func (r *rankingRepository) UpdateAmounts(rankings domain.Rankings) error {
 	return tx.Commit()
 }
 
+func (r *rankingRepository) RankingsForContest(
+	contestID uint64,
+	languageCode domain.LanguageCode,
+) (domain.Rankings, error) {
+	return nil, nil
+}
+
 func (r *rankingRepository) FindAll(contestID uint64, userID uint64) (domain.Rankings, error) {
 	var rankings []domain.Ranking
 

--- a/interfaces/repositories/ranking_repository_test.go
+++ b/interfaces/repositories/ranking_repository_test.go
@@ -112,12 +112,13 @@ func TestRankingRepository_RankingsForContest(t *testing.T) {
 
 	contestID := uint64(1)
 
-	expected := []struct {
+	type testCase struct {
 		contestID uint64
 		userID    uint64
 		language  domain.LanguageCode
 		amount    float32
-	}{
+	}
+	expected := []testCase{
 		{contestID, 3, domain.Global, 30},
 		{contestID, 2, domain.Global, 20},
 		{contestID, 1, domain.Global, 10},
@@ -125,7 +126,7 @@ func TestRankingRepository_RankingsForContest(t *testing.T) {
 
 	// Correct rankings
 	{
-		for _, data := range expected {
+		for _, data := range []testCase{expected[2], expected[1], expected[0]} {
 			ranking := &domain.Ranking{
 				ContestID: data.contestID,
 				UserID:    data.userID,
@@ -140,12 +141,7 @@ func TestRankingRepository_RankingsForContest(t *testing.T) {
 
 	// Create unrelated rankings to check if it is really working
 	{
-		for _, data := range []struct {
-			contestID uint64
-			userID    uint64
-			language  domain.LanguageCode
-			amount    float32
-		}{
+		for _, data := range []testCase{
 			{contestID + 1, 1, domain.Global, 50},
 			{contestID, 1, domain.Japanese, 250},
 			{contestID, 2, domain.Korean, 150},
@@ -168,13 +164,9 @@ func TestRankingRepository_RankingsForContest(t *testing.T) {
 
 	assert.Equal(t, len(expected), len(rankings))
 
-	for _, expected := range expected {
-		var ranking domain.Ranking
-		for _, r := range rankings {
-			if r.UserID == expected.userID {
-				ranking = r
-			}
-		}
+	for i, expected := range expected {
+		// This assumption should work as the order of the rankings should be fixed
+		ranking := rankings[i]
 
 		assert.Equal(t, expected.amount, ranking.Amount)
 		assert.Equal(t, contestID, ranking.ContestID)

--- a/interfaces/repositories/ranking_repository_test.go
+++ b/interfaces/repositories/ranking_repository_test.go
@@ -103,6 +103,85 @@ func TestRankingRepository_GetAllLanguagesForContestAndUser(t *testing.T) {
 	}
 }
 
+func TestRankingRepository_RankingsForContest(t *testing.T) {
+	t.Parallel()
+	sqlHandler, cleanup := setupTestingSuite(t)
+	defer cleanup()
+
+	repo := repositories.NewRankingRepository(sqlHandler)
+
+	contestID := uint64(1)
+
+	expected := []struct {
+		contestID uint64
+		userID    uint64
+		language  domain.LanguageCode
+		amount    float32
+	}{
+		{contestID, 3, domain.Global, 30},
+		{contestID, 2, domain.Global, 20},
+		{contestID, 1, domain.Global, 10},
+	}
+
+	// Correct rankings
+	{
+		for _, data := range expected {
+			ranking := &domain.Ranking{
+				ContestID: data.contestID,
+				UserID:    data.userID,
+				Language:  data.language,
+				Amount:    data.amount,
+			}
+
+			err := repo.Store(*ranking)
+			assert.NoError(t, err)
+		}
+	}
+
+	// Create unrelated rankings to check if it is really working
+	{
+		for _, data := range []struct {
+			contestID uint64
+			userID    uint64
+			language  domain.LanguageCode
+			amount    float32
+		}{
+			{contestID + 1, 1, domain.Global, 50},
+			{contestID, 1, domain.Japanese, 250},
+			{contestID, 2, domain.Korean, 150},
+			{contestID + 1, 3, domain.Global, 200},
+		} {
+			ranking := &domain.Ranking{
+				ContestID: data.contestID,
+				UserID:    data.userID,
+				Language:  data.language,
+				Amount:    0,
+			}
+
+			err := repo.Store(*ranking)
+			assert.NoError(t, err)
+		}
+	}
+
+	rankings, err := repo.RankingsForContest(contestID, domain.Global)
+	assert.NoError(t, err)
+
+	assert.Equal(t, len(expected), len(rankings))
+
+	for _, expected := range expected {
+		var ranking domain.Ranking
+		for _, r := range rankings {
+			if r.UserID == expected.userID {
+				ranking = r
+			}
+		}
+
+		assert.Equal(t, expected.amount, ranking.Amount)
+		assert.Equal(t, contestID, ranking.ContestID)
+		assert.Equal(t, expected.userID, ranking.UserID)
+	}
+}
+
 func TestRankingRepository_FindAllByContestAndUser(t *testing.T) {
 	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)

--- a/interfaces/services/context.go
+++ b/interfaces/services/context.go
@@ -11,6 +11,9 @@ import (
 
 // Context is a subset of the echo framework context, so we are not directly depending on it
 type Context interface {
+	// QueryParam returns the query param for the provided name.
+	QueryParam(name string) string
+
 	// Get retrieves data from the context.
 	Get(key string) interface{}
 

--- a/interfaces/services/context_mock.go
+++ b/interfaces/services/context_mock.go
@@ -34,6 +34,20 @@ func (m *MockContext) EXPECT() *MockContextMockRecorder {
 	return m.recorder
 }
 
+// QueryParam mocks base method
+func (m *MockContext) QueryParam(name string) string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryParam", name)
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// QueryParam indicates an expected call of QueryParam
+func (mr *MockContextMockRecorder) QueryParam(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryParam", reflect.TypeOf((*MockContext)(nil).QueryParam), name)
+}
+
 // Get mocks base method
 func (m *MockContext) Get(key string) interface{} {
 	m.ctrl.T.Helper()

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -50,7 +50,12 @@ func (s *rankingService) Create(ctx Context) error {
 }
 
 func (s *rankingService) Get(ctx Context) error {
-	rankings, err := s.RankingInteractor.RankingsForContest(1, domain.Global)
+	contestID, err := ctx.GetID()
+	if err != nil {
+		return fail.Wrap(err)
+	}
+
+	rankings, err := s.RankingInteractor.RankingsForContest(contestID, domain.Global)
 	if err != nil {
 		return fail.Wrap(err)
 	}

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -11,6 +11,7 @@ import (
 // RankingService is responsible for managing rankings
 type RankingService interface {
 	Create(ctx Context) error
+	Get(ctx Context) error
 }
 
 // NewRankingService initializer
@@ -46,4 +47,13 @@ func (s *rankingService) Create(ctx Context) error {
 	}
 
 	return ctx.NoContent(http.StatusCreated)
+}
+
+func (s *rankingService) Get(ctx Context) error {
+	rankings, err := s.RankingInteractor.RankingsForContest(1, domain.Global)
+	if err != nil {
+		return fail.Wrap(err)
+	}
+
+	return ctx.JSON(http.StatusOK, rankings)
 }

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/srvc/fail"
 
@@ -51,11 +52,10 @@ func (s *rankingService) Create(ctx Context) error {
 }
 
 func (s *rankingService) Get(ctx Context) error {
-	contestID, err := ctx.GetID()
+	contestID, err := strconv.ParseUint(ctx.QueryParam("contest_id"), 10, 64)
 	if err != nil {
 		return fail.Wrap(err)
 	}
-
 	language := domain.LanguageCode(ctx.QueryParam("language"))
 
 	rankings, err := s.RankingInteractor.RankingsForContest(contestID, language)

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -56,7 +56,9 @@ func (s *rankingService) Get(ctx Context) error {
 		return fail.Wrap(err)
 	}
 
-	rankings, err := s.RankingInteractor.RankingsForContest(contestID, domain.Global)
+	language := domain.LanguageCode(ctx.QueryParam("language"))
+
+	rankings, err := s.RankingInteractor.RankingsForContest(contestID, language)
 	if err != nil {
 		if err == usecases.ErrNoRankingsFound {
 			return ctx.NoContent(http.StatusNotFound)

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/srvc/fail"
+
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
 )
@@ -57,6 +58,10 @@ func (s *rankingService) Get(ctx Context) error {
 
 	rankings, err := s.RankingInteractor.RankingsForContest(contestID, domain.Global)
 	if err != nil {
+		if err == usecases.ErrNoRankingsFound {
+			return ctx.NoContent(http.StatusNotFound)
+		}
+
 		return fail.Wrap(err)
 	}
 

--- a/interfaces/services/ranking_service_test.go
+++ b/interfaces/services/ranking_service_test.go
@@ -51,6 +51,7 @@ func TestRankingService_Get(t *testing.T) {
 	}
 
 	ctx := services.NewMockContext(ctrl)
+	ctx.EXPECT().GetID().Return(contestID, nil)
 	ctx.EXPECT().JSON(200, expected)
 
 	i := usecases.NewMockRankingInteractor(ctrl)

--- a/interfaces/services/ranking_service_test.go
+++ b/interfaces/services/ranking_service_test.go
@@ -51,7 +51,7 @@ func TestRankingService_Get(t *testing.T) {
 	}
 
 	ctx := services.NewMockContext(ctrl)
-	ctx.EXPECT().GetID().Return(contestID, nil)
+	ctx.EXPECT().QueryParam("contest_id").Return("1")
 	ctx.EXPECT().QueryParam("language").Return(string(domain.Global))
 	ctx.EXPECT().JSON(200, expected)
 

--- a/interfaces/services/ranking_service_test.go
+++ b/interfaces/services/ranking_service_test.go
@@ -15,21 +15,49 @@ func TestRankingService_Create(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
+	contestID := uint64(1)
+	userID := uint64(1)
+
 	payload := &services.CreateRankingPayload{
-		ContestID: 1,
+		ContestID: contestID,
 		Languages: domain.LanguageCodes{domain.Japanese},
 	}
 
 	ctx := services.NewMockContext(ctrl)
 	ctx.EXPECT().NoContent(201)
-	ctx.EXPECT().User().Return(&domain.User{ID: 1}, nil)
+	ctx.EXPECT().User().Return(&domain.User{ID: userID}, nil)
 	ctx.EXPECT().Bind(gomock.Any()).Return(nil).SetArg(0, *payload)
 
 	i := usecases.NewMockRankingInteractor(ctrl)
-	i.EXPECT().CreateRanking(uint64(1), uint64(1), payload.Languages).Return(nil)
+	i.EXPECT().CreateRanking(contestID, userID, payload.Languages).Return(nil)
 
 	s := services.NewRankingService(i)
 	err := s.Create(ctx)
+
+	assert.NoError(t, err)
+}
+
+func TestRankingService_Get(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	contestID := uint64(1)
+	language := domain.Global
+
+	expected := domain.Rankings{
+		{ID: 1, ContestID: contestID, UserID: 1, Language: domain.Global, Amount: 15},
+		{ID: 2, ContestID: contestID, UserID: 2, Language: domain.Global, Amount: 12},
+		{ID: 3, ContestID: contestID, UserID: 3, Language: domain.Global, Amount: 11},
+	}
+
+	ctx := services.NewMockContext(ctrl)
+	ctx.EXPECT().JSON(200, expected)
+
+	i := usecases.NewMockRankingInteractor(ctrl)
+	i.EXPECT().RankingsForContest(contestID, language).Return(expected, nil)
+
+	s := services.NewRankingService(i)
+	err := s.Get(ctx)
 
 	assert.NoError(t, err)
 }

--- a/interfaces/services/ranking_service_test.go
+++ b/interfaces/services/ranking_service_test.go
@@ -52,6 +52,7 @@ func TestRankingService_Get(t *testing.T) {
 
 	ctx := services.NewMockContext(ctrl)
 	ctx.EXPECT().GetID().Return(contestID, nil)
+	ctx.EXPECT().QueryParam("language").Return(string(domain.Global))
 	ctx.EXPECT().JSON(200, expected)
 
 	i := usecases.NewMockRankingInteractor(ctrl)

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -195,5 +195,14 @@ func (i *rankingInteractor) RankingsForContest(
 	contestID uint64,
 	languageCode domain.LanguageCode,
 ) (domain.Rankings, error) {
-	return nil, nil
+	rankings, err := i.rankingRepository.RankingsForContest(contestID, languageCode)
+	if err != nil {
+		return nil, fail.Wrap(err)
+	}
+
+	if len(rankings) == 0 {
+		return nil, ErrNoRankingsFound
+	}
+
+	return rankings, nil
 }

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -40,6 +40,8 @@ type RankingInteractor interface {
 	) error
 	CreateLog(log domain.ContestLog) error
 	UpdateRanking(contestID uint64, userID uint64) error
+
+	RankingsForContest(contestID uint64, languageCode domain.LanguageCode) (domain.Rankings, error)
 }
 
 // NewRankingInteractor instantiates RankingInteractor with all dependencies
@@ -187,4 +189,11 @@ func (i *rankingInteractor) UpdateRanking(contestID uint64, userID uint64) error
 	}
 
 	return i.rankingRepository.UpdateAmounts(updatedRankings)
+}
+
+func (i *rankingInteractor) RankingsForContest(
+	contestID uint64,
+	languageCode domain.LanguageCode,
+) (domain.Rankings, error) {
+	return nil, nil
 }

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -31,6 +31,9 @@ var ErrInvalidContestLog = fail.New("invalid contest log supplied")
 // ErrContestLanguageNotSignedUp for when a user tries to log an entry for a contest with a language they're not signed up for
 var ErrContestLanguageNotSignedUp = fail.New("user has not signed up for given language")
 
+// GlobalRankingsContestID is the ID that's passed in when the overall rankings are requested
+var GlobalRankingsContestID = uint64(0)
+
 // RankingInteractor contains all business logic for rankings
 type RankingInteractor interface {
 	CreateRanking(
@@ -201,7 +204,12 @@ func (i *rankingInteractor) RankingsForContest(
 		validatedLanguage = languageCode
 	}
 
-	rankings, err := i.rankingRepository.RankingsForContest(contestID, validatedLanguage)
+	lookup := i.rankingRepository.RankingsForContest
+	if contestID == GlobalRankingsContestID {
+		return nil, fail.New("not yet implemented")
+	}
+
+	rankings, err := lookup(contestID, validatedLanguage)
 	if err != nil {
 		return nil, fail.Wrap(err)
 	}

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -195,7 +195,13 @@ func (i *rankingInteractor) RankingsForContest(
 	contestID uint64,
 	languageCode domain.LanguageCode,
 ) (domain.Rankings, error) {
-	rankings, err := i.rankingRepository.RankingsForContest(contestID, languageCode)
+
+	validatedLanguage := domain.Global
+	if ok, _ := i.validator.Validate(languageCode); ok {
+		validatedLanguage = languageCode
+	}
+
+	rankings, err := i.rankingRepository.RankingsForContest(contestID, validatedLanguage)
 	if err != nil {
 		return nil, fail.Wrap(err)
 	}

--- a/usecases/ranking_interactor_mock.go
+++ b/usecases/ranking_interactor_mock.go
@@ -74,3 +74,18 @@ func (mr *MockRankingInteractorMockRecorder) UpdateRanking(contestID, userID int
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRanking", reflect.TypeOf((*MockRankingInteractor)(nil).UpdateRanking), contestID, userID)
 }
+
+// RankingsForContest mocks base method
+func (m *MockRankingInteractor) RankingsForContest(contestID uint64, languageCode domain.LanguageCode) (domain.Rankings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RankingsForContest", contestID, languageCode)
+	ret0, _ := ret[0].(domain.Rankings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RankingsForContest indicates an expected call of RankingsForContest
+func (mr *MockRankingInteractorMockRecorder) RankingsForContest(contestID, languageCode interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RankingsForContest", reflect.TypeOf((*MockRankingInteractor)(nil).RankingsForContest), contestID, languageCode)
+}

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -300,6 +300,17 @@ func TestRankingInteractor_RankingsForContent(t *testing.T) {
 	}
 
 	{
+		expected := domain.Rankings{
+			{ID: 1, ContestID: contestID, UserID: userID, Language: domain.Japanese, Amount: 15},
+		}
+		rankingRepo.EXPECT().RankingsForContest(contestID, domain.Japanese).Return(expected, nil)
+		validator.EXPECT().Validate(domain.Japanese).Return(true, nil)
+
+		_, err := interactor.RankingsForContest(contestID, domain.Japanese)
+		assert.NoError(t, err)
+	}
+
+	{
 		invalidLanguage := domain.LanguageCode("")
 		expected := domain.Rankings{
 			{ID: 1, ContestID: contestID, UserID: userID, Language: language, Amount: 15},

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -263,22 +263,24 @@ func TestRankingInteractor_UpdateRankings(t *testing.T) {
 }
 
 func TestRankingInteractor_RankingsForContent(t *testing.T) {
-	ctrl, rankingRepo, _, _, _, _, interactor := setupRankingTest(t)
+	ctrl, rankingRepo, _, _, _, validator, interactor := setupRankingTest(t)
 	defer ctrl.Finish()
 
 	contestID := uint64(1)
 	userID := uint64(1)
+	language := domain.Global
 
 	{
 		expected := domain.Rankings{
-			{ID: 1, ContestID: contestID, UserID: userID, Language: domain.Global, Amount: 15},
-			{ID: 2, ContestID: contestID, UserID: userID + 1, Language: domain.Global, Amount: 12},
-			{ID: 3, ContestID: contestID, UserID: userID + 2, Language: domain.Global, Amount: 11},
-			{ID: 4, ContestID: contestID, UserID: userID + 3, Language: domain.Global, Amount: 0},
+			{ID: 1, ContestID: contestID, UserID: userID, Language: language, Amount: 15},
+			{ID: 2, ContestID: contestID, UserID: userID + 1, Language: language, Amount: 12},
+			{ID: 3, ContestID: contestID, UserID: userID + 2, Language: language, Amount: 11},
+			{ID: 4, ContestID: contestID, UserID: userID + 3, Language: language, Amount: 0},
 		}
-		rankingRepo.EXPECT().RankingsForContest(contestID, domain.Global).Return(expected, nil)
+		rankingRepo.EXPECT().RankingsForContest(contestID, language).Return(expected, nil)
+		validator.EXPECT().Validate(language).Return(true, nil)
 
-		rankings, err := interactor.RankingsForContest(contestID, domain.Global)
+		rankings, err := interactor.RankingsForContest(contestID, language)
 		assert.NoError(t, err)
 
 		for i, ranking := range rankings {
@@ -290,9 +292,22 @@ func TestRankingInteractor_RankingsForContent(t *testing.T) {
 	}
 
 	{
-		rankingRepo.EXPECT().RankingsForContest(contestID, domain.Global).Return(nil, nil)
+		rankingRepo.EXPECT().RankingsForContest(contestID, language).Return(nil, nil)
+		validator.EXPECT().Validate(language).Return(true, nil)
 
-		_, err := interactor.RankingsForContest(contestID, domain.Global)
+		_, err := interactor.RankingsForContest(contestID, language)
 		assert.EqualError(t, err, usecases.ErrNoRankingsFound.Error())
+	}
+
+	{
+		invalidLanguage := domain.LanguageCode("")
+		expected := domain.Rankings{
+			{ID: 1, ContestID: contestID, UserID: userID, Language: language, Amount: 15},
+		}
+		rankingRepo.EXPECT().RankingsForContest(contestID, language).Return(expected, nil)
+		validator.EXPECT().Validate(invalidLanguage).Return(false, domain.ErrInvalidLanguage)
+
+		_, err := interactor.RankingsForContest(contestID, invalidLanguage)
+		assert.NoError(t, err)
 	}
 }

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -30,6 +30,7 @@ type RankingRepository interface {
 	Store(contest domain.Ranking) error
 	UpdateAmounts(domain.Rankings) error
 
+	RankingsForContest(contestID uint64, languageCode domain.LanguageCode) (domain.Rankings, error)
 	FindAll(contestID uint64, userID uint64) (domain.Rankings, error)
 	GetAllLanguagesForContestAndUser(contestID uint64, userID uint64) (domain.LanguageCodes, error)
 }

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -232,6 +232,21 @@ func (mr *MockRankingRepositoryMockRecorder) UpdateAmounts(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAmounts", reflect.TypeOf((*MockRankingRepository)(nil).UpdateAmounts), arg0)
 }
 
+// RankingsForContest mocks base method
+func (m *MockRankingRepository) RankingsForContest(contestID uint64, languageCode domain.LanguageCode) (domain.Rankings, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RankingsForContest", contestID, languageCode)
+	ret0, _ := ret[0].(domain.Rankings)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RankingsForContest indicates an expected call of RankingsForContest
+func (mr *MockRankingRepositoryMockRecorder) RankingsForContest(contestID, languageCode interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RankingsForContest", reflect.TypeOf((*MockRankingRepository)(nil).RankingsForContest), contestID, languageCode)
+}
+
 // FindAll mocks base method
 func (m *MockRankingRepository) FindAll(contestID, userID uint64) (domain.Rankings, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why

Cf. #22 

## What

- [x] Accessible for unauthenticated users
- [x] Route: `GET /rankings?contest_id=:contest_id`
- [x] Should return an ordered list of the users with the rankings for the given contest
- [x] Language filter