### PR TITLE
Make joining contest more robus

### DIFF
--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -132,19 +132,22 @@ func (i *rankingInteractor) CreateRanking(
 		return ErrNoRankingToCreate
 	}
 
-	for _, lang := range targetLanguages {
+	rankings := make([]domain.Ranking, len(targetLanguages))
+	for i, lang := range targetLanguages {
 		if _, err := lang.Validate(); err != nil {
 			return domain.WrapError(err)
 		}
 
-		ranking := domain.Ranking{
+		rankings[i] = domain.Ranking{
 			ContestID: contestID,
 			UserID:    userID,
 			Language:  lang,
 			Amount:    0,
 		}
-		err = i.rankingRepository.Store(ranking)
-		if err != nil {
+	}
+
+	for _, ranking := range rankings {
+		if err := i.rankingRepository.Store(ranking); err != nil {
 			return domain.WrapError(err)
 		}
 	}


### PR DESCRIPTION
## Why

If validation for a `Ranking` fails while joining a contest, we'd have joined all languages up until now, but do nothing with all the languages after that.

## What

Fail early, before creating the rankings.