### PR TITLE
Restrict contest log changes to those of running contests only

### DIFF
--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -68,7 +68,22 @@ func (r *contestRepository) GetOpenContests() ([]uint64, error) {
 }
 
 func (r *contestRepository) GetRunningContests() ([]uint64, error) {
-	return nil, nil
+	query := `
+		select id
+		from contests
+		where
+			open = true and
+			start <= now() at time zone 'utc' and
+			"end" >= now() at time zone 'utc'
+	`
+
+	var ids []uint64
+	err := r.sqlHandler.Select(&ids, query)
+	if err != nil {
+		return nil, domain.WrapError(err)
+	}
+
+	return ids, nil
 }
 
 func (r *contestRepository) FindLatest() (domain.Contest, error) {

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -67,6 +67,10 @@ func (r *contestRepository) GetOpenContests() ([]uint64, error) {
 	return ids, nil
 }
 
+func (r *contestRepository) GetRunningContests() ([]uint64, error) {
+	return nil, nil
+}
+
 func (r *contestRepository) FindLatest() (domain.Contest, error) {
 	query := `
 		select id, description, start, "end", open

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -61,6 +61,32 @@ func TestContestRepository_GetOpenContests(t *testing.T) {
 	}
 }
 
+func TestContestRepository_GetRunningContests(t *testing.T) {
+	sqlHandler, cleanup := setupTestingSuite(t)
+	defer cleanup()
+
+	repo := repositories.NewContestRepository(sqlHandler)
+
+	{
+		ids, err := repo.GetRunningContests()
+		assert.NoError(t, err)
+		assert.Empty(t, ids, "no running contests should exist")
+
+		for _, contest := range []*domain.Contest{
+			&domain.Contest{Start: time.Now().Add(-1 * time.Hour), End: time.Now().Add(1 * time.Hour), Open: true},
+			&domain.Contest{Start: time.Now().Add(-1 * time.Hour), End: time.Now().Add(1 * time.Hour), Open: false},
+			&domain.Contest{Start: time.Now().Add(-5 * time.Hour), End: time.Now().Add(-1 * time.Hour), Open: false},
+		} {
+			err = repo.Store(contest)
+			assert.NoError(t, err, "saving seed contest should return no error")
+		}
+
+		ids, err = repo.GetOpenContests()
+		assert.Equal(t, 1, len(ids), "only one running contest should exist")
+		assert.NoError(t, err)
+	}
+}
+
 func TestContestRepository_FindLatest(t *testing.T) {
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -184,7 +184,7 @@ func (i *rankingInteractor) saveLog(log domain.ContestLog) error {
 		}
 	}
 
-	ids, err := i.contestRepository.GetOpenContests()
+	ids, err := i.contestRepository.GetRunningContests()
 	if err != nil {
 		domain.WrapError(err)
 	}

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -218,7 +218,7 @@ func (i *rankingInteractor) DeleteLog(logID uint64, userID uint64) error {
 		return domain.ErrInsufficientPermissions
 	}
 
-	ids, err := i.contestRepository.GetOpenContests()
+	ids, err := i.contestRepository.GetRunningContests()
 	if err != nil {
 		domain.WrapError(err)
 	}

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -332,7 +332,7 @@ func TestRankingInteractor_DeleteLog(t *testing.T) {
 
 		contestLogRepo.EXPECT().Delete(log.ID)
 		contestLogRepo.EXPECT().FindByID(log.ID).Return(log, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
 		rankingRepo.EXPECT().FindAll(contestID, userID).Return(rankings, nil)
 		contestLogRepo.EXPECT().FindAll(contestID, userID).Return(domain.ContestLogs{}, nil)
 		rankingRepo.EXPECT().UpdateAmounts(expectedRankings).Return(nil)
@@ -352,7 +352,7 @@ func TestRankingInteractor_DeleteLog(t *testing.T) {
 	// Sad path: contest is cloaed
 	{
 		contestLogRepo.EXPECT().FindByID(log.ID).Return(log, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID + 1}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID + 1}, nil)
 
 		err := interactor.DeleteLog(log.ID, log.UserID)
 		assert.EqualError(t, err, usecases.ErrContestIsClosed.Error())

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -133,7 +133,7 @@ func TestRankingInteractor_CreateLog(t *testing.T) {
 
 		contestLogRepo.EXPECT().Store(&log)
 		validator.EXPECT().Validate(log).Return(true, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
 		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.Japanese}, nil)
 		rankingRepo.EXPECT().FindAll(contestID, userID).Return(rankings, nil)
 		contestLogRepo.EXPECT().FindAll(contestID, userID).Return(domain.ContestLogs{log}, nil)
@@ -185,7 +185,7 @@ func TestRankingInteractor_CreateLog(t *testing.T) {
 		}
 
 		validator.EXPECT().Validate(log).Return(true, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
 
 		err := interactor.CreateLog(log)
 		assert.EqualError(t, err, usecases.ErrContestIsClosed.Error())
@@ -202,7 +202,7 @@ func TestRankingInteractor_CreateLog(t *testing.T) {
 		}
 
 		validator.EXPECT().Validate(log).Return(true, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
 		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.Korean}, nil)
 
 		err := interactor.CreateLog(log)
@@ -220,7 +220,7 @@ func TestRankingInteractor_CreateLog(t *testing.T) {
 		}
 
 		validator.EXPECT().Validate(log).Return(true, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
 		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.Japanese}, nil)
 
 		err := interactor.CreateLog(log)
@@ -258,7 +258,7 @@ func TestRankingInteractor_UpdateLog(t *testing.T) {
 		contestLogRepo.EXPECT().Store(&log)
 		validator.EXPECT().Validate(log).Return(true, nil)
 		contestLogRepo.EXPECT().FindByID(log.ID).Return(log, nil)
-		contestRepo.EXPECT().GetOpenContests().Return([]uint64{contestID}, nil)
+		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
 		rankingRepo.EXPECT().GetAllLanguagesForContestAndUser(contestID, userID).Return(domain.LanguageCodes{domain.Japanese}, nil)
 		rankingRepo.EXPECT().FindAll(contestID, userID).Return(rankings, nil)
 		contestLogRepo.EXPECT().FindAll(contestID, userID).Return(domain.ContestLogs{log}, nil)

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -17,6 +17,7 @@ type UserRepository interface {
 type ContestRepository interface {
 	Store(contest *domain.Contest) error
 	GetOpenContests() ([]uint64, error)
+	GetRunningContests() ([]uint64, error)
 	FindLatest() (domain.Contest, error)
 	FindByID(id uint64) (domain.Contest, error)
 }

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -129,6 +129,21 @@ func (mr *MockContestRepositoryMockRecorder) GetOpenContests() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenContests", reflect.TypeOf((*MockContestRepository)(nil).GetOpenContests))
 }
 
+// GetRunningContests mocks base method
+func (m *MockContestRepository) GetRunningContests() ([]uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRunningContests")
+	ret0, _ := ret[0].([]uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRunningContests indicates an expected call of GetRunningContests
+func (mr *MockContestRepositoryMockRecorder) GetRunningContests() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningContests", reflect.TypeOf((*MockContestRepository)(nil).GetRunningContests))
+}
+
 // FindLatest mocks base method
 func (m *MockContestRepository) FindLatest() (domain.Contest, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why

At present you can still update contest logs when the contest is open, but hasn't started yet.

## What

- [x] Implement a method to get the running contests only
- [x] Change the check from open contests to running contests when checking in create/update/delete contest log