### PR TITLE
Error wrapping refactor

### DIFF
--- a/domain/errors.go
+++ b/domain/errors.go
@@ -11,3 +11,15 @@ var ErrNotFound = sql.ErrNoRows
 
 // ErrInsufficientPermissions for when access to a resource is denied
 var ErrInsufficientPermissions = fail.New("need higher permissions for this resource")
+
+// WrapError wraps errors except for domain logic related ones
+func WrapError(err error, annotators ...fail.Annotator) error {
+	if err == ErrNotFound {
+		return err
+	}
+	if err == ErrInsufficientPermissions {
+		return err
+	}
+
+	return fail.Wrap(err, annotators...)
+}

--- a/infra/context.go
+++ b/infra/context.go
@@ -41,12 +41,12 @@ func (c context) GetID() (uint64, error) {
 	idFromRoute := c.Param("id")
 	id, err := strconv.ParseUint(idFromRoute, 10, 64)
 
-	return id, fail.Wrap(err)
+	return id, domain.WrapError(err)
 }
 
 func (c context) BindID(id *uint64) error {
 	value, err := c.GetID()
 	*id = value
 
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }

--- a/infra/password_hasher.go
+++ b/infra/password_hasher.go
@@ -1,10 +1,10 @@
 package infra
 
 import (
-	"github.com/srvc/fail"
+	"golang.org/x/crypto/bcrypt"
+
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
-	"golang.org/x/crypto/bcrypt"
 )
 
 // NewPasswordHasher initializes a new password hasher with sane defaults
@@ -19,7 +19,7 @@ type passwordHasher struct {
 func (h *passwordHasher) Hash(value domain.Password) (domain.Password, error) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(value), h.cost)
 	if err != nil {
-		return "", fail.Wrap(err)
+		return "", domain.WrapError(err)
 	}
 
 	return domain.Password(hash), nil

--- a/infra/rdb.go
+++ b/infra/rdb.go
@@ -4,7 +4,8 @@ import (
 	"github.com/jmoiron/sqlx"
 	// Postgres driver that's used to connect to the db
 	_ "github.com/lib/pq"
-	"github.com/srvc/fail"
+
+	"github.com/tadoku/api/domain"
 )
 
 // RDB is a relational database connection pool
