### PR TITLE
Changed error message in prepare_test.go and updated readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Install [`direnv`](https://direnv.net/)
 - Copy over the default environment: `$ cp .env{.sample,}`
 - Go over the file and make sure the environment variables are correct for your env (eg. database url)
+- Make sure to generate a JWT Secret (instructions are inside .env)
 - Allow direnv `$ direnv allow`
 
 ## Commands
@@ -19,6 +20,11 @@
 
 ```sh
 $ make all
+```
+
+### Run project without tests
+```sh
+$ make run
 ```
 
 ### Lint project

--- a/interfaces/repositories/prepare_test.go
+++ b/interfaces/repositories/prepare_test.go
@@ -51,7 +51,7 @@ func TestMain(m *testing.M) {
 func loadConfig() *test.Config {
 	c, err := test.LoadConfig()
 	if err != nil {
-		panic("could not load config")
+		panic(fmt.Sprintf("could not load config: %s", err))
 	}
 
 	return c


### PR DESCRIPTION
## Why

Because I had a hard time installing.

## What

This might be a little redundant because I should have known better when installing, but I think a reminder to change JWT Secret in env and listing the `make run` command might be good. Also, thanks to Anton's help better error reporting for migrations.