### PR TITLE
Refactor `/contest/latest` into a list of all contests

### DIFF
--- a/app/server.go
+++ b/app/server.go
@@ -155,7 +155,7 @@ func (d *serverDependencies) routes() []services.Route {
 		{Method: http.MethodPost, Path: "/users/profile", HandlerFunc: d.Services().User.UpdateProfile, MinRole: domain.RoleUser},
 
 		// Contests
-		{Method: http.MethodGet, Path: "/contests/latest", HandlerFunc: d.Services().Contest.Latest},
+		{Method: http.MethodGet, Path: "/contests", HandlerFunc: d.Services().Contest.All},
 		{Method: http.MethodGet, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Get},
 		{Method: http.MethodPost, Path: "/contests", HandlerFunc: d.Services().Contest.Create, MinRole: domain.RoleAdmin},
 		{Method: http.MethodPut, Path: "/contests/:id", HandlerFunc: d.Services().Contest.Update, MinRole: domain.RoleAdmin},
@@ -164,10 +164,12 @@ func (d *serverDependencies) routes() []services.Route {
 		{Method: http.MethodGet, Path: "/rankings/current", HandlerFunc: d.Services().Ranking.CurrentRegistration, MinRole: domain.RoleUser},
 		{Method: http.MethodGet, Path: "/rankings/registration", HandlerFunc: d.Services().Ranking.RankingsForRegistration},
 		{Method: http.MethodPost, Path: "/rankings", HandlerFunc: d.Services().Ranking.Create, MinRole: domain.RoleUser},
+		// TODO: Rename Get to All
 		{Method: http.MethodGet, Path: "/rankings", HandlerFunc: d.Services().Ranking.Get},
 
 		// Contest logs
 		{Method: http.MethodPost, Path: "/contest_logs", HandlerFunc: d.Services().ContestLog.Create, MinRole: domain.RoleUser},
+		// TODO: Rename Get to All
 		{Method: http.MethodGet, Path: "/contest_logs", HandlerFunc: d.Services().ContestLog.Get},
 		{Method: http.MethodPut, Path: "/contest_logs/:id", HandlerFunc: d.Services().ContestLog.Update, MinRole: domain.RoleUser},
 		{Method: http.MethodDelete, Path: "/contest_logs/:id", HandlerFunc: d.Services().ContestLog.Delete, MinRole: domain.RoleUser},

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/tadoku/api
 
+go 1.14
+
 require (
 	github.com/DATA-DOG/go-txdb v0.1.3
 	github.com/DavidHuie/gomigrate v0.0.0-20160809001028-4004e6142040

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -103,6 +103,23 @@ func (r *contestRepository) FindLatest() (domain.Contest, error) {
 	return contest, nil
 }
 
+func (r *contestRepository) FindRecent(count int) ([]domain.Contest, error) {
+	query := `
+		select id, description, start, "end", open
+		from contests
+		order by id desc
+		limit $1
+	`
+
+	var contests []domain.Contest
+	err := r.sqlHandler.Select(&contests, query, count)
+	if err != nil {
+		return contests, domain.WrapError(err)
+	}
+
+	return contests, nil
+}
+
 func (r *contestRepository) FindByID(id uint64) (domain.Contest, error) {
 	query := `
 		select id, description, start, "end", open

--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -86,21 +86,24 @@ func (r *contestRepository) GetRunningContests() ([]uint64, error) {
 	return ids, nil
 }
 
-func (r *contestRepository) FindLatest() (domain.Contest, error) {
+func (r *contestRepository) FindAll() ([]domain.Contest, error) {
 	query := `
 		select id, description, start, "end", open
 		from contests
 		order by id desc
-		limit 1
 	`
 
-	var contest domain.Contest
-	err := r.sqlHandler.Get(&contest, query)
+	var contests []domain.Contest
+	err := r.sqlHandler.Select(&contests, query)
 	if err != nil {
-		return contest, domain.WrapError(err)
+		return contests, domain.WrapError(err)
 	}
 
-	return contest, nil
+	if len(contests) == 0 {
+		return nil, domain.ErrNotFound
+	}
+
+	return contests, nil
 }
 
 func (r *contestRepository) FindRecent(count int) ([]domain.Contest, error) {

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -87,14 +87,14 @@ func TestContestRepository_GetRunningContests(t *testing.T) {
 	}
 }
 
-func TestContestRepository_FindLatest(t *testing.T) {
+func TestContestRepository_FindAll(t *testing.T) {
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()
 
 	repo := repositories.NewContestRepository(sqlHandler)
 
 	{
-		contest, err := repo.FindLatest()
+		contest, err := repo.FindAll()
 		assert.EqualError(t, err, domain.ErrNotFound.Error())
 		assert.Empty(t, contest, "no contests should be found")
 	}
@@ -104,9 +104,9 @@ func TestContestRepository_FindLatest(t *testing.T) {
 		err := repo.Store(&expected)
 		assert.NoError(t, err)
 
-		contest, err := repo.FindLatest()
-		assert.Equal(t, expected.Description, contest.Description, "contest should have the same description")
-		assert.Equal(t, expected.Open, contest.Open, "contest should both be open")
+		contest, err := repo.FindAll()
+		assert.Equal(t, expected.Description, contest[0].Description, "contest should have the same description")
+		assert.Equal(t, expected.Open, contest[0].Open, "contest should both be open")
 		assert.NoError(t, err)
 	}
 
@@ -115,9 +115,9 @@ func TestContestRepository_FindLatest(t *testing.T) {
 		err := repo.Store(&expected)
 		assert.NoError(t, err)
 
-		contest, err := repo.FindLatest()
-		assert.Equal(t, expected.Description, contest.Description, "contest should have the same description")
-		assert.Equal(t, expected.Open, contest.Open, "contest should both be open")
+		contest, err := repo.FindAll()
+		assert.Equal(t, expected.Description, contest[0].Description, "contest should have the same description")
+		assert.Equal(t, expected.Open, contest[0].Open, "contest should both be open")
 		assert.NoError(t, err)
 	}
 }

--- a/interfaces/repositories/contest_repository_test.go
+++ b/interfaces/repositories/contest_repository_test.go
@@ -122,6 +122,30 @@ func TestContestRepository_FindLatest(t *testing.T) {
 	}
 }
 
+func TestContestRepository_FindRecent(t *testing.T) {
+	sqlHandler, cleanup := setupTestingSuite(t)
+	defer cleanup()
+
+	repo := repositories.NewContestRepository(sqlHandler)
+
+	{
+		contests := []domain.Contest{
+			{Description: "Foo 2017", Start: time.Date(2017, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2020, 1, 30, 0, 0, 0, 0, time.UTC), Open: false},
+			{Description: "Foo 2018", Start: time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2020, 1, 30, 0, 0, 0, 0, time.UTC), Open: false},
+			{Description: "Foo 2019", Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC), End: time.Date(2020, 1, 30, 0, 0, 0, 0, time.UTC), Open: false},
+		}
+		for _, contest := range contests {
+			err := repo.Store(&contest)
+			assert.NoError(t, err)
+		}
+
+		expected := contests[1:]
+		result, err := repo.FindRecent(2)
+		assert.Equal(t, len(expected), len(result))
+		assert.NoError(t, err)
+	}
+}
+
 func TestContestRepository_FindByID(t *testing.T) {
 	sqlHandler, cleanup := setupTestingSuite(t)
 	defer cleanup()

--- a/interfaces/services/contest_service.go
+++ b/interfaces/services/contest_service.go
@@ -12,6 +12,7 @@ type ContestService interface {
 	Create(ctx Context) error
 	Update(ctx Context) error
 	Latest(ctx Context) error
+	Recent(ctx Context) error
 	Get(ctx Context) error
 }
 
@@ -66,6 +67,20 @@ func (s *contestService) Latest(ctx Context) error {
 	}
 
 	return ctx.JSON(http.StatusOK, contest)
+}
+
+func (s *contestService) Recent(ctx Context) error {
+	contests, err := s.ContestInteractor.Recent(5)
+
+	if err != nil {
+		if err == usecases.ErrContestNotFound {
+			return ctx.NoContent(http.StatusNotFound)
+		}
+
+		return domain.WrapError(err)
+	}
+
+	return ctx.JSON(http.StatusOK, contests)
 }
 
 func (s *contestService) Get(ctx Context) error {

--- a/interfaces/services/contest_service.go
+++ b/interfaces/services/contest_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"net/http"
+	"strconv"
 
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/usecases"
@@ -11,8 +12,7 @@ import (
 type ContestService interface {
 	Create(ctx Context) error
 	Update(ctx Context) error
-	Latest(ctx Context) error
-	Recent(ctx Context) error
+	All(ctx Context) error
 	Get(ctx Context) error
 }
 
@@ -55,22 +55,12 @@ func (s *contestService) Update(ctx Context) error {
 	return ctx.NoContent(http.StatusNoContent)
 }
 
-func (s *contestService) Latest(ctx Context) error {
-	contest, err := s.ContestInteractor.Latest()
-
+func (s *contestService) All(ctx Context) error {
+	limit, err := strconv.ParseInt(ctx.QueryParam("limit"), 10, 64)
 	if err != nil {
-		if err == usecases.ErrContestNotFound {
-			return ctx.NoContent(http.StatusNotFound)
-		}
-
-		return domain.WrapError(err)
+		limit = 0
 	}
-
-	return ctx.JSON(http.StatusOK, contest)
-}
-
-func (s *contestService) Recent(ctx Context) error {
-	contests, err := s.ContestInteractor.Recent(5)
+	contests, err := s.ContestInteractor.Recent(int(limit))
 
 	if err != nil {
 		if err == usecases.ErrContestNotFound {

--- a/interfaces/services/contest_service_test.go
+++ b/interfaces/services/contest_service_test.go
@@ -98,6 +98,52 @@ func TestContestService_Latest(t *testing.T) {
 	}
 }
 
+func TestContestService_Recent(t *testing.T) {
+	contests := []domain.Contest{
+		{
+			ID:    1,
+			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
+			Open:  false,
+		},
+		{
+			ID:    2,
+			Start: time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+			End:   time.Date(2020, 1, 31, 0, 0, 0, 0, time.UTC),
+			Open:  true,
+		},
+	}
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	{
+		ctx := services.NewMockContext(ctrl)
+		ctx.EXPECT().JSON(200, contests)
+
+		i := usecases.NewMockContestInteractor(ctrl)
+		i.EXPECT().Recent(5).Return(contests, nil)
+
+		s := services.NewContestService(i)
+		err := s.Recent(ctx)
+
+		assert.NoError(t, err)
+	}
+
+	{
+		ctx := services.NewMockContext(ctrl)
+		ctx.EXPECT().NoContent(404)
+
+		i := usecases.NewMockContestInteractor(ctrl)
+		i.EXPECT().Recent(5).Return(nil, usecases.ErrContestNotFound)
+
+		s := services.NewContestService(i)
+		err := s.Recent(ctx)
+
+		assert.NoError(t, err)
+	}
+}
+
 func TestContestService_Get(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -27,6 +27,7 @@ type ContestInteractor interface {
 	CreateContest(contest domain.Contest) error
 	UpdateContest(contest domain.Contest) error
 	Latest() (*domain.Contest, error)
+	Recent(count int) ([]domain.Contest, error)
 	Find(contestID uint64) (*domain.Contest, error)
 }
 
@@ -96,6 +97,19 @@ func (i *contestInteractor) Latest() (*domain.Contest, error) {
 	}
 
 	return &contest, nil
+}
+
+func (i *contestInteractor) Recent(count int) ([]domain.Contest, error) {
+	contest, err := i.contestRepository.FindRecent(count)
+	if err != nil {
+		if err == domain.ErrNotFound {
+			return nil, ErrContestNotFound
+		}
+
+		return nil, domain.WrapError(err)
+	}
+
+	return contest, nil
 }
 
 func (i *contestInteractor) Find(contestID uint64) (*domain.Contest, error) {

--- a/usecases/contest_interactor.go
+++ b/usecases/contest_interactor.go
@@ -19,14 +19,13 @@ var ErrContestIDMissing = fail.New("a contest id is required when updating")
 // ErrCreateContestHasID for when you try to create a contest with a given id
 var ErrCreateContestHasID = fail.New("a contest can't have an id when being created")
 
-// ErrContestNotFound for when no contest could be found, e.g no contets has ever be ran
+// ErrContestNotFound for when no contest could be found, e.g no contest has ever be ran
 var ErrContestNotFound = fail.New("no contest could be found")
 
 // ContestInteractor contains all business logic for contests
 type ContestInteractor interface {
 	CreateContest(contest domain.Contest) error
 	UpdateContest(contest domain.Contest) error
-	Latest() (*domain.Contest, error)
 	Recent(count int) ([]domain.Contest, error)
 	Find(contestID uint64) (*domain.Contest, error)
 }
@@ -86,21 +85,16 @@ func (i *contestInteractor) saveContest(contest domain.Contest) error {
 	return domain.WrapError(err)
 }
 
-func (i *contestInteractor) Latest() (*domain.Contest, error) {
-	contest, err := i.contestRepository.FindLatest()
-	if err != nil {
-		if err == domain.ErrNotFound {
-			return nil, ErrContestNotFound
-		}
-
-		return nil, domain.WrapError(err)
-	}
-
-	return &contest, nil
-}
-
 func (i *contestInteractor) Recent(count int) ([]domain.Contest, error) {
-	contest, err := i.contestRepository.FindRecent(count)
+	var contests []domain.Contest
+	var err error
+
+	if count == 0 {
+		contests, err = i.contestRepository.FindAll()
+	} else {
+		contests, err = i.contestRepository.FindRecent(count)
+	}
+
 	if err != nil {
 		if err == domain.ErrNotFound {
 			return nil, ErrContestNotFound
@@ -109,7 +103,7 @@ func (i *contestInteractor) Recent(count int) ([]domain.Contest, error) {
 		return nil, domain.WrapError(err)
 	}
 
-	return contest, nil
+	return contests, nil
 }
 
 func (i *contestInteractor) Find(contestID uint64) (*domain.Contest, error) {

--- a/usecases/contest_interactor_mock.go
+++ b/usecases/contest_interactor_mock.go
@@ -61,21 +61,6 @@ func (mr *MockContestInteractorMockRecorder) UpdateContest(contest interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateContest", reflect.TypeOf((*MockContestInteractor)(nil).UpdateContest), contest)
 }
 
-// Latest mocks base method
-func (m *MockContestInteractor) Latest() (*domain.Contest, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Latest")
-	ret0, _ := ret[0].(*domain.Contest)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Latest indicates an expected call of Latest
-func (mr *MockContestInteractorMockRecorder) Latest() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Latest", reflect.TypeOf((*MockContestInteractor)(nil).Latest))
-}
-
 // Recent mocks base method
 func (m *MockContestInteractor) Recent(count int) ([]domain.Contest, error) {
 	m.ctrl.T.Helper()

--- a/usecases/contest_interactor_mock.go
+++ b/usecases/contest_interactor_mock.go
@@ -76,6 +76,21 @@ func (mr *MockContestInteractorMockRecorder) Latest() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Latest", reflect.TypeOf((*MockContestInteractor)(nil).Latest))
 }
 
+// Recent mocks base method
+func (m *MockContestInteractor) Recent(count int) ([]domain.Contest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Recent", count)
+	ret0, _ := ret[0].([]domain.Contest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Recent indicates an expected call of Recent
+func (mr *MockContestInteractorMockRecorder) Recent(count interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Recent", reflect.TypeOf((*MockContestInteractor)(nil).Recent), count)
+}
+
 // Find mocks base method
 func (m *MockContestInteractor) Find(contestID uint64) (*domain.Contest, error) {
 	m.ctrl.T.Helper()

--- a/usecases/contest_interactor_test.go
+++ b/usecases/contest_interactor_test.go
@@ -109,35 +109,6 @@ func TestContestInteractor_UpdateContest(t *testing.T) {
 	}
 }
 
-func TestContestInteractor_Latest(t *testing.T) {
-	ctrl, repo, _, interactor := setupContestTest(t)
-	defer ctrl.Finish()
-
-	// Happy path
-	{
-		contest := domain.Contest{
-			ID:    1,
-			Start: time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
-			End:   time.Date(2019, 1, 31, 0, 0, 0, 0, time.UTC),
-			Open:  false,
-		}
-
-		repo.EXPECT().FindLatest().Return(contest, nil)
-
-		found, err := interactor.Latest()
-		assert.NoError(t, err)
-		assert.Equal(t, &contest, found)
-	}
-
-	// Sad path: none found
-	{
-		repo.EXPECT().FindLatest().Return(domain.Contest{}, domain.ErrNotFound)
-
-		_, err := interactor.Latest()
-		assert.EqualError(t, err, usecases.ErrContestNotFound.Error())
-	}
-}
-
 func TestContestInteractor_Recent(t *testing.T) {
 	ctrl, repo, _, interactor := setupContestTest(t)
 	defer ctrl.Finish()

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -19,7 +19,7 @@ type ContestRepository interface {
 	Store(contest *domain.Contest) error
 	GetOpenContests() ([]uint64, error)
 	GetRunningContests() ([]uint64, error)
-	FindLatest() (domain.Contest, error)
+	FindAll() ([]domain.Contest, error)
 	FindRecent(count int) ([]domain.Contest, error)
 	FindByID(id uint64) (domain.Contest, error)
 }

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -20,6 +20,7 @@ type ContestRepository interface {
 	GetOpenContests() ([]uint64, error)
 	GetRunningContests() ([]uint64, error)
 	FindLatest() (domain.Contest, error)
+	FindRecent(count int) ([]domain.Contest, error)
 	FindByID(id uint64) (domain.Contest, error)
 }
 

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -158,19 +158,19 @@ func (mr *MockContestRepositoryMockRecorder) GetRunningContests() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRunningContests", reflect.TypeOf((*MockContestRepository)(nil).GetRunningContests))
 }
 
-// FindLatest mocks base method
-func (m *MockContestRepository) FindLatest() (domain.Contest, error) {
+// FindAll mocks base method
+func (m *MockContestRepository) FindAll() ([]domain.Contest, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindLatest")
-	ret0, _ := ret[0].(domain.Contest)
+	ret := m.ctrl.Call(m, "FindAll")
+	ret0, _ := ret[0].([]domain.Contest)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// FindLatest indicates an expected call of FindLatest
-func (mr *MockContestRepositoryMockRecorder) FindLatest() *gomock.Call {
+// FindAll indicates an expected call of FindAll
+func (mr *MockContestRepositoryMockRecorder) FindAll() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLatest", reflect.TypeOf((*MockContestRepository)(nil).FindLatest))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindAll", reflect.TypeOf((*MockContestRepository)(nil).FindAll))
 }
 
 // FindRecent mocks base method

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -173,6 +173,21 @@ func (mr *MockContestRepositoryMockRecorder) FindLatest() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindLatest", reflect.TypeOf((*MockContestRepository)(nil).FindLatest))
 }
 
+// FindRecent mocks base method
+func (m *MockContestRepository) FindRecent(count int) ([]domain.Contest, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindRecent", count)
+	ret0, _ := ret[0].([]domain.Contest)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindRecent indicates an expected call of FindRecent
+func (mr *MockContestRepositoryMockRecorder) FindRecent(count interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRecent", reflect.TypeOf((*MockContestRepository)(nil).FindRecent), count)
+}
+
 // FindByID mocks base method
 func (m *MockContestRepository) FindByID(id uint64) (domain.Contest, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Why

We need to be able to list up all contests.

## What

We don't need to implement a special `/latest` endpoint if we can list up all contests and limit the results