### PR TITLE
Fix incorrect current registration when multiple contests are open

### DIFF
--- a/infra/router.go
+++ b/infra/router.go
@@ -97,6 +97,11 @@ func errorHandler(errorReporter usecases.ErrorReporter) func(error, echo.Context
 			}
 		}
 
+		if err == domain.ErrNotFound {
+			c.NoContent(http.StatusNotFound)
+			return
+		}
+
 		errorReporter.Capture(err)
 		c.NoContent(http.StatusInternalServerError)
 	}

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -177,7 +177,6 @@ func (r *rankingRepository) CurrentRegistration(userID uint64, now time.Time) (d
 		where
 			rankings.user_id = $1 and
 			rankings.language_code != 'GLO' and
-			$2::date >= contests.start and
 			$2::date <= contests."end"
 		group by contests.id
 		order by contests.id desc

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -180,6 +180,7 @@ func (r *rankingRepository) CurrentRegistration(userID uint64, now time.Time) (d
 			$2::date <= contests."end"
 		group by contests.id
 		order by contests.id desc
+		limit 1
 	`
 
 	err := r.sqlHandler.Get(&row, query, userID, now)

--- a/interfaces/repositories/ranking_repository.go
+++ b/interfaces/repositories/ranking_repository.go
@@ -3,6 +3,8 @@ package repositories
 import (
 	"time"
 
+	"github.com/lib/pq"
+
 	"github.com/tadoku/api/domain"
 	"github.com/tadoku/api/interfaces/rdb"
 	"github.com/tadoku/api/usecases"
@@ -155,38 +157,40 @@ func (r *rankingRepository) GetAllLanguagesForContestAndUser(contestID uint64, u
 }
 
 func (r *rankingRepository) CurrentRegistration(userID uint64) (domain.RankingRegistration, error) {
-	var rows []struct {
-		ID           uint64
-		Start        time.Time
-		End          time.Time
-		LanguageCode domain.LanguageCode `db:"language_code"`
+	type Row struct {
+		ContestID uint64 `db:"contest_id"`
+		Start     time.Time
+		End       time.Time
+		Languages pq.StringArray `db:"language_codes"`
 	}
+	row := Row{}
+	result := &domain.RankingRegistration{}
 
 	query := `
 		select
-			contests.id as id,
+			contests.id as contest_id,
 			contests."end" as "end",
 			contests.start as start,
-			rankings.language_code as language_code
+			array_agg(rankings.language_code) as language_codes
 		from rankings
 		inner join contests on contests.id = rankings.contest_id and contests.open = true
 		where rankings.user_id = $1 and rankings.language_code != 'GLO'
+		group by contests.id, rankings.contest_id
+		order by contest_id desc
+		limit 1
 	`
 
-	err := r.sqlHandler.Select(&rows, query, userID)
+	err := r.sqlHandler.Get(&row, query, userID)
 	if err != nil {
 		return domain.RankingRegistration{}, domain.WrapError(err)
 	}
 
-	result := &domain.RankingRegistration{}
+	result.ContestID = row.ContestID
+	result.Start = row.Start
+	result.End = row.End
 
-	for i, row := range rows {
-		if i == 0 {
-			result.ContestID = row.ID
-			result.Start = row.Start
-			result.End = row.End
-		}
-		result.Languages = append(result.Languages, row.LanguageCode)
+	for _, code := range row.Languages {
+		result.Languages = append(result.Languages, domain.LanguageCode(code))
 	}
 
 	return *result, nil

--- a/interfaces/repositories/ranking_repository_test.go
+++ b/interfaces/repositories/ranking_repository_test.go
@@ -379,6 +379,8 @@ func TestRankingRepository_CurrentRegistration(t *testing.T) {
 		Open:        true,
 	}
 
+	now := time.Date(2019, 1, 20, 0, 0, 0, 0, time.UTC)
+
 	{
 		err := contestRepo.Store(contest)
 		assert.NoError(t, err)
@@ -397,7 +399,7 @@ func TestRankingRepository_CurrentRegistration(t *testing.T) {
 	}
 
 	{
-		registration, err := repo.CurrentRegistration(user.ID)
+		registration, err := repo.CurrentRegistration(user.ID, now)
 		assert.NoError(t, err)
 		assert.Equal(t, contest.ID, registration.ContestID)
 		assert.Equal(t, contest.Start.UTC(), registration.Start.UTC())

--- a/usecases/ranking_interactor.go
+++ b/usecases/ranking_interactor.go
@@ -3,6 +3,8 @@
 package usecases
 
 import (
+	"time"
+
 	"github.com/srvc/fail"
 
 	"github.com/tadoku/api/domain"
@@ -316,7 +318,7 @@ func (i *rankingInteractor) RankingsForContest(
 }
 
 func (i *rankingInteractor) CurrentRegistration(userID uint64) (domain.RankingRegistration, error) {
-	registration, err := i.rankingRepository.CurrentRegistration(userID)
+	registration, err := i.rankingRepository.CurrentRegistration(userID, time.Now())
 	if err != nil {
 		return registration, domain.WrapError(err)
 	}

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -544,10 +544,11 @@ func TestRankingInteractor_CurrentRegistration(t *testing.T) {
 		// Happy path
 		expected := domain.RankingRegistration{
 			ContestID: 1,
-			End:       time.Now(),
+			Start:     time.Now().Add(-10 * time.Minute),
+			End:       time.Now().Add(10 * time.Minute),
 			Languages: domain.LanguageCodes{domain.Japanese, domain.Korean},
 		}
-		rankingRepo.EXPECT().CurrentRegistration(userID).Return(expected, nil)
+		rankingRepo.EXPECT().CurrentRegistration(userID, gomock.Any()).Return(expected, nil)
 
 		registration, err := interactor.CurrentRegistration(userID)
 		assert.NoError(t, err)
@@ -556,7 +557,7 @@ func TestRankingInteractor_CurrentRegistration(t *testing.T) {
 
 	{
 		// Sad path no registration found
-		rankingRepo.EXPECT().CurrentRegistration(userID).Return(domain.RankingRegistration{}, nil)
+		rankingRepo.EXPECT().CurrentRegistration(userID, gomock.Any()).Return(domain.RankingRegistration{}, nil)
 
 		_, err := interactor.CurrentRegistration(userID)
 		assert.EqualError(t, err, usecases.ErrNoRankingRegistrationFound.Error())

--- a/usecases/repositories.go
+++ b/usecases/repositories.go
@@ -3,6 +3,8 @@
 package usecases
 
 import (
+	"time"
+
 	"github.com/tadoku/api/domain"
 )
 
@@ -42,5 +44,5 @@ type RankingRepository interface {
 	GlobalRankings(languageCode domain.LanguageCode) (domain.Rankings, error)
 	FindAll(contestID uint64, userID uint64) (domain.Rankings, error)
 	GetAllLanguagesForContestAndUser(contestID uint64, userID uint64) (domain.LanguageCodes, error)
-	CurrentRegistration(userID uint64) (domain.RankingRegistration, error)
+	CurrentRegistration(userID uint64, now time.Time) (domain.RankingRegistration, error)
 }

--- a/usecases/repositories_mock.go
+++ b/usecases/repositories_mock.go
@@ -8,6 +8,7 @@ import (
 	gomock "github.com/golang/mock/gomock"
 	domain "github.com/tadoku/api/domain"
 	reflect "reflect"
+	time "time"
 )
 
 // MockUserRepository is a mock of UserRepository interface
@@ -411,16 +412,16 @@ func (mr *MockRankingRepositoryMockRecorder) GetAllLanguagesForContestAndUser(co
 }
 
 // CurrentRegistration mocks base method
-func (m *MockRankingRepository) CurrentRegistration(userID uint64) (domain.RankingRegistration, error) {
+func (m *MockRankingRepository) CurrentRegistration(userID uint64, now time.Time) (domain.RankingRegistration, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CurrentRegistration", userID)
+	ret := m.ctrl.Call(m, "CurrentRegistration", userID, now)
 	ret0, _ := ret[0].(domain.RankingRegistration)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CurrentRegistration indicates an expected call of CurrentRegistration
-func (mr *MockRankingRepositoryMockRecorder) CurrentRegistration(userID interface{}) *gomock.Call {
+func (mr *MockRankingRepositoryMockRecorder) CurrentRegistration(userID, now interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentRegistration", reflect.TypeOf((*MockRankingRepository)(nil).CurrentRegistration), userID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentRegistration", reflect.TypeOf((*MockRankingRepository)(nil).CurrentRegistration), userID, now)
 }


### PR DESCRIPTION
## Why

When two contests were open, it would merge the languages from all open contests that you are registered for.

## What

- Only get the contest that's currently running or will start next