### PR TITLE
Expose recent updates of a contest

### DIFF
--- a/infra/context.go
+++ b/infra/context.go
@@ -55,3 +55,22 @@ func (c context) BindID(id *uint64) error {
 
 	return domain.WrapError(err)
 }
+
+func (c context) IntQueryParam(name string) (uint64, error) {
+	param := c.QueryParam(name)
+	result, err := strconv.ParseUint(param, 10, 64)
+	if err != nil {
+		return 0, domain.WrapError(err)
+	}
+
+	return result, nil
+}
+
+func (c context) OptionalIntQueryParam(name string, defaultValue uint64) uint64 {
+	result, err := c.IntQueryParam(name)
+	if err != nil {
+		return defaultValue
+	}
+
+	return result
+}

--- a/interfaces/repositories/contest_log_repository.go
+++ b/interfaces/repositories/contest_log_repository.go
@@ -128,3 +128,25 @@ func (r *contestLogRepository) Delete(id uint64) error {
 
 	return nil
 }
+
+func (r *contestLogRepository) FindRecent(contestID uint64) (domain.ContestLogs, error) {
+	var logs []domain.ContestLog
+
+	query := `
+		select
+			id, contest_id, user_id, language_code, medium_id, amount, description, created_at, updated_at
+		from contest_logs
+		where
+			contest_id = $1 and
+			deleted_at is null
+		order by created_at desc, id desc
+		limit 25
+	`
+
+	err := r.sqlHandler.Select(&logs, query, contestID)
+	if err != nil {
+		return nil, domain.WrapError(err)
+	}
+
+	return logs, nil
+}

--- a/interfaces/repositories/contest_log_repository.go
+++ b/interfaces/repositories/contest_log_repository.go
@@ -129,7 +129,7 @@ func (r *contestLogRepository) Delete(id uint64) error {
 	return nil
 }
 
