### PR TITLE
Introduce rankings view

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ migrate:
 .PHONY: test
 test:
 	@make lint
-	@go test -v ./...
+	@go test -v ./... -count=1
 
 .PHONY: run
 run:

--- a/domain/ranking.go
+++ b/domain/ranking.go
@@ -13,6 +13,9 @@ type Ranking struct {
 	Amount    float32      `json:"amount" db:"amount" valid:"required"`
 	CreatedAt time.Time    `json:"created_at" db:"created_at"`
 	UpdatedAt time.Time    `json:"updated_at" db:"updated_at"`
+
+	// Optional fields
+	UserDisplayName string `json:"user_display_name" db:"user_display_name"`
 }
 
 // Rankings is a collection of Ranking

--- a/domain/ranking.go
+++ b/domain/ranking.go
@@ -18,5 +18,34 @@ type Ranking struct {
 	UserDisplayName string `json:"user_display_name" db:"user_display_name"`
 }
 
+// GetView gets the external view representation of a Ranking
+func (r Ranking) GetView() RankingView {
+	return RankingView{
+		UserID:          r.UserID,
+		UserDisplayName: r.UserDisplayName,
+		Language:        r.Language,
+		Amount:          r.Amount,
+	}
+}
+
 // Rankings is a collection of Ranking
 type Rankings []Ranking
+
+// GetView gets the external view representation of a Rankings collection
+func (r Rankings) GetView() []RankingView {
+	result := make([]RankingView, len(r))
+
+	for i, val := range r {
+		result[i] = val.GetView()
+	}
+
+	return result
+}
+
+// RankingView is a representation of a ranking for external usages
+type RankingView struct {
+	UserID          uint64       `json:"user_id"`
+	UserDisplayName string       `json:"user_display_name"`
+	Language        LanguageCode `json:"language_code"`
+	Amount          float32      `json:"amount"`
+}

--- a/infra/sql.go
+++ b/infra/sql.go
@@ -156,7 +156,7 @@ type sqlResult struct {
 	Result sql.Result
 }
 
