### PR TITLE
Add refresh session endpoint

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -140,6 +140,7 @@ func (d *serverDependencies) routes() []services.Route {
 		// Session
 		{Method: http.MethodPost, Path: "/login", HandlerFunc: d.Services().Session.Login},
 		{Method: http.MethodPost, Path: "/register", HandlerFunc: d.Services().Session.Register},
+		{Method: http.MethodPost, Path: "/refresh", HandlerFunc: d.Services().Session.Refresh, MinRole: domain.RoleUser},
 
 		// Users
 		{Method: http.MethodPost, Path: "/users/update_password", HandlerFunc: d.Services().User.UpdatePassword, MinRole: domain.RoleUser},

--- a/interfaces/services/session_service.go
+++ b/interfaces/services/session_service.go
@@ -12,6 +12,7 @@ import (
 type SessionService interface {
 	Login(ctx Context) error
 	Register(ctx Context) error
+	Refresh(ctx Context) error
 }
 
 // NewSessionService initializer
@@ -68,4 +69,24 @@ func (s *sessionService) Register(ctx Context) error {
 	}
 
 	return ctx.NoContent(http.StatusCreated)
+}
+
+func (s *sessionService) Refresh(ctx Context) error {
+	sessionUser, err := ctx.User()
+	if err != nil {
+		return domain.WrapError(err)
+	}
+
+	user, token, err := s.SessionInteractor.RefreshSession(*sessionUser)
+	if err != nil {
+		ctx.NoContent(http.StatusUnauthorized)
+		return domain.WrapError(err)
+	}
+
+	res := map[string]interface{}{
+		"token": token,
+		"user":  user,
+	}
+
+	return ctx.JSON(http.StatusOK, res)
 }

--- a/interfaces/services/session_service_test.go
+++ b/interfaces/services/session_service_test.go
@@ -68,3 +68,31 @@ func TestSessionService_Login(t *testing.T) {
 
 	assert.NoError(t, err)
 }
+
+func TestSessionService_Refresh(t *testing.T) {
+	user := &domain.User{
+		ID:          1,
+		Email:       "foo@bar.com",
+		DisplayName: "John Doe",
+		Role:        domain.RoleUser,
+	}
+	token := "foobar"
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	ctx := services.NewMockContext(ctrl)
+	ctx.EXPECT().JSON(200, map[string]interface{}{
+		"token": token,
+		"user":  *user,
+	})
+	ctx.EXPECT().User().Return(user, nil)
+
+	i := usecases.NewMockSessionInteractor(ctrl)
+	i.EXPECT().RefreshSession(*user).Return(*user, token, nil)
+
+	s := services.NewSessionService(i)
+	err := s.Refresh(ctx)
+
+	assert.NoError(t, err)
+}

--- a/usecases/session_interactor.go
+++ b/usecases/session_interactor.go
@@ -19,6 +19,7 @@ var ErrUserDoesNotExist = fail.New("user does not exist")
 type SessionInteractor interface {
 	CreateUser(user domain.User) error
 	CreateSession(email, password string) (user domain.User, token string, err error)
+	RefreshSession(user domain.User) error
 }
 
 // NewSessionInteractor instantiates SessionInteractor with all dependencies
@@ -81,4 +82,8 @@ func (si *sessionInteractor) CreateSession(email, password string) (domain.User,
 	}
 
 	return user, token, nil
+}
+
+func (si *SessionInteractor) RefreshSession(user domain.User) error {
+	return nil
 }

--- a/usecases/session_interactor.go
+++ b/usecases/session_interactor.go
@@ -19,7 +19,7 @@ var ErrUserDoesNotExist = fail.New("user does not exist")
 type SessionInteractor interface {
 	CreateUser(user domain.User) error
 	CreateSession(email, password string) (user domain.User, token string, err error)
-	RefreshSession(user domain.User) error
+	RefreshSession(user domain.User) (latestUser domain.User, token string, err error)
 }
 
 // NewSessionInteractor instantiates SessionInteractor with all dependencies
@@ -84,6 +84,6 @@ func (si *sessionInteractor) CreateSession(email, password string) (domain.User,
 	return user, token, nil
 }
 
-func (si *SessionInteractor) RefreshSession(user domain.User) error {
-	return nil
+func (si *SessionInteractor) RefreshSession(user domain.User) (domain.User, string, error) {
+	return domain.User{}, "", nil
 }

--- a/usecases/session_interactor_mock.go
+++ b/usecases/session_interactor_mock.go
@@ -62,3 +62,17 @@ func (mr *MockSessionInteractorMockRecorder) CreateSession(email, password inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateSession", reflect.TypeOf((*MockSessionInteractor)(nil).CreateSession), email, password)
 }
+
+// RefreshSession mocks base method
+func (m *MockSessionInteractor) RefreshSession(user domain.User) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RefreshSession", user)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RefreshSession indicates an expected call of RefreshSession
+func (mr *MockSessionInteractorMockRecorder) RefreshSession(user interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RefreshSession", reflect.TypeOf((*MockSessionInteractor)(nil).RefreshSession), user)
+}

--- a/usecases/session_interactor_mock.go
+++ b/usecases/session_interactor_mock.go
@@ -64,11 +64,13 @@ func (mr *MockSessionInteractorMockRecorder) CreateSession(email, password inter
 }
 
 // RefreshSession mocks base method
-func (m *MockSessionInteractor) RefreshSession(user domain.User) error {
+func (m *MockSessionInteractor) RefreshSession(user domain.User) (domain.User, string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "RefreshSession", user)
-	ret0, _ := ret[0].(error)
-	return ret0
+	ret0, _ := ret[0].(domain.User)
+	ret1, _ := ret[1].(string)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // RefreshSession indicates an expected call of RefreshSession


### PR DESCRIPTION
## Why

So we can get an up-to-date token for the user. E.G: updating the display name