### PR TITLE
Add health check endpoints to all services

### DIFF
--- a/services/authz-api/BUILD.bazel
+++ b/services/authz-api/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//services/common/authz/roles",
         "//services/common/client/keto",
         "//services/common/client/kratos",
+        "//services/common/health",
         "//services/common/middleware",
         "@com_github_getsentry_sentry_go//:sentry-go",
         "@com_github_getsentry_sentry_go//echo",

--- a/services/immersion-api/BUILD.bazel
+++ b/services/immersion-api/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
         "//services/common/authz/roles",
         "//services/common/client/keto",
         "//services/common/domain",
+        "//services/common/health",
         "//services/common/middleware",
         "//services/immersion-api/client/ory",
         "//services/immersion-api/domain",

--- a/services/immersion-api/main.go
+++ b/services/immersion-api/main.go
@@ -14,6 +14,7 @@ import (
 	commonroles "github.com/tadoku/tadoku/services/common/authz/roles"
 	ketoclient "github.com/tadoku/tadoku/services/common/client/keto"
 	"github.com/tadoku/tadoku/services/common/domain"
+	"github.com/tadoku/tadoku/services/common/health"
 	tadokumiddleware "github.com/tadoku/tadoku/services/common/middleware"
 	"github.com/tadoku/tadoku/services/immersion-api/client/ory"
 	immersiondomain "github.com/tadoku/tadoku/services/immersion-api/domain"
@@ -90,13 +91,22 @@ func main() {
 	go outboxWorker.Run(workerCtx)
 
 	e := echo.New()
-	e.Use(tadokumiddleware.Logger([]string{"/ping"}))
-	e.Use(tadokumiddleware.VerifyJWT(cfg.JWKS))
-	e.Use(tadokumiddleware.Identity())
-	e.Use(tadokumiddleware.RolesFromKeto(rolesSvc))
-	e.Use(tadokumiddleware.RequireServiceAudience(cfg.ServiceName))
-	e.Use(tadokumiddleware.RejectBannedUsers())
 	e.Use(middleware.Recover())
+
+	// Health endpoints: allow K8s probes without auth, require admin if JWT is present
+	optAuth := tadokumiddleware.OptionalAdminAuth(cfg.JWKS, rolesSvc)
+	pgChecker := health.NewPostgresChecker("postgres", psql)
+	e.GET("/livez", health.LivezHandler, optAuth)
+	e.GET("/readyz", health.ReadyzHandler([]health.HealthChecker{pgChecker}), optAuth)
+
+	// Business endpoints: full auth middleware stack
+	api := e.Group("")
+	api.Use(tadokumiddleware.Logger([]string{"/ping"}))
+	api.Use(tadokumiddleware.VerifyJWT(cfg.JWKS))
+	api.Use(tadokumiddleware.Identity())
+	api.Use(tadokumiddleware.RolesFromKeto(rolesSvc))
+	api.Use(tadokumiddleware.RequireServiceAudience(cfg.ServiceName))
+	api.Use(tadokumiddleware.RejectBannedUsers())
 
 	if cfg.SentryDSN != "" {
 		if err := sentry.Init(sentry.ClientOptions{
@@ -105,7 +115,7 @@ func main() {
 		}); err != nil {
 			panic(fmt.Errorf("sentry initialization failed: %v", err))
 		}
-		e.Use(sentryecho.New(sentryecho.Options{}))
+		api.Use(sentryecho.New(sentryecho.Options{}))
 	}
 
 	// Service-per-function services
@@ -178,7 +188,7 @@ func main() {
 		logContestUpdate,
 	)
 
-	openapi.RegisterHandlersWithBaseURL(e, server, "")
+	openapi.RegisterHandlersWithBaseURL(api, server, "")
 
 	// Start server in goroutine
 	go func() {

--- a/services/profile-api/BUILD.bazel
+++ b/services/profile-api/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     deps = [
         "//services/common/authz/roles",
         "//services/common/client/keto",
+        "//services/common/health",
         "//services/common/middleware",
         "//services/profile-api/cache",
         "//services/profile-api/client/ory",


### PR DESCRIPTION
## Summary
This PR adds Kubernetes-compatible health check endpoints (`/livez` and `/readyz`) to all three services (profile-api, authz-api, and immersion-api). The health endpoints are accessible without full authentication, allowing Kubernetes probes to function independently of the service's JWT authentication requirements.

## Key Changes
- **Health check endpoints**: Added `/livez` (liveness) and `/readyz` (readiness) endpoints to all services
  - Liveness probe returns immediately to indicate the service is running
  - Readiness probe includes database connectivity checks via `PostgresChecker`
- **Optional authentication middleware**: Implemented `OptionalAdminAuth` middleware that allows unauthenticated access to health endpoints while requiring admin role if a JWT is present
- **Route organization**: Separated health check routes from business logic routes by:
  - Registering health endpoints directly on the main Echo instance
  - Creating an `api` route group for all business endpoints with full authentication middleware stack
  - Moving all existing middleware (Logger, VerifyJWT, Identity, RolesFromKeto, RequireServiceAudience, RejectBannedUsers, Sentry) to the `api` group
- **Database health checks**: Added `PostgresChecker` to readiness probes to verify database connectivity
- **Build dependencies**: Updated BUILD.bazel files to include the new `//services/common/health` dependency

## Implementation Details
- Health endpoints use the new `health` package from `services/common/health`
- The `OptionalAdminAuth` middleware allows Kubernetes probes to access health endpoints without authentication
- All business logic routes continue to use the full authentication middleware stack via the `api` group
- Sentry error tracking is now only applied to business endpoints, not health checks

https://claude.ai/code/session_018EHvGNiA8wZD83qicsiULb