### PR TITLE
add reviewdog actions for golang

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -1,0 +1,22 @@
+name: reviewdog
+on: [pull_request]
+jobs:
+  golangci-lint:
+    name: runner / golangci-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-golangci-lint@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          level: 'warning'
+          reporter: github-pr-check
+  staticcheck:
+    name: runner / staticcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: reviewdog/action-staticcheck@v1
+        with:
+          github_token: ${{ secrets.github_token }}
+          reporter: github-pr-check


### PR DESCRIPTION
This adds some actions for the following with results to indicate that they work. It does look like its ran as part of CI, but might be nicer to have it use the GitHub PR Checks API instead.

golangci-lint: https://github.com/oohnoitz/api/runs/1198820808?check_suite_focus=true
staticcheck: https://github.com/oohnoitz/api/runs/1198824299?check_suite_focus=true