### PR TITLE
Prevent late registration

### DIFF
--- a/interfaces/repositories/contest_repository.go
+++ b/interfaces/repositories/contest_repository.go
@@ -72,7 +72,6 @@ func (r *contestRepository) GetRunningContests() ([]uint64, error) {
 		select id
 		from contests
 		where
-			open = true and
 			start <= now() at time zone 'utc' and
 			"end" >= now() at time zone 'utc'
 	`

--- a/usecases/ranking_interactor_test.go
+++ b/usecases/ranking_interactor_test.go
@@ -174,23 +174,6 @@ func TestRankingInteractor_CreateLog(t *testing.T) {
 		assert.EqualError(t, err, usecases.ErrInvalidContestLog.Error())
 	}
 
-	// Test contest being closed
-	{
-		log := domain.ContestLog{
-			ContestID: contestID + 1,
-			UserID:    userID,
-			Language:  domain.Japanese,
-			Amount:    10,
-			MediumID:  domain.MediumComic,
-		}
-
-		validator.EXPECT().Validate(log).Return(true, nil)
-		contestRepo.EXPECT().GetRunningContests().Return([]uint64{contestID}, nil)
-
-		err := interactor.CreateLog(log)
-		assert.EqualError(t, err, usecases.ErrContestIsClosed.Error())
-	}
-
 	// Test not being signed up for a language
 	{
 		log := domain.ContestLog{


### PR DESCRIPTION
## Why

When a contest is closed but still running users should be able to log new pages.

## What

Remove the check if contest is open when submitting pages.