### PR TITLE
Fix duplicate rankings

### DIFF
--- a/migrations/201902262055_rankings_up.sql
+++ b/migrations/201902262055_rankings_up.sql
@@ -14,5 +14,6 @@ create table rankings (
 create index rankings_contest_id on rankings(contest_id);
 create index rankings_user_id on rankings(user_id);
 create index rankings_language_code on rankings(language_code);
+create unique index rankings_unique_contest_user_language on rankings(contest_id, user_id, language_code);
 
 alter sequence ranking_seq restart with 1;

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -95,7 +95,7 @@ func (i *rankingInteractor) CreateRanking(
 	if err != nil {
 		return fail.Wrap(err)
 	}
-	needsGlobal := !existingLanguages.ContainsLanguage(domain.Global)
+	needsGlobal := len(existingLanguages) == 0
 
 	// Figure out which languages we need to create new rankings for
 	targetLanguages := domain.LanguageCodes{}

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -59,7 +59,7 @@ func TestRankingInteractor_CreateRanking(t *testing.T) {
 
 		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
 		userRepo.EXPECT().FindByID(userID).Return(domain.User{ID: userID}, nil)
-		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.English, domain.Global}, nil)
+		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.English}, nil)
 		rankingRepo.EXPECT().Store(domain.Ranking{ContestID: contestID, UserID: userID, Language: languages[0], Amount: 0}).Return(nil)
 
 		err := interactor.CreateRanking(userID, contestID, languages)
@@ -72,7 +72,7 @@ func TestRankingInteractor_CreateRanking(t *testing.T) {
 
 		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
 		userRepo.EXPECT().FindByID(userID).Return(domain.User{ID: userID}, nil)
-		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.English, domain.Global}, nil)
+		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.English}, nil)
 
 		err := interactor.CreateRanking(userID, contestID, languages)
 


### PR DESCRIPTION
## Why

When you add a new language after you're already registered for a contest, it will create a new global ranking for that user/contest.

## What

This didn't get caught in the tests as the mocking for the tests did return the global language for `GetAllLanguagesForContestAndUser`, which in practice never returns the global language.

- [x] check for global by array length
- [x] add constraint to database so a duplicate record is impossible