### PR TITLE
Get contest details

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -138,6 +138,7 @@ func (d *serverDependencies) routes() []services.Route {
 		{Method: http.MethodPost, Path: "/login", HandlerFunc: d.Services().Session.Login},
 		{Method: http.MethodPost, Path: "/register", HandlerFunc: d.Services().Session.Register},
 		{Method: http.MethodGet, Path: "/contests/latest", HandlerFunc: d.Services().Contest.Latest},
+		{Method: http.MethodGet, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Get},
 		{Method: http.MethodPost, Path: "/contests", HandlerFunc: d.Services().Contest.Create, MinRole: domain.RoleAdmin},
 		{Method: http.MethodPut, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Update, MinRole: domain.RoleAdmin},
 		{Method: http.MethodGet, Path: "/rankings/current", HandlerFunc: d.Services().Ranking.CurrentRegistration, MinRole: domain.RoleUser},

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -1,0 +1,8 @@
+package domain
+
+import (
+	"database/sql"
+)
+
+// ErrNotFound for when an entity could not be found
+var ErrNotFound = sql.ErrNoRows

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -95,7 +95,10 @@ func (r *contestRepository) FindByID(id uint64) (domain.Contest, error) {
 
 	var contest domain.Contest
 	err := r.sqlHandler.Get(&contest, query, id)
-	if err != nil {
+	switch {
+	case err == domain.ErrNotFound:
+		return contest, err
+	case err != nil:
 		return contest, fail.Wrap(err)
 	}
 

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -78,7 +78,10 @@ func (r *contestRepository) FindLatest() (domain.Contest, error) {
 
 	var contest domain.Contest
 	err := r.sqlHandler.Get(&contest, query)
-	if err != nil {
+	switch {
+	case err == domain.ErrNotFound:
+		return contest, err
+	case err != nil:
 		return contest, fail.Wrap(err)
 	}
 

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -84,3 +84,7 @@ func (r *contestRepository) FindLatest() (domain.Contest, error) {
 
 	return contest, nil
 }
+
+func (r *contestRepository) FindByID(id uint64) (domain.Contest, error) {
+	return domain.Contest{}, nil
+}

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -86,5 +86,18 @@ func (r *contestRepository) FindLatest() (domain.Contest, error) {
 }
 
 func (r *contestRepository) FindByID(id uint64) (domain.Contest, error) {
-	return domain.Contest{}, nil
+	query := `
+		select id, description, start, "end", open
+		from contests
+		where id = $1
+		limit 1
+	`
+
+	var contest domain.Contest
+	err := r.sqlHandler.Get(&contest, query, id)
+	if err != nil {
+		return contest, fail.Wrap(err)
+	}
+
+	return contest, nil
 }

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -83,3 +83,25 @@ func TestContestRepository_FindLatest(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+func TestContestRepository_FindByID(t *testing.T) {
+	sqlHandler, cleanup := setupTestingSuite(t)
+	defer cleanup()
+
+	repo := repositories.NewContestRepository(sqlHandler)
+
+	{
+		contest, err := repo.FindByID(0)
+		assert.EqualError(t, err, sql.ErrNoRows.Error())
+		assert.Empty(t, contest, "no contests should be found")
+
+		expected := domain.Contest{Description: "Foo 2019", Start: time.Now(), End: time.Now(), Open: true}
+		err = repo.Store(&expected)
+		assert.NoError(t, err)
+
+		contest, err = repo.FindByID(expected.ID)
+		assert.Equal(t, expected.Description, contest.Description, "contest should have the same description")
+		assert.Equal(t, expected.Open, contest.Open, "contest should both be open")
+		assert.NoError(t, err)
+	}
+}

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -1,7 +1,6 @@
 package repositories_test
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
@@ -70,7 +69,7 @@ func TestContestRepository_FindLatest(t *testing.T) {
 
 	{
 		contest, err := repo.FindLatest()
-		assert.EqualError(t, err, sql.ErrNoRows.Error())
+		assert.EqualError(t, err, domain.ErrNotFound.Error())
 		assert.Empty(t, contest, "no contests should be found")
 
 		expected := domain.Contest{Description: "Foo 2019", Start: time.Now(), End: time.Now(), Open: true}
@@ -92,7 +91,7 @@ func TestContestRepository_FindByID(t *testing.T) {
 
 	{
 		contest, err := repo.FindByID(0)
-		assert.EqualError(t, err, sql.ErrNoRows.Error())
+		assert.EqualError(t, err, domain.ErrNotFound.Error())
 		assert.Empty(t, contest, "no contests should be found")
 
 		expected := domain.Contest{Description: "Foo 2019", Start: time.Now(), End: time.Now(), Open: true}

--- a/interfaces/services/contest_service.go
+++ b/interfaces/services/contest_service.go
@@ -13,6 +13,7 @@ type ContestService interface {
 	Create(ctx Context) error
 	Update(ctx Context) error
 	Latest(ctx Context) error
+	Get(ctx Context) error
 }
 
 // NewContestService initializer
@@ -56,6 +57,23 @@ func (s *contestService) Update(ctx Context) error {
 
 func (s *contestService) Latest(ctx Context) error {
 	contest, err := s.ContestInteractor.Latest()
+
+	if err != nil {
+		if err == usecases.ErrContestNotFound {
+			return ctx.NoContent(http.StatusNotFound)
+		}
+
+		return fail.Wrap(err)
+	}
+
+	return ctx.JSON(http.StatusOK, contest)
+}
+
+func (s *contestService) Get(ctx Context) error {
+	var contestID uint64
+	ctx.BindID(&contestID)
+
+	contest, err := s.ContestInteractor.Find(contestID)
 
 	if err != nil {
 		if err == usecases.ErrContestNotFound {

--- a/interfaces/services/contest_service_test.go
+++ b/interfaces/services/contest_service_test.go
@@ -97,3 +97,45 @@ func TestContestService_Latest(t *testing.T) {
 		assert.NoError(t, err)
 	}
 }
+
+func TestContestService_Get(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	{
+		contestID := uint64(1)
+		contest := &domain.Contest{
+			ID:    contestID,
+			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
+			Open:  true,
+		}
+
+		ctx := services.NewMockContext(ctrl)
+		ctx.EXPECT().BindID(gomock.Any()).Return(nil).SetArg(0, contestID)
+		ctx.EXPECT().JSON(200, contest)
+
+		i := usecases.NewMockContestInteractor(ctrl)
+		i.EXPECT().Find(contestID).Return(contest, nil)
+
+		s := services.NewContestService(i)
+		err := s.Get(ctx)
+
+		assert.NoError(t, err)
+	}
+
+	{
+		contestID := uint64(1)
+		ctx := services.NewMockContext(ctrl)
+		ctx.EXPECT().BindID(gomock.Any()).Return(nil).SetArg(0, contestID)
+		ctx.EXPECT().NoContent(404)
+
+		i := usecases.NewMockContestInteractor(ctrl)
+		i.EXPECT().Find(contestID).Return(nil, usecases.ErrContestNotFound)
+
+		s := services.NewContestService(i)
+		err := s.Get(ctx)
+
+		assert.NoError(t, err)
+	}
+}

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -29,6 +29,7 @@ type ContestInteractor interface {
 	CreateContest(contest domain.Contest) error
 	UpdateContest(contest domain.Contest) error
 	Latest() (*domain.Contest, error)
+	Find(contestID uint64) (*domain.Contest, error)
 }
 
 // NewContestInteractor instantiates ContestInteractor with all dependencies
@@ -88,6 +89,19 @@ func (i *contestInteractor) saveContest(contest domain.Contest) error {
 
 func (i *contestInteractor) Latest() (*domain.Contest, error) {
 	contest, err := i.contestRepository.FindLatest()
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, ErrContestNotFound
+		}
+
+		return nil, fail.Wrap(err)
+	}
+
+	return &contest, nil
+}
+
+func (i *contestInteractor) Find(contestID uint64) (*domain.Contest, error) {
+	contest, err := i.contestRepository.FindByID(contestID)
 	if err != nil {
 		if err == sql.ErrNoRows {
 			return nil, ErrContestNotFound

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -3,8 +3,6 @@
 package usecases
 
 import (
-	"database/sql"
-
 	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 )
@@ -90,7 +88,7 @@ func (i *contestInteractor) saveContest(contest domain.Contest) error {
 func (i *contestInteractor) Latest() (*domain.Contest, error) {
 	contest, err := i.contestRepository.FindLatest()
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if err == domain.ErrNotFound {
 			return nil, ErrContestNotFound
 		}
 
@@ -103,7 +101,7 @@ func (i *contestInteractor) Latest() (*domain.Contest, error) {
 func (i *contestInteractor) Find(contestID uint64) (*domain.Contest, error) {
 	contest, err := i.contestRepository.FindByID(contestID)
 	if err != nil {
-		if err == sql.ErrNoRows {
+		if err == domain.ErrNotFound {
 			return nil, ErrContestNotFound
 		}
 

--- a/usecases/contest_interactor_mock.go
+++ b/usecases/contest_interactor_mock.go
@@ -75,3 +75,18 @@ func (mr *MockContestInteractorMockRecorder) Latest() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Latest", reflect.TypeOf((*MockContestInteractor)(nil).Latest))
 }
+
+// Find mocks base method
+func (m *MockContestInteractor) Find(contestID uint64) (*domain.Contest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Find", contestID)
+	ret0, _ := ret[0].(*domain.Contest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Find indicates an expected call of Find
+func (mr *MockContestInteractorMockRecorder) Find(contestID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Find", reflect.TypeOf((*MockContestInteractor)(nil).Find), contestID)
+}

--- a/usecases/contest_interactor_test.go
+++ b/usecases/contest_interactor_test.go
@@ -1,7 +1,6 @@
 package usecases_test
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
@@ -133,7 +132,7 @@ func TestContestInteractor_Latest(t *testing.T) {
 	// Sad path: none found
 	{
 
-		repo.EXPECT().FindLatest().Return(domain.Contest{}, sql.ErrNoRows)
+		repo.EXPECT().FindLatest().Return(domain.Contest{}, domain.ErrNotFound)
 
 		_, err := interactor.Latest()
 		assert.EqualError(t, err, usecases.ErrContestNotFound.Error())
@@ -165,7 +164,7 @@ func TestContestInteractor_Find(t *testing.T) {
 	// Sad path: none found
 	{
 
-		repo.EXPECT().FindByID(contestID).Return(domain.Contest{}, sql.ErrNoRows)
+		repo.EXPECT().FindByID(contestID).Return(domain.Contest{}, domain.ErrNotFound)
 
 		_, err := interactor.Find(contestID)
 		assert.EqualError(t, err, usecases.ErrContestNotFound.Error())

--- a/usecases/contest_interactor_test.go
+++ b/usecases/contest_interactor_test.go
@@ -139,3 +139,35 @@ func TestContestInteractor_Latest(t *testing.T) {
 		assert.EqualError(t, err, usecases.ErrContestNotFound.Error())
 	}
 }
+
+func TestContestInteractor_Find(t *testing.T) {
+	ctrl, repo, _, interactor := setupContestTest(t)
+	defer ctrl.Finish()
+
+	contestID := uint64(1)
+
+	// Happy path
+	{
+		contest := domain.Contest{
+			ID:    contestID,
+			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
+			Open:  false,
+		}
+
+		repo.EXPECT().FindByID(contestID).Return(contest, nil)
+
+		found, err := interactor.Find(contestID)
+		assert.NoError(t, err)
+		assert.Equal(t, &contest, found)
+	}
+
+	// Sad path: none found
+	{
+
+		repo.EXPECT().FindByID(contestID).Return(domain.Contest{}, sql.ErrNoRows)
+
+		_, err := interactor.Find(contestID)
+		assert.EqualError(t, err, usecases.ErrContestNotFound.Error())
+	}
+}

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -18,6 +18,7 @@ type ContestRepository interface {
 	Store(contest *domain.Contest) error
 	GetOpenContests() ([]uint64, error)
 	FindLatest() (domain.Contest, error)
+	FindByID(id uint64) (domain.Contest, error)
 }
 
 // ContestLogRepository handles ContestLog related database interactions

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -144,6 +144,21 @@ func (mr *MockContestRepositoryMockRecorder) FindLatest() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLatest", reflect.TypeOf((*MockContestRepository)(nil).FindLatest))
 }
 
+// FindByID mocks base method
+func (m *MockContestRepository) FindByID(id uint64) (domain.Contest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindByID", id)
+	ret0, _ := ret[0].(domain.Contest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindByID indicates an expected call of FindByID
+func (mr *MockContestRepositoryMockRecorder) FindByID(id interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindByID", reflect.TypeOf((*MockContestRepository)(nil).FindByID), id)
+}
+
 // MockContestLogRepository is a mock of ContestLogRepository interface
 type MockContestLogRepository struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
## Why

So we can get the contest description for a given contest.

## What

- [x] Implement `Contest.Get` service
- [x] Extract `sql.ErrNoRows` into `domain.ErrNotFound` error