### PR TITLE
Update Discord invite link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 I'm really glad you're reading this, because volunteer developers are always welcome to improve Tadoku.
 
-If you haven't already, come find us on our [Discord server](https://discord.gg/Dd8t9WB). We want you working on things you're excited about.
+If you haven't already, come find us on our [Discord server](https://discord.gg/AsC9vZs2Ex). We want you working on things you're excited about.
 
 ## Architecture
 

--- a/frontend/apps/webv2/app/common/routes.ts
+++ b/frontend/apps/webv2/app/common/routes.ts
@@ -62,5 +62,5 @@ export const routes = {
   personalWebsite: () => `https://antonve.be`,
   twitter: () => `https://twitter.com/tadoku_app`,
   github: () => `https://github.com/tadoku`,
-  discord: () => `https://discord.gg/Dd8t9WB`,
+  discord: () => `https://discord.gg/AsC9vZs2Ex`,
 }


### PR DESCRIPTION
Replaces the expired Discord invite with the new permanent one in the two places it appears: CONTRIBUTING.md and the webv2 footer routes.