-func (r *contestLogRepository) FindRecent(contestID uint64) (domain.ContestLogs, error) {
+func (r *contestLogRepository) FindRecent(contestID, limit uint64) (domain.ContestLogs, error) {
 	var logs []domain.ContestLog
 
 	query := `
@@ -140,10 +140,10 @@ func (r *contestLogRepository) FindRecent(contestID uint64) (domain.ContestLogs,
 			contest_id = $1 and
 			deleted_at is null
 		order by created_at desc, id desc
-		limit 25
+		limit $2
 	`
 
-	err := r.sqlHandler.Select(&logs, query, contestID)
+	err := r.sqlHandler.Select(&logs, query, contestID, limit)
 	if err != nil {
 		return nil, domain.WrapError(err)
 	}

--- a/interfaces/repositories/contest_log_repository_test.go
+++ b/interfaces/repositories/contest_log_repository_test.go
@@ -178,16 +178,27 @@ func TestContestLogRepository_FindRecent(t *testing.T) {
 		}
 	}
 
-	logs, err := repo.FindRecent(contestID)
-	assert.NoError(t, err)
+	// Test when there are too few logs
+	{
+		logs, err := repo.FindRecent(contestID, 25)
+		assert.NoError(t, err)
 
-	count := len(expected)
-	for i, expected := range expected {
-		log := logs[count-i-1]
+		count := len(expected)
+		for i, expected := range expected {
+			log := logs[count-i-1]
 
-		assert.Equal(t, expected.amount, log.Amount)
-		assert.Equal(t, expected.medium, log.MediumID)
-		assert.Equal(t, expected.description, log.Description)
-		assert.Equal(t, contestID, log.ContestID)
+			assert.Equal(t, expected.amount, log.Amount)
+			assert.Equal(t, expected.medium, log.MediumID)
+			assert.Equal(t, expected.description, log.Description)
+			assert.Equal(t, contestID, log.ContestID)
+		}
+	}
+
+	// Test when there are too many logs
+	{
+		logs, err := repo.FindRecent(contestID, 2)
+		assert.NoError(t, err)
+		assert.Equal(t, 2, len(logs))
+		assert.Equal(t, expected[len(expected)-1].description, logs[0].Description)
 	}
 }

--- a/interfaces/services/context.go
+++ b/interfaces/services/context.go
@@ -16,6 +16,12 @@ type Context interface {
 	// QueryParam returns the query param for the provided name.
 	QueryParam(name string) string
 
+	// IntQueryParam returns the query param for the provided name, converted to int
+	IntQueryParam(name string) (uint64, error)
+
+	// OptionalIntQueryParam returns the query param for the provided name, converted to int with a fallback
+	OptionalIntQueryParam(name string, defaultValue uint64) (result uint64)
+
 	// Get retrieves data from the context.
 	Get(key string) interface{}
 

--- a/interfaces/services/context_mock.go
+++ b/interfaces/services/context_mock.go
@@ -49,6 +49,35 @@ func (mr *MockContextMockRecorder) QueryParam(name interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryParam", reflect.TypeOf((*MockContext)(nil).QueryParam), name)
 }
 
+// IntQueryParam mocks base method
+func (m *MockContext) IntQueryParam(name string) (uint64, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "IntQueryParam", name)
+	ret0, _ := ret[0].(uint64)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// IntQueryParam indicates an expected call of IntQueryParam
+func (mr *MockContextMockRecorder) IntQueryParam(name interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IntQueryParam", reflect.TypeOf((*MockContext)(nil).IntQueryParam), name)
+}
+
+// OptionalIntQueryParam mocks base method
+func (m *MockContext) OptionalIntQueryParam(name string, defaultValue uint64) uint64 {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "OptionalIntQueryParam", name, defaultValue)
+	ret0, _ := ret[0].(uint64)
+	return ret0
+}
+
+// OptionalIntQueryParam indicates an expected call of OptionalIntQueryParam
+func (mr *MockContextMockRecorder) OptionalIntQueryParam(name, defaultValue interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OptionalIntQueryParam", reflect.TypeOf((*MockContext)(nil).OptionalIntQueryParam), name, defaultValue)
+}
+
 // Get mocks base method
 func (m *MockContext) Get(key string) interface{} {
 	m.ctrl.T.Helper()

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -60,6 +60,7 @@ type RankingInteractor interface {
 	RankingsForContest(contestID uint64, languageCode domain.LanguageCode) (domain.Rankings, error)
 	CurrentRegistration(userID uint64) (domain.RankingRegistration, error)
 	ContestLogs(contestID uint64, userID uint64) (domain.ContestLogs, error)
+	RecentContestLogs(contestID uint64, limit uint64) (domain.ContestLogs, error)
 }
 
 // NewRankingInteractor instantiates RankingInteractor with all dependencies
@@ -329,6 +330,19 @@ func (i *rankingInteractor) CurrentRegistration(userID uint64) (domain.RankingRe
 
 func (i *rankingInteractor) ContestLogs(contestID uint64, userID uint64) (domain.ContestLogs, error) {
 	logs, err := i.contestLogRepository.FindAll(contestID, userID)
+	if err != nil {
+		return logs, domain.WrapError(err)
+	}
+
+	if len(logs) == 0 {
+		return logs, ErrNoContestLogsFound
+	}
+
+	return logs, nil
+}
+
+func (i *rankingInteractor) RecentContestLogs(contestID, limit uint64) (domain.ContestLogs, error) {
+	logs, err := i.contestLogRepository.FindRecent(contestID, limit)
 	if err != nil {
 		return logs, domain.WrapError(err)
 	}

--- a/usecases/ranking_interactor_mock.go
+++ b/usecases/ranking_interactor_mock.go
@@ -162,3 +162,18 @@ func (mr *MockRankingInteractorMockRecorder) ContestLogs(contestID, userID inter
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContestLogs", reflect.TypeOf((*MockRankingInteractor)(nil).ContestLogs), contestID, userID)
 }
+
+// RecentContestLogs mocks base method
+func (m *MockRankingInteractor) RecentContestLogs(contestID, limit uint64) (domain.ContestLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RecentContestLogs", contestID, limit)
+	ret0, _ := ret[0].(domain.ContestLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RecentContestLogs indicates an expected call of RecentContestLogs
+func (mr *MockRankingInteractorMockRecorder) RecentContestLogs(contestID, limit interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RecentContestLogs", reflect.TypeOf((*MockRankingInteractor)(nil).RecentContestLogs), contestID, limit)
+}

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -30,7 +30,7 @@ type ContestLogRepository interface {
 	FindAll(contestID uint64, userID uint64) (domain.ContestLogs, error)
 	FindByID(id uint64) (domain.ContestLog, error)
 	Delete(id uint64) error
-	FindRecent(contestID uint64) (domain.ContestLogs, error)
+	FindRecent(contestID uint64, limit uint64) (domain.ContestLogs, error)
 }
 
 // RankingRepository handles Ranking related database interactions

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -30,6 +30,7 @@ type ContestLogRepository interface {
 	FindAll(contestID uint64, userID uint64) (domain.ContestLogs, error)
 	FindByID(id uint64) (domain.ContestLog, error)
 	Delete(id uint64) error
+	FindRecent(contestID uint64) (domain.ContestLogs, error)
 }
 
 // RankingRepository handles Ranking related database interactions

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -285,18 +285,18 @@ func (mr *MockContestLogRepositoryMockRecorder) Delete(id interface{}) *gomock.C
 }
 
 // FindRecent mocks base method
-func (m *MockContestLogRepository) FindRecent(contestID uint64) (domain.ContestLogs, error) {
+func (m *MockContestLogRepository) FindRecent(contestID, limit uint64) (domain.ContestLogs, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "FindRecent", contestID)
+	ret := m.ctrl.Call(m, "FindRecent", contestID, limit)
 	ret0, _ := ret[0].(domain.ContestLogs)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // FindRecent indicates an expected call of FindRecent
-func (mr *MockContestLogRepositoryMockRecorder) FindRecent(contestID interface{}) *gomock.Call {
+func (mr *MockContestLogRepositoryMockRecorder) FindRecent(contestID, limit interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRecent", reflect.TypeOf((*MockContestLogRepository)(nil).FindRecent), contestID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRecent", reflect.TypeOf((*MockContestLogRepository)(nil).FindRecent), contestID, limit)
 }
 
 // MockRankingRepository is a mock of RankingRepository interface

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -284,6 +284,21 @@ func (mr *MockContestLogRepositoryMockRecorder) Delete(id interface{}) *gomock.C
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockContestLogRepository)(nil).Delete), id)
 }
 
+// FindRecent mocks base method
+func (m *MockContestLogRepository) FindRecent(contestID uint64) (domain.ContestLogs, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindRecent", contestID)
+	ret0, _ := ret[0].(domain.ContestLogs)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// FindRecent indicates an expected call of FindRecent
+func (mr *MockContestLogRepositoryMockRecorder) FindRecent(contestID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindRecent", reflect.TypeOf((*MockContestLogRepository)(nil).FindRecent), contestID)
+}
+
 // MockRankingRepository is a mock of RankingRepository interface
 type MockRankingRepository struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
## What

- Makes the user parameter on `GET /contest_logs` optional
- Add limit parameter when used without user param