@@ -14,7 +15,7 @@ type RDB = sqlx.DB
 func NewRDB(URL string, maxIdleConns, maxOpenConns int) (*RDB, error) {
 	db, err := sqlx.Open("postgres", URL)
 	if err != nil {
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	db.SetMaxIdleConns(maxIdleConns)

--- a/infra/sql.go
+++ b/infra/sql.go
@@ -4,11 +4,11 @@ import (
 	"database/sql"
 
 	"github.com/jmoiron/sqlx"
-	"github.com/srvc/fail"
-	"github.com/tadoku/api/interfaces/rdb"
-
 	// Postgres driver that's used to connect to the db
 	_ "github.com/lib/pq"
+
+	"github.com/tadoku/api/domain"
+	"github.com/tadoku/api/interfaces/rdb"
 )
 
 // -----------------------------------------------------------------
@@ -28,7 +28,7 @@ func (handler *sqlHandler) Execute(statement string, args ...interface{}) (rdb.R
 	res := sqlResult{}
 	result, err := handler.db.Exec(statement, args...)
 	if err != nil {
-		return res, fail.Wrap(err)
+		return res, domain.WrapError(err)
 	}
 	res.Result = result
 
@@ -39,7 +39,7 @@ func (handler *sqlHandler) NamedExecute(statement string, arg interface{}) (rdb.
 	res := sqlResult{}
 	result, err := handler.db.NamedExec(statement, arg)
 	if err != nil {
-		return res, fail.Wrap(err)
+		return res, domain.WrapError(err)
 	}
 	res.Result = result
 
@@ -50,7 +50,7 @@ func (handler *sqlHandler) Query(statement string, args ...interface{}) (rdb.Row
 	row := new(sqlRows)
 	rows, err := handler.db.Queryx(statement, args...)
 	if err != nil {
-		return row, fail.Wrap(err)
+		return row, domain.WrapError(err)
 	}
 	row.Rows = rows
 
@@ -72,7 +72,7 @@ func (handler *sqlHandler) Select(dest interface{}, query string, args ...interf
 func (handler *sqlHandler) Begin() (rdb.TxHandler, error) {
 	tx, err := handler.db.Beginx()
 	if err != nil {
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	return &txHandler{tx: tx}, nil
@@ -89,7 +89,7 @@ func (handler *txHandler) Execute(statement string, args ...interface{}) (rdb.Re
 	res := sqlResult{}
 	result, err := handler.tx.Exec(statement, args...)
 	if err != nil {
-		return res, fail.Wrap(err)
+		return res, domain.WrapError(err)
 	}
 	res.Result = result
 
@@ -100,7 +100,7 @@ func (handler *txHandler) NamedExecute(statement string, arg interface{}) (rdb.R
 	res := sqlResult{}
 	result, err := handler.tx.NamedExec(statement, arg)
 	if err != nil {
-		return res, fail.Wrap(err)
+		return res, domain.WrapError(err)
 	}
 	res.Result = result
 
@@ -111,7 +111,7 @@ func (handler *txHandler) Query(statement string, args ...interface{}) (rdb.Rows
 	row := new(sqlRows)
 	rows, err := handler.tx.Queryx(statement, args...)
 	if err != nil {
-		return row, fail.Wrap(err)
+		return row, domain.WrapError(err)
 	}
 	row.Rows = rows
 
@@ -133,7 +133,7 @@ func (handler *txHandler) Select(dest interface{}, query string, args ...interfa
 func (handler *txHandler) Commit() error {
 	err := handler.tx.Commit()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return nil
@@ -142,7 +142,7 @@ func (handler *txHandler) Commit() error {
 func (handler *txHandler) Rollback() error {
 	err := handler.tx.Rollback()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return nil

--- a/interfaces/repositories/contest_log_repository.go
+++ b/interfaces/repositories/contest_log_repository.go
@@ -1,7 +1,6 @@
 package repositories
 
 import (
-	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/interfaces/rdb"
 	"github.com/tadoku/api/usecases"
@@ -35,7 +34,7 @@ func (r *contestLogRepository) create(contestLog *domain.ContestLog) error {
 	row := r.sqlHandler.QueryRow(query, contestLog.ContestID, contestLog.UserID, contestLog.Language, contestLog.MediumID, contestLog.Amount)
 	err := row.Scan(&contestLog.ID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return nil
@@ -52,7 +51,7 @@ func (r *contestLogRepository) update(contestLog *domain.ContestLog) error {
 	`
 
 	_, err := r.sqlHandler.NamedExecute(query, contestLog)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (r *contestLogRepository) FindByID(id uint64) (domain.ContestLog, error) {
@@ -91,7 +90,7 @@ func (r *contestLogRepository) FindAll(contestID uint64, userID uint64) (domain.
 
 	err := r.sqlHandler.Select(&logs, query, contestID, userID)
 	if err != nil {
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	return logs, nil
@@ -108,12 +107,12 @@ func (r *contestLogRepository) Delete(id uint64) error {
 
 	result, err := r.sqlHandler.Execute(query, id)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	rows, err := result.RowsAffected()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 	if rows != 1 {
 		return domain.ErrNotFound

--- a/interfaces/repositories/contest_log_repository.go
+++ b/interfaces/repositories/contest_log_repository.go
@@ -67,11 +67,7 @@ func (r *contestLogRepository) FindByID(id uint64) (domain.ContestLog, error) {
 	`
 	err := r.sqlHandler.QueryRow(query, id).StructScan(&l)
 	if err != nil {
-		if err == domain.ErrNotFound {
-			return l, domain.ErrNotFound
-		}
-
-		return l, fail.Wrap(err)
+		return l, domain.WrapError(err)
 	}
 	if l.ID == 0 {
 		return l, domain.ErrNotFound

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -1,7 +1,6 @@
 package repositories
 
 import (
-	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/interfaces/rdb"
 	"github.com/tadoku/api/usecases"
@@ -35,7 +34,7 @@ func (r *contestRepository) create(contest *domain.Contest) error {
 	row := r.sqlHandler.QueryRow(query, contest.Description, contest.Start, contest.End, contest.Open)
 	err := row.Scan(&contest.ID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return nil
@@ -49,7 +48,7 @@ func (r *contestRepository) update(contest *domain.Contest) error {
 	`
 
 	_, err := r.sqlHandler.NamedExecute(query, contest)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (r *contestRepository) GetOpenContests() ([]uint64, error) {
@@ -62,7 +61,7 @@ func (r *contestRepository) GetOpenContests() ([]uint64, error) {
 	var ids []uint64
 	err := r.sqlHandler.Select(&ids, query)
 	if err != nil {
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	return ids, nil

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -78,11 +78,8 @@ func (r *contestRepository) FindLatest() (domain.Contest, error) {
 
 	var contest domain.Contest
 	err := r.sqlHandler.Get(&contest, query)
-	switch {
-	case err == domain.ErrNotFound:
-		return contest, err
-	case err != nil:
-		return contest, fail.Wrap(err)
+	if err != nil {
+		return contest, domain.WrapError(err)
 	}
 
 	return contest, nil
@@ -98,11 +95,8 @@ func (r *contestRepository) FindByID(id uint64) (domain.Contest, error) {
 
 	var contest domain.Contest
 	err := r.sqlHandler.Get(&contest, query, id)
-	switch {
-	case err == domain.ErrNotFound:
-		return contest, err
-	case err != nil:
-		return contest, fail.Wrap(err)
+	if err != nil {
+		return contest, domain.WrapError(err)
 	}
 
 	return contest, nil

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -3,7 +3,6 @@ package repositories
 import (
 	"time"
 
-	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/interfaces/rdb"
 	"github.com/tadoku/api/usecases"
@@ -34,7 +33,7 @@ func (r *rankingRepository) create(ranking domain.Ranking) error {
 	`
 
 	_, err := r.sqlHandler.NamedExecute(query, ranking)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (r *rankingRepository) update(ranking domain.Ranking) error {
@@ -45,13 +44,13 @@ func (r *rankingRepository) update(ranking domain.Ranking) error {
 	`
 
 	_, err := r.sqlHandler.NamedExecute(query, ranking)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (r *rankingRepository) UpdateAmounts(rankings domain.Rankings) error {
 	tx, err := r.sqlHandler.Begin()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	query := `
@@ -67,7 +66,7 @@ func (r *rankingRepository) UpdateAmounts(rankings domain.Rankings) error {
 
 		if err != nil {
 			_ = tx.Rollback()
-			return fail.Wrap(err)
+			return domain.WrapError(err)
 		}
 	}
 
@@ -174,7 +173,7 @@ func (r *rankingRepository) CurrentRegistration(userID uint64) (domain.RankingRe
 
 	err := r.sqlHandler.Select(&rows, query, userID)
 	if err != nil {
-		return domain.RankingRegistration{}, fail.Wrap(err)
+		return domain.RankingRegistration{}, domain.WrapError(err)
 	}
 
 	result := &domain.RankingRegistration{}

--- a/interfaces/repositories/user_repository.go
+++ b/interfaces/repositories/user_repository.go
@@ -1,7 +1,6 @@
 package repositories
 
 import (
-	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/interfaces/rdb"
 	"github.com/tadoku/api/usecases"
@@ -35,7 +34,7 @@ func (r *userRepository) create(user *domain.User) error {
 	row := r.sqlHandler.QueryRow(query, user.Email, user.DisplayName, user.Password, user.Role, user.Preferences)
 	err := row.Scan(&user.ID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return nil
@@ -50,7 +49,7 @@ func (r *userRepository) update(user *domain.User) error {
 		where id = :id
 	`
 	_, err := r.sqlHandler.NamedExecute(query, user)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (r *userRepository) FindByID(id uint64) (domain.User, error) {
@@ -63,7 +62,7 @@ func (r *userRepository) FindByID(id uint64) (domain.User, error) {
 	`
 	err := r.sqlHandler.QueryRow(query, id).StructScan(&u)
 	if err != nil {
-		return u, fail.Wrap(err)
+		return u, domain.WrapError(err)
 	}
 
 	return u, nil
@@ -79,7 +78,7 @@ func (r *userRepository) FindByEmail(email string) (domain.User, error) {
 	`
 	err := r.sqlHandler.QueryRow(query, email).StructScan(&u)
 	if err != nil {
-		return u, fail.Wrap(err)
+		return u, domain.WrapError(err)
 	}
 
 	return u, nil

--- a/interfaces/services/contest_log_service.go
+++ b/interfaces/services/contest_log_service.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/srvc/fail"
-
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
 )
@@ -32,18 +30,18 @@ type contestLogService struct {
 func (s *contestLogService) Create(ctx Context) error {
 	log := &domain.ContestLog{}
 	if err := ctx.Bind(log); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	user, err := ctx.User()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	log.UserID = user.ID
 
 	if err := s.RankingInteractor.CreateLog(*log); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusCreated)
@@ -52,14 +50,14 @@ func (s *contestLogService) Create(ctx Context) error {
 func (s *contestLogService) Update(ctx Context) error {
 	log := &domain.ContestLog{}
 	if err := ctx.Bind(log); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	ctx.BindID(&log.ID)
 
 	user, err := ctx.User()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	log.UserID = user.ID
@@ -69,7 +67,7 @@ func (s *contestLogService) Update(ctx Context) error {
 			return ctx.NoContent(http.StatusForbidden)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusNoContent)
@@ -81,7 +79,7 @@ func (s *contestLogService) Delete(ctx Context) error {
 
 	user, err := ctx.User()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	if err := s.RankingInteractor.DeleteLog(id, user.ID); err != nil {
@@ -92,7 +90,7 @@ func (s *contestLogService) Delete(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusOK)
@@ -101,12 +99,12 @@ func (s *contestLogService) Delete(ctx Context) error {
 func (s *contestLogService) Get(ctx Context) error {
 	contestID, err := strconv.ParseUint(ctx.QueryParam("contest_id"), 10, 64)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	userID, err := strconv.ParseUint(ctx.QueryParam("user_id"), 10, 64)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	logs, err := s.RankingInteractor.ContestLogs(contestID, userID)
@@ -115,7 +113,7 @@ func (s *contestLogService) Get(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, logs.GetView())

--- a/interfaces/services/contest_service.go
+++ b/interfaces/services/contest_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"net/http"
 
-	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
 )
@@ -30,11 +29,11 @@ type contestService struct {
 func (s *contestService) Create(ctx Context) error {
 	contest := &domain.Contest{}
 	if err := ctx.Bind(contest); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	if err := s.ContestInteractor.CreateContest(*contest); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusCreated)
@@ -43,13 +42,13 @@ func (s *contestService) Create(ctx Context) error {
 func (s *contestService) Update(ctx Context) error {
 	contest := &domain.Contest{}
 	if err := ctx.Bind(contest); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	ctx.BindID(&contest.ID)
 
 	if err := s.ContestInteractor.UpdateContest(*contest); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusNoContent)
@@ -63,7 +62,7 @@ func (s *contestService) Latest(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, contest)
@@ -80,7 +79,7 @@ func (s *contestService) Get(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, contest)

--- a/interfaces/services/ranking_service.go
+++ b/interfaces/services/ranking_service.go
@@ -4,8 +4,6 @@ import (
 	"net/http"
 	"strconv"
 
-	"github.com/srvc/fail"
-
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
 )
@@ -38,16 +36,16 @@ type CreateRankingPayload struct {
 func (s *rankingService) Create(ctx Context) error {
 	payload := &CreateRankingPayload{}
 	if err := ctx.Bind(payload); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	user, err := ctx.User()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	if err := s.RankingInteractor.CreateRanking(payload.ContestID, user.ID, payload.Languages); err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusCreated)
@@ -56,7 +54,7 @@ func (s *rankingService) Create(ctx Context) error {
 func (s *rankingService) Get(ctx Context) error {
 	contestID, err := strconv.ParseUint(ctx.QueryParam("contest_id"), 10, 64)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 	language := domain.LanguageCode(ctx.QueryParam("language"))
 
@@ -66,7 +64,7 @@ func (s *rankingService) Get(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, rankings.GetView())
@@ -75,7 +73,7 @@ func (s *rankingService) Get(ctx Context) error {
 func (s *rankingService) CurrentRegistration(ctx Context) error {
 	user, err := ctx.User()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	registration, err := s.RankingInteractor.CurrentRegistration(user.ID)
@@ -84,7 +82,7 @@ func (s *rankingService) CurrentRegistration(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, registration)
@@ -93,11 +91,11 @@ func (s *rankingService) CurrentRegistration(ctx Context) error {
 func (s *rankingService) RankingsForRegistration(ctx Context) error {
 	contestID, err := strconv.ParseUint(ctx.QueryParam("contest_id"), 10, 64)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 	userID, err := strconv.ParseUint(ctx.QueryParam("user_id"), 10, 64)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	rankings, err := s.RankingInteractor.RankingsForRegistration(contestID, userID)
@@ -106,7 +104,7 @@ func (s *rankingService) RankingsForRegistration(ctx Context) error {
 			return ctx.NoContent(http.StatusNotFound)
 		}
 
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.JSON(http.StatusOK, rankings.GetView())

--- a/interfaces/services/session_service.go
+++ b/interfaces/services/session_service.go
@@ -3,7 +3,6 @@ package services
 import (
 	"net/http"
 
-	"github.com/srvc/fail"
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
 )
@@ -36,13 +35,13 @@ func (s *sessionService) Login(ctx Context) error {
 	b := &SessionLoginBody{}
 	err := ctx.Bind(b)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	user, token, err := s.SessionInteractor.CreateSession(b.Email, b.Password)
 	if err != nil {
 		ctx.NoContent(http.StatusUnauthorized)
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	res := map[string]interface{}{
@@ -57,7 +56,7 @@ func (s *sessionService) Register(ctx Context) error {
 	user := &domain.User{}
 	err := ctx.Bind(user)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	user.Role = domain.RoleUser
@@ -65,7 +64,7 @@ func (s *sessionService) Register(ctx Context) error {
 
 	err = s.SessionInteractor.CreateUser(*user)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return ctx.NoContent(http.StatusCreated)

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -2,7 +2,8 @@ package test
 
 import (
 	"github.com/creasty/configo"
-	"github.com/srvc/fail"
+
+	"github.com/tadoku/api/domain"
 )
 
 // Config contains testing configuration data
@@ -20,5 +21,5 @@ func LoadConfig() (*Config, error) {
 	}
 	err := configo.Load(c, opts)
 
-	return c, fail.Wrap(err)
+	return c, domain.WrapError(err)
 }

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -70,7 +70,7 @@ func (i *contestInteractor) saveContest(contest domain.Contest) error {
 	if contest.Open {
 		ids, err := i.contestRepository.GetOpenContests()
 		if err != nil {
-			return fail.Wrap(err)
+			return domain.WrapError(err)
 		}
 		if len(ids) > 0 {
 			for _, id := range ids {
@@ -82,7 +82,7 @@ func (i *contestInteractor) saveContest(contest domain.Contest) error {
 	}
 
 	err := i.contestRepository.Store(&contest)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (i *contestInteractor) Latest() (*domain.Contest, error) {
@@ -105,7 +105,7 @@ func (i *contestInteractor) Find(contestID uint64) (*domain.Contest, error) {
 			return nil, ErrContestNotFound
 		}
 
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	return &contest, nil

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -92,7 +92,7 @@ func (i *contestInteractor) Latest() (*domain.Contest, error) {
 			return nil, ErrContestNotFound
 		}
 
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	return &contest, nil

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -210,11 +210,7 @@ func (i *rankingInteractor) saveLog(log domain.ContestLog) error {
 func (i *rankingInteractor) DeleteLog(logID uint64, userID uint64) error {
 	log, err := i.contestLogRepository.FindByID(logID)
 	if err != nil {
-		if err == domain.ErrNotFound {
-			return err
-		}
-
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	if log.UserID != userID {

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -4,6 +4,7 @@ package usecases
 
 import (
 	"github.com/srvc/fail"
+
 	"github.com/tadoku/api/domain"
 )
 
@@ -93,7 +94,7 @@ func (i *rankingInteractor) CreateRanking(
 ) error {
 	ids, err := i.contestRepository.GetOpenContests()
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	if !domain.ContainsID(ids, contestID) {
@@ -106,7 +107,7 @@ func (i *rankingInteractor) CreateRanking(
 
 	existingLanguages, err := i.rankingRepository.GetAllLanguagesForContestAndUser(contestID, userID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 	needsGlobal := len(existingLanguages) == 0
 
@@ -133,7 +134,7 @@ func (i *rankingInteractor) CreateRanking(
 
 	for _, lang := range targetLanguages {
 		if _, err := lang.Validate(); err != nil {
-			return fail.Wrap(err)
+			return domain.WrapError(err)
 		}
 
 		ranking := domain.Ranking{
@@ -144,7 +145,7 @@ func (i *rankingInteractor) CreateRanking(
 		}
 		err = i.rankingRepository.Store(ranking)
 		if err != nil {
-			return fail.Wrap(err)
+			return domain.WrapError(err)
 		}
 	}
 
@@ -175,7 +176,7 @@ func (i *rankingInteractor) saveLog(log domain.ContestLog) error {
 	if log.ID != 0 {
 		existingLog, err := i.contestLogRepository.FindByID(log.ID)
 		if err != nil {
-			return fail.Wrap(err)
+			return domain.WrapError(err)
 		}
 
 		if existingLog.UserID != log.UserID {
@@ -185,7 +186,7 @@ func (i *rankingInteractor) saveLog(log domain.ContestLog) error {
 
 	ids, err := i.contestRepository.GetOpenContests()
 	if err != nil {
-		fail.Wrap(err)
+		domain.WrapError(err)
 	}
 	if !domain.ContainsID(ids, log.ContestID) {
 		return ErrContestIsClosed
@@ -193,7 +194,7 @@ func (i *rankingInteractor) saveLog(log domain.ContestLog) error {
 
 	languages, err := i.rankingRepository.GetAllLanguagesForContestAndUser(log.ContestID, log.UserID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 	if !languages.ContainsLanguage(log.Language) {
 		return ErrContestLanguageNotSignedUp
@@ -201,7 +202,7 @@ func (i *rankingInteractor) saveLog(log domain.ContestLog) error {
 
 	err = i.contestLogRepository.Store(&log)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return i.UpdateRanking(log.ContestID, log.UserID)
@@ -219,7 +220,7 @@ func (i *rankingInteractor) DeleteLog(logID uint64, userID uint64) error {
 
 	ids, err := i.contestRepository.GetOpenContests()
 	if err != nil {
-		fail.Wrap(err)
+		domain.WrapError(err)
 	}
 	if !domain.ContainsID(ids, log.ContestID) {
 		return ErrContestIsClosed
@@ -227,7 +228,7 @@ func (i *rankingInteractor) DeleteLog(logID uint64, userID uint64) error {
 
 	err = i.contestLogRepository.Delete(logID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	return i.UpdateRanking(log.ContestID, log.UserID)
@@ -236,7 +237,7 @@ func (i *rankingInteractor) DeleteLog(logID uint64, userID uint64) error {
 func (i *rankingInteractor) UpdateRanking(contestID uint64, userID uint64) error {
 	rankings, err := i.rankingRepository.FindAll(contestID, userID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	if len(rankings) == 0 {
@@ -245,7 +246,7 @@ func (i *rankingInteractor) UpdateRanking(contestID uint64, userID uint64) error
 
 	logs, err := i.contestLogRepository.FindAll(contestID, userID)
 	if err != nil {
-		return fail.Wrap(err)
+		return domain.WrapError(err)
 	}
 
 	totals := make(map[domain.LanguageCode]float32)
@@ -270,7 +271,7 @@ func (i *rankingInteractor) RankingsForRegistration(
 ) (domain.Rankings, error) {
 	rankings, err := i.rankingRepository.FindAll(contestID, userID)
 	if err != nil {
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	if len(rankings) == 0 {
@@ -300,7 +301,7 @@ func (i *rankingInteractor) RankingsForContest(
 	}
 
 	if err != nil {
-		return nil, fail.Wrap(err)
+		return nil, domain.WrapError(err)
 	}
 
 	if len(rankings) == 0 {
@@ -313,7 +314,7 @@ func (i *rankingInteractor) RankingsForContest(
 func (i *rankingInteractor) CurrentRegistration(userID uint64) (domain.RankingRegistration, error) {
 	registration, err := i.rankingRepository.CurrentRegistration(userID)
 	if err != nil {
-		return registration, fail.Wrap(err)
+		return registration, domain.WrapError(err)
 	}
 
 	if registration.ContestID == 0 {
@@ -326,7 +327,7 @@ func (i *rankingInteractor) CurrentRegistration(userID uint64) (domain.RankingRe
 func (i *rankingInteractor) ContestLogs(contestID uint64, userID uint64) (domain.ContestLogs, error) {
 	logs, err := i.contestLogRepository.FindAll(contestID, userID)
 	if err != nil {
-		return logs, fail.Wrap(err)
+		return logs, domain.WrapError(err)
 	}
 
 	if len(logs) == 0 {

--- a/usecases/session_interactor.go
+++ b/usecases/session_interactor.go
@@ -52,32 +52,32 @@ func (si *sessionInteractor) CreateUser(user domain.User) error {
 		var err error
 		user.Password, err = si.passwordHasher.Hash(user.Password)
 		if err != nil {
-			return fail.Wrap(err)
+			return domain.WrapError(err)
 		}
 	}
 
 	err := si.userRepository.Store(&user)
-	return fail.Wrap(err)
+	return domain.WrapError(err)
 }
 
 func (si *sessionInteractor) CreateSession(email, password string) (domain.User, string, error) {
 	user, err := si.userRepository.FindByEmail(email)
 	if err != nil {
-		return domain.User{}, "", fail.Wrap(err)
+		return domain.User{}, "", domain.WrapError(err)
 	}
 
 	if user.ID == 0 {
-		return domain.User{}, "", fail.Wrap(ErrUserDoesNotExist, fail.WithIgnorable())
+		return domain.User{}, "", domain.WrapError(ErrUserDoesNotExist, fail.WithIgnorable())
 	}
 
 	if !si.passwordHasher.Compare(user.Password, password) {
-		return domain.User{}, "", fail.Wrap(ErrPasswordIncorrect, fail.WithIgnorable())
+		return domain.User{}, "", domain.WrapError(ErrPasswordIncorrect, fail.WithIgnorable())
 	}
 
 	claims := SessionClaims{User: &user}
 	token, err := si.jwtGenerator.NewToken(si.sessionLength, claims)
 	if err != nil {
-		return domain.User{}, "", fail.Wrap(err)
+		return domain.User{}, "", domain.WrapError(err)
 	}
 
 	return user, token, nil


### PR DESCRIPTION
## Why

Domain errors like `ErrNotFound` won't be comparable after wrapping them with `fail.Wrap`. This is unfortunate and something that needs special care every time we want to check for a domain error.

## What

Wrap the `fail.Wrap` function in which we ignore domain errors.