-func (r sqlResult) LastInsertId() (int64, error) {
+func (r sqlResult) LastInsertID() (int64, error) {
 	return r.Result.LastInsertId()
 }
 

--- a/interfaces/rdb/sql.go
+++ b/interfaces/rdb/sql.go
@@ -32,7 +32,7 @@ type TxHandler interface {
 
 // Result contains meta data of a query that was executed
 type Result interface {
-	LastInsertId() (int64, error)
+	LastInsertID() (int64, error)
 	RowsAffected() (int64, error)
 }
 

--- a/interfaces/repositories/contest_log_repository_test.go
+++ b/interfaces/repositories/contest_log_repository_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestContestLogRepository_StoreContest(t *testing.T) {
-	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
 
@@ -42,7 +41,6 @@ func TestContestLogRepository_StoreContest(t *testing.T) {
 }
 
 func TestContestLogRepository_FindAllByContestAndUser(t *testing.T) {
-	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
 

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -10,7 +10,6 @@ import (
 )
 
 func TestContestRepository_StoreContest(t *testing.T) {
-	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
 
@@ -39,7 +38,6 @@ func TestContestRepository_StoreContest(t *testing.T) {
 }
 
 func TestContestRepository_GetOpenContests(t *testing.T) {
-	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
 

--- a/interfaces/repositories/prepare_test.go
+++ b/interfaces/repositories/prepare_test.go
@@ -63,5 +63,8 @@ func prepareDB(t *testing.T) (db *sqlx.DB, cleanup func() error) {
 		t.Fatalf("open pgx connection: %s", err)
 	}
 
-	return db, db.Close
+	return db, func() error {
+		fmt.Printf("Closing: %s\n", cName)
+		return db.Close()
+	}
 }

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -97,10 +97,11 @@ func (r *rankingRepository) GlobalRankings(languageCode domain.LanguageCode) (do
 	var rankings []domain.Ranking
 
 	query := `
-		select user_id, language_code, sum(amount) as amount
+		select user_id, language_code, sum(amount) as amount, users.display_name as user_display_name
 		from rankings
+		inner join users on users.id = rankings.user_id
 		where language_code = $1
-		group by user_id, language_code
+		group by user_id, user_display_name, language_code
 		order by amount desc
 	`
 

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -79,8 +79,9 @@ func (r *rankingRepository) RankingsForContest(
 	var rankings []domain.Ranking
 
 	query := `
-		select id, contest_id, user_id, language_code, amount, created_at, updated_at
+		select rankings.id as id, contest_id, user_id, language_code, amount, created_at, updated_at, users.display_name as user_display_name
 		from rankings
+		inner join users on users.id = rankings.user_id
 		where contest_id = $1 and language_code = $2
 		order by amount desc, id asc
 	`

--- a/interfaces/repositories/ranking_repository_test.go
+++ b/interfaces/repositories/ranking_repository_test.go
@@ -188,9 +188,9 @@ func TestRankingRepository_GlobalRankings(t *testing.T) {
 		language        domain.LanguageCode
 		amount          float32
 	}{
-		{users[0].ID, "FOO 0", domain.Global, 50},
-		{users[2].ID, "FOO 2", domain.Global, 30},
-		{users[1].ID, "FOO 1", domain.Global, 20},
+		{users[0].ID, users[0].DisplayName, domain.Global, 50},
+		{users[2].ID, users[2].DisplayName, domain.Global, 30},
+		{users[1].ID, users[1].DisplayName, domain.Global, 20},
 	}
 
 	{

--- a/interfaces/repositories/user_repository_test.go
+++ b/interfaces/repositories/user_repository_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestUserRepository_StoreUser(t *testing.T) {
-	t.Parallel()
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
 

--- a/interfaces/repositories/user_repository_test.go
+++ b/interfaces/repositories/user_repository_test.go
@@ -23,22 +23,21 @@ func TestUserRepository_StoreUser(t *testing.T) {
 	}
 
 	{
-		err := repo.Store(*user)
+		err := repo.Store(user)
 		assert.NoError(t, err)
 	}
 
 	{
-		user.ID = 1
 		user.DisplayName = "John Smith"
-		err := repo.Store(*user)
+		err := repo.Store(user)
 		assert.NoError(t, err)
 	}
 
 	{
-		dbUser, err := repo.FindByID(1)
+		dbUser, err := repo.FindByID(user.ID)
 		assert.NoError(t, err)
 		assert.Equal(t, dbUser, domain.User{
-			ID:          1,
+			ID:          user.ID,
 			Email:       "foo@example.com",
 			DisplayName: "John Smith",
 			Password:    "",
@@ -51,7 +50,7 @@ func TestUserRepository_StoreUser(t *testing.T) {
 		dbUser, err := repo.FindByEmail("foo@example.com")
 		assert.NoError(t, err)
 		assert.Equal(t, dbUser, domain.User{
-			ID:          1,
+			ID:          user.ID,
 			Email:       "foo@example.com",
 			DisplayName: "John Smith",
 			Password:    "foobar",

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -67,5 +67,5 @@ func (s *rankingService) Get(ctx Context) error {
 		return fail.Wrap(err)
 	}
 
-	return ctx.JSON(http.StatusOK, rankings)
+	return ctx.JSON(http.StatusOK, rankings.GetView())
 }

--- a/interfaces/services/ranking_service_test.go
+++ b/interfaces/services/ranking_service_test.go
@@ -53,7 +53,7 @@ func TestRankingService_Get(t *testing.T) {
 	ctx := services.NewMockContext(ctrl)
 	ctx.EXPECT().QueryParam("contest_id").Return("1")
 	ctx.EXPECT().QueryParam("language").Return(string(domain.Global))
-	ctx.EXPECT().JSON(200, expected)
+	ctx.EXPECT().JSON(200, expected.GetView())
 
 	i := usecases.NewMockRankingInteractor(ctrl)
 	i.EXPECT().RankingsForContest(contestID, language).Return(expected, nil)

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -8,7 +8,7 @@ import (
 
 // UserRepository handles User related database interactions
 type UserRepository interface {
-	Store(user domain.User) error
+	Store(user *domain.User) error
 	FindByID(id uint64) (domain.User, error)
 	FindByEmail(email string) (domain.User, error)
 }

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -34,7 +34,7 @@ func (m *MockUserRepository) EXPECT() *MockUserRepositoryMockRecorder {
 }
 
 // Store mocks base method
-func (m *MockUserRepository) Store(user domain.User) error {
+func (m *MockUserRepository) Store(user *domain.User) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Store", user)
 	ret0, _ := ret[0].(error)

--- a/usecases/session_interactor.go
+++ b/usecases/session_interactor.go
@@ -56,7 +56,7 @@ func (si *sessionInteractor) CreateUser(user domain.User) error {
 		}
 	}
 
-	err := si.userRepository.Store(user)
+	err := si.userRepository.Store(&user)
 	return fail.Wrap(err)
 }
 

--- a/usecases/session_interactor_test.go
+++ b/usecases/session_interactor_test.go
@@ -46,7 +46,7 @@ func TestSessionInteractor_CreateUser(t *testing.T) {
 	hashedUser.Password = "barbar"
 
 	pwHasher.EXPECT().Hash(user.Password).Return(hashedUser.Password, nil)
-	repo.EXPECT().Store(hashedUser)
+	repo.EXPECT().Store(&hashedUser)
 
 	err := interactor.CreateUser(user)
 


### PR DESCRIPTION
## Why

When we return data on an API endpoint we sometimes want to combine it with other data, or hide some of the data. To do so we define a `view` specific for that type.

## What

- [x] Add optional display name for the user of the ranking entry
- [x] Introduce ranking concept