### PR TITLE
Add activity-specific tags sidebar to log forms

### DIFF
--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -150,7 +150,7 @@ export const EditLogForm = ({ options, log }: Props) => {
           </div>
         </form>
         <aside className="hidden lg:block lg:w-56 lg:pt-1">
-          <div className="sticky top-4">
+          <div className="sticky top-14 sm:top-20">
             <TagsSidebar activityId={log.activity.id} />
           </div>
         </aside>

--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -1,4 +1,5 @@
 import { Input, TagsInput } from 'ui'
+import { TagsSidebar } from '@app/immersion/components/TagsSidebar'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -78,72 +79,82 @@ export const EditLogForm = ({ options, log }: Props) => {
 
   return (
     <FormProvider {...methods}>
-      <form
-        onSubmit={methods.handleSubmit(onSubmit, errors => console.log(errors))}
-        className="v-stack spaced max-w-lg"
-      >
-        <div className="card">
-          <div className="v-stack spaced">
-            <label className="label">
-              <span className="label-text">Language</span>
-              <input
-                type="text"
-                value={log.language.name}
-                disabled
+      <div className="flex flex-col lg:flex-row lg:gap-6">
+        <form
+          onSubmit={methods.handleSubmit(onSubmit, errors => console.log(errors))}
+          className="v-stack spaced max-w-lg flex-1"
+        >
+          <div className="card">
+            <div className="v-stack spaced">
+              <label className="label">
+                <span className="label-text">Language</span>
+                <input
+                  type="text"
+                  value={log.language.name}
+                  disabled
+                />
+              </label>
+              <label className="label">
+                <span className="label-text">Activity</span>
+                <input
+                  type="text"
+                  value={log.activity.name}
+                  disabled
+                />
+              </label>
+              <AmountWithUnit
+                label="Amount"
+                name="amount"
+                defaultValue={log.amount}
+                min={0}
+                step="any"
+                units={unitsAsOptions}
+                unitsLabel="Unit"
               />
-            </label>
-            <label className="label">
-              <span className="label-text">Activity</span>
-              <input
+              <Input
+                name="description"
+                label="Description"
                 type="text"
-                value={log.activity.name}
-                disabled
+                placeholder="e.g. One Piece volume 45"
               />
-            </label>
-            <AmountWithUnit
-              label="Amount"
-              name="amount"
-              defaultValue={log.amount}
-              min={0}
-              step="any"
-              units={unitsAsOptions}
-              unitsLabel="Unit"
-            />
-            <Input
-              name="description"
-              label="Description"
-              type="text"
-              placeholder="e.g. One Piece volume 45"
-            />
-            <TagsInput
-              name="tags"
-              label="Tags"
-              placeholder="Add tags..."
-              maxTags={10}
-              getSuggestions={fetchTagSuggestions}
-              renderSuggestion={s =>
-                s.count > 0 ? `${s.tag} (${s.count}x)` : s.tag
-              }
-              getValue={s => s.tag}
-            />
+              <TagsInput
+                name="tags"
+                label="Tags"
+                placeholder="Add tags..."
+                maxTags={10}
+                getSuggestions={fetchTagSuggestions}
+                renderSuggestion={s =>
+                  s.count > 0 ? `${s.tag} (${s.count}x)` : s.tag
+                }
+                getValue={s => s.tag}
+              />
+              <div className="lg:hidden">
+                <TagsSidebar activityId={log.activity.id} />
+              </div>
+            </div>
+            <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
+              Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+            </div>
           </div>
-          <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-            Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+          <div className="h-stack spaced justify-end">
+            <a href={routes.log(log.id)} className="btn ghost">
+              Cancel
+            </a>
+            <button
+              type="submit"
+              className="btn primary"
+              disabled={methods.formState.isSubmitting}
+            >
+              Save
+            </button>
           </div>
-        </div>
-        <div className="h-stack spaced justify-end">
-          <a href={routes.log(log.id)} className="btn ghost">
-            Cancel
-          </a>
-          <button
-            type="submit"
-            className="btn primary"
-            disabled={methods.formState.isSubmitting}
-          >
-            Save
-          </button>
-        </div>
-      </form>
+        </form>
+        <aside className="hidden lg:block lg:w-56 lg:pt-1">
+          <div className="sticky top-4">
+            <TagsSidebar activityId={log.activity.id} />
+          </div>
+        </aside>
+      </div>
     </FormProvider>
   )
 }

--- a/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
@@ -237,7 +237,7 @@ export const LogForm = ({
           </div>
         </form>
         <aside className="hidden lg:block lg:w-56 lg:pt-1">
-          <div className="sticky top-4">
+          <div className="sticky top-14 sm:top-20">
             <TagsSidebar activityId={activityId} />
           </div>
         </aside>

--- a/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
@@ -4,6 +4,7 @@ import {
   RadioGroup,
   TagsInput,
 } from 'ui'
+import { TagsSidebar } from '@app/immersion/components/TagsSidebar'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -146,91 +147,101 @@ export const LogForm = ({
 
   return (
     <FormProvider {...methods}>
-      <form
-        onSubmit={methods.handleSubmit(onSubmit, errors => console.log(errors))}
-        className="v-stack spaced max-w-4xl"
-      >
-        <div className="card">
-          <div className="v-stack spaced lg:h-stack lg:!space-x-8 w-full">
-            <div className="flex-grow v-stack spaced lg:w-2/5">
-              <RadioGroup
-                options={trackingModesForRegistrations(registrations.length)}
-                label="Contests"
-                name="tracking_mode"
-              />
-              {trackingMode === 'manual' ? (
-                <AutocompleteMultiInput
-                  name="selected_registrations"
-                  label="Contest selection"
-                  options={registrations}
-                  match={(option, query) =>
-                    option.contest?.title
-                      .toLowerCase()
-                      .replace(/[^a-zA-Z0-9]/g, '')
-                      .includes(query.toLowerCase()) ?? false
-                  }
-                  getIdForOption={option => option.id}
-                  format={option => formatContestLabel(option.contest!)}
+      <div className="flex flex-col lg:flex-row lg:gap-6">
+        <form
+          onSubmit={methods.handleSubmit(onSubmit, errors => console.log(errors))}
+          className="v-stack spaced max-w-4xl flex-1"
+        >
+          <div className="card">
+            <div className="v-stack spaced lg:h-stack lg:!space-x-8 w-full">
+              <div className="flex-grow v-stack spaced lg:w-2/5">
+                <RadioGroup
+                  options={trackingModesForRegistrations(registrations.length)}
+                  label="Contests"
+                  name="tracking_mode"
                 />
-              ) : null}
-            </div>
-            <div className="v-stack spaced lg:w-3/5">
-              <Select
-                name="languageCode"
-                label="Language"
-                values={languagesAsOptions}
-              />
-              <Select
-                name="activityId"
-                label="Activity"
-                values={activitiesAsOptions}
-                options={{ valueAsNumber: true }}
-              />
-              <div className="h-stack spaced">
-                <AmountWithUnit
-                  label="Amount"
-                  name="amount"
-                  defaultValue={0}
-                  min={0}
-                  step="any"
-                  units={unitsAsOptions}
-                  unitsLabel="Unit"
-                />
+                {trackingMode === 'manual' ? (
+                  <AutocompleteMultiInput
+                    name="selected_registrations"
+                    label="Contest selection"
+                    options={registrations}
+                    match={(option, query) =>
+                      option.contest?.title
+                        .toLowerCase()
+                        .replace(/[^a-zA-Z0-9]/g, '')
+                        .includes(query.toLowerCase()) ?? false
+                    }
+                    getIdForOption={option => option.id}
+                    format={option => formatContestLabel(option.contest!)}
+                  />
+                ) : null}
               </div>
-              <Input
-                name="description"
-                label="Description"
-                type="text"
-                placeholder="e.g. One Piece volume 45"
-              />
-              <TagsInput
-                name="tags"
-                label="Tags"
-                placeholder="Add tags..."
-                maxTags={10}
-                getSuggestions={fetchTagSuggestions}
-                renderSuggestion={s => s.count > 0 ? `${s.tag} (${s.count}×)` : s.tag}
-                getValue={s => s.tag}
-              />
+              <div className="v-stack spaced lg:w-3/5">
+                <Select
+                  name="languageCode"
+                  label="Language"
+                  values={languagesAsOptions}
+                />
+                <Select
+                  name="activityId"
+                  label="Activity"
+                  values={activitiesAsOptions}
+                  options={{ valueAsNumber: true }}
+                />
+                <div className="h-stack spaced">
+                  <AmountWithUnit
+                    label="Amount"
+                    name="amount"
+                    defaultValue={0}
+                    min={0}
+                    step="any"
+                    units={unitsAsOptions}
+                    unitsLabel="Unit"
+                  />
+                </div>
+                <Input
+                  name="description"
+                  label="Description"
+                  type="text"
+                  placeholder="e.g. One Piece volume 45"
+                />
+                <TagsInput
+                  name="tags"
+                  label="Tags"
+                  placeholder="Add tags..."
+                  maxTags={10}
+                  getSuggestions={fetchTagSuggestions}
+                  renderSuggestion={s => s.count > 0 ? `${s.tag} (${s.count}×)` : s.tag}
+                  getValue={s => s.tag}
+                />
+                <div className="lg:hidden">
+                  <TagsSidebar activityId={activityId} />
+                </div>
+              </div>
+            </div>
+            <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
+              Estimated score: <strong>{formatScore(estimatedScore)}</strong>
             </div>
           </div>
-          <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-            Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+          <div className="h-stack spaced justify-end">
+            <a href={routes.contestListOfficial()} className="btn ghost">
+              Cancel
+            </a>
+            <button
+              type="submit"
+              className="btn primary"
+              disabled={methods.formState.isSubmitting}
+            >
+              Create
+            </button>
           </div>
-        </div>
-        <div className="h-stack spaced justify-end">
-          <a href={routes.contestListOfficial()} className="btn ghost">
-            Cancel
-          </a>
-          <button
-            type="submit"
-            className="btn primary"
-            disabled={methods.formState.isSubmitting}
-          >
-            Create
-          </button>
-        </div>
-      </form>
+        </form>
+        <aside className="hidden lg:block lg:w-56 lg:pt-1">
+          <div className="sticky top-4">
+            <TagsSidebar activityId={activityId} />
+          </div>
+        </aside>
+      </div>
     </FormProvider>
   )
 }

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -176,7 +176,7 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
           </div>
         </form>
         <aside className="hidden lg:block lg:w-56 lg:pt-1">
-          <div className="sticky top-4">
+          <div className="sticky top-14 sm:top-20">
             <TagsSidebar activityId={activityId} />
           </div>
         </aside>

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -1,4 +1,5 @@
 import { Input, TagsInput } from 'ui'
+import { TagsSidebar } from '@app/immersion/components/TagsSidebar'
 import { FormProvider, useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import {
@@ -111,65 +112,75 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
 
   return (
     <FormProvider {...methods}>
-      <form
-        onSubmit={methods.handleSubmit(onSubmit, errors => console.log(errors))}
-        className="v-stack spaced max-w-lg"
-      >
-        <div className="card">
-          <div className="v-stack spaced">
-            <Select
-              name="languageCode"
-              label="Language"
-              values={languagesAsOptions}
-            />
-            <Select
-              name="activityId"
-              label="Activity"
-              values={activitiesAsOptions}
-              options={{ valueAsNumber: true }}
-            />
-            <AmountWithUnit
-              label="Amount"
-              name="amount"
-              defaultValue={0}
-              min={0}
-              step="any"
-              units={unitsAsOptions}
-              unitsLabel="Unit"
-            />
-            <Input
-              name="description"
-              label="Description"
-              type="text"
-              placeholder="e.g. One Piece volume 45"
-            />
-            <TagsInput
-              name="tags"
-              label="Tags"
-              placeholder="Add tags..."
-              maxTags={10}
-              getSuggestions={fetchTagSuggestions}
-              renderSuggestion={s => (s.count > 0 ? `${s.tag} (${s.count}×)` : s.tag)}
-              getValue={s => s.tag}
-            />
+      <div className="flex flex-col lg:flex-row lg:gap-6">
+        <form
+          onSubmit={methods.handleSubmit(onSubmit, errors => console.log(errors))}
+          className="v-stack spaced max-w-lg flex-1"
+        >
+          <div className="card">
+            <div className="v-stack spaced">
+              <Select
+                name="languageCode"
+                label="Language"
+                values={languagesAsOptions}
+              />
+              <Select
+                name="activityId"
+                label="Activity"
+                values={activitiesAsOptions}
+                options={{ valueAsNumber: true }}
+              />
+              <AmountWithUnit
+                label="Amount"
+                name="amount"
+                defaultValue={0}
+                min={0}
+                step="any"
+                units={unitsAsOptions}
+                unitsLabel="Unit"
+              />
+              <Input
+                name="description"
+                label="Description"
+                type="text"
+                placeholder="e.g. One Piece volume 45"
+              />
+              <TagsInput
+                name="tags"
+                label="Tags"
+                placeholder="Add tags..."
+                maxTags={10}
+                getSuggestions={fetchTagSuggestions}
+                renderSuggestion={s => (s.count > 0 ? `${s.tag} (${s.count}×)` : s.tag)}
+                getValue={s => s.tag}
+              />
+              <div className="lg:hidden">
+                <TagsSidebar activityId={activityId} />
+              </div>
+            </div>
+            <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
+              Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+            </div>
           </div>
-          <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-            Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+          <div className="h-stack spaced justify-end">
+            <a href={routes.home()} className="btn ghost">
+              Cancel
+            </a>
+            <button
+              type="submit"
+              className="btn primary"
+              disabled={methods.formState.isSubmitting}
+            >
+              Create
+            </button>
           </div>
-        </div>
-        <div className="h-stack spaced justify-end">
-          <a href={routes.home()} className="btn ghost">
-            Cancel
-          </a>
-          <button
-            type="submit"
-            className="btn primary"
-            disabled={methods.formState.isSubmitting}
-          >
-            Create
-          </button>
-        </div>
-      </form>
+        </form>
+        <aside className="hidden lg:block lg:w-56 lg:pt-1">
+          <div className="sticky top-4">
+            <TagsSidebar activityId={activityId} />
+          </div>
+        </aside>
+      </div>
     </FormProvider>
   )
 }

--- a/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
+++ b/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
@@ -1,0 +1,106 @@
+import { useFormContext } from 'react-hook-form'
+
+interface ActivityTagSuggestion {
+  tag: string
+  // Future: modifiers for score adjustments
+  // modifiers?: { unitId: string; multiplier: number }[]
+}
+
+const activityTags: Record<number, ActivityTagSuggestion[]> = {
+  // Reading
+  1: [
+    { tag: 'book' },
+    { tag: 'ebook' },
+    { tag: 'manga' },
+    { tag: 'comic' },
+    { tag: 'fiction' },
+    { tag: 'non-fiction' },
+    { tag: 'web page' },
+    { tag: 'lyric' },
+    { tag: 'game' },
+  ],
+  // Listening
+  2: [
+    { tag: 'audiobook' },
+    { tag: 'podcast' },
+    { tag: 'anime' },
+    { tag: 'drama' },
+    { tag: 'tv' },
+    { tag: 'news' },
+    { tag: 'online video' },
+    { tag: 'fiction' },
+    { tag: 'non-fiction' },
+  ],
+  // Writing
+  3: [
+    { tag: 'fiction' },
+    { tag: 'non-fiction' },
+    { tag: 'social media' },
+    { tag: 'chat' },
+  ],
+  // Speaking
+  4: [
+    { tag: 'conversation' },
+    { tag: 'presentation' },
+    { tag: 'shadowing' },
+    { tag: 'chorusing' },
+  ],
+  // Study
+  5: [
+    { tag: 'grammar' },
+    { tag: 'vocabulary' },
+    { tag: 'srs' },
+    { tag: 'textbook' },
+  ],
+}
+
+const MAX_TAGS = 10
+
+interface TagsSidebarProps {
+  activityId: number | undefined
+}
+
+export function TagsSidebar({ activityId }: TagsSidebarProps) {
+  const { watch, getValues, setValue } = useFormContext()
+  const tags: string[] = watch('tags') ?? []
+  const suggestions: ActivityTagSuggestion[] = activityId != null ? (activityTags[activityId] ?? []) : []
+
+  if (suggestions.length === 0) return null
+
+  const isAtLimit = tags.length >= MAX_TAGS
+
+  const handleToggle = (tag: string) => {
+    const current: string[] = getValues('tags') ?? []
+    if (current.includes(tag)) {
+      setValue('tags', current.filter(t => t !== tag), { shouldValidate: true })
+    } else if (current.length < MAX_TAGS) {
+      setValue('tags', [...current, tag], { shouldValidate: true })
+    }
+  }
+
+  return (
+    <div className="v-stack gap-2">
+      <span className="text-sm font-medium text-slate-500">Common tags</span>
+      <div className="flex flex-wrap gap-2">
+        {suggestions.map(({ tag }) => {
+          const isSelected = tags.includes(tag)
+          return (
+            <button
+              key={tag}
+              type="button"
+              onClick={() => handleToggle(tag)}
+              disabled={!isSelected && isAtLimit}
+              className={`tag rounded-md cursor-pointer transition-colors ${
+                isSelected
+                  ? 'bg-secondary/10 border border-secondary/30 text-secondary-900'
+                  : 'bg-white border border-slate-300 text-slate-700 hover:bg-slate-50'
+              } ${!isSelected && isAtLimit ? 'opacity-50 cursor-not-allowed' : ''}`}
+            >
+              {tag}
+            </button>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
+++ b/frontend/apps/webv2/app/immersion/components/TagsSidebar.tsx
@@ -79,8 +79,8 @@ export function TagsSidebar({ activityId }: TagsSidebarProps) {
   }
 
   return (
-    <div className="v-stack gap-2">
-      <span className="text-sm font-medium text-slate-500">Common tags</span>
+    <div className="v-stack gap-2 mt-4 lg:mt-0">
+      <span className="subtitle text-sm">Common tags</span>
       <div className="flex flex-wrap gap-2">
         {suggestions.map(({ tag }) => {
           const isSelected = tags.includes(tag)
@@ -90,10 +90,10 @@ export function TagsSidebar({ activityId }: TagsSidebarProps) {
               type="button"
               onClick={() => handleToggle(tag)}
               disabled={!isSelected && isAtLimit}
-              className={`tag rounded-md cursor-pointer transition-colors ${
+              className={`tag cursor-pointer transition-colors border border-b-2 border-black/5 lg:border-black/15 bg-black/5 lg:bg-white ${
                 isSelected
-                  ? 'bg-secondary/10 border border-secondary/30 text-secondary-900'
-                  : 'bg-white border border-slate-300 text-slate-700 hover:bg-slate-50'
+                  ? 'opacity-70 line-through'
+                  : 'hover:bg-slate-50'
               } ${!isSelected && isAtLimit ? 'opacity-50 cursor-not-allowed' : ''}`}
             >
               {tag}


### PR DESCRIPTION
## Summary
- Add a sidebar panel next to log forms showing common tags as clickable chips, filtered by the selected activity (reading, listening, writing, speaking, study)
- On desktop, the sidebar renders as a sticky panel to the right of the form; on mobile it renders inline below the tags input
- Clicking a tag toggles it on/off in the form; selected tags show as strikethrough with reduced opacity
- Tag data is structured to support future score modifier annotations

## Test plan
- [ ] Verify sidebar shows correct tags when switching between activities
- [ ] Verify clicking a tag adds it to the form's tag list
- [ ] Verify clicking a selected tag removes it
- [ ] Verify tags disable when 10-tag limit is reached
- [ ] Verify sidebar sticks below navbar when scrolling on desktop
- [ ] Verify inline layout renders correctly on mobile
- [ ] Test on all three forms: new log (v1), new log (v2), edit log

🤖 Generated with [Claude Code](https://claude.com/claude-code)