### PR TITLE
chore(infra): move machine-specific dev config into gitignored local files

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -14,6 +14,6 @@ else:
 include('./k8s/dev/Tiltfile')
 
 # Private
-# private_infra_path = '../tadoku-private/Tiltfile'
-# if os.path.exists(private_infra_path):
-#     include(private_infra_path)
+private_infra_path = os.getenv('TADOKU_PRIVATE_INFRA_TILTFILE', '')
+if private_infra_path and os.path.exists(private_infra_path):
+    include(private_infra_path)

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -37,7 +37,7 @@ Built images stay in your local docker daemon. Because backend images are built 
 
 Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the platform TLS certificate once available) before Tilt can push images.
 
-Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only.
+Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only. The context keys can also be set via environment variables (`shared_k8s_context` → `TADOKU_SHARED_K8S_CONTEXT`, `local_k8s_context` → `TADOKU_LOCAL_K8S_CONTEXT`); environment variables take precedence over `tilt_config.json`.
 
 Fetch the dev-cluster kubeconfig after creating `infra/dev/.env.local` from `infra/dev/.env.example`:
 
@@ -49,9 +49,13 @@ export KUBECONFIG="$HOME/.kube/<shared-context>.yaml"
 kubectl get nodes
 ```
 
-The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), context (`TADOKU_DEV_K8S_CONTEXT`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can be set in `infra/dev/.env.local` or as environment variables; environment variables take precedence over `.env.local`.
+The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), context (`TADOKU_DEV_K8S_CONTEXT`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can be set in `infra/dev/.env.local` or as environment variables; environment variables take precedence over `.env.local`. Set `TADOKU_DEV_KUBECONFIG_ENV` to read the env file from a different path.
 
 Built images are pushed to `shared.registry` from `tilt_config.json`. The app and auth/admin hostnames come from the `shared.hosts` block.
+
+### Private infrastructure
+
+Operators can include a private Tiltfile (kept outside this repository) by setting `TADOKU_PRIVATE_INFRA_TILTFILE` to its path before running `tilt up`; it is skipped when unset or when the file does not exist.
 
 ## Can't connect connect to service/database
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -7,7 +7,7 @@ title: Development Environment
 
 Tadoku is made up of several services working together. It can be quite difficult to set up a local development environment with all the required services linked up together. This is a requirement for anyone to be productive in this project, and is also why we've provided a development environment for you.
 
-We use [Tilt](https://tilt.dev/) to deploy all our backend services & dependencies to a Kubernetes cluster. Tilt can target either a local cluster or the shared `dev-lab` cluster; when targeting `dev-lab`, built images are pushed to the registry configured in `tilt_config.json`. The environment includes both the backend services and the frontend apps. Each frontend also has a development mode which is configured to connect to this environment.
+We use [Tilt](https://tilt.dev/) to deploy all our backend services & dependencies to a Kubernetes cluster. Tilt can target either a local cluster or a shared development cluster; when targeting the shared cluster, built images are pushed to the registry configured in `tilt_config.json`. The environment includes both the backend services and the frontend apps. Each frontend also has a development mode which is configured to connect to this environment.
 
 ## Getting Started
 
@@ -33,21 +33,23 @@ kubectl config use-context docker-desktop
 
 Built images stay in your local docker daemon. Because backend images are built with Bazel and never pushed to a registry for local contexts, the cluster must be able to run images straight from the host Docker daemon (e.g. OrbStack or Docker Desktop). Clusters with their own container runtime, such as kind or minikube, would need an extra image-load step (e.g. `kind load`) that is not supported yet. Access the environment using the `local.hosts` values in `tilt_config.json`.
 
-### Option B: Shared lab cluster (`dev-lab`)
+### Option B: Shared development cluster
 
-Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the lab TLS certificate once available) before Tilt can push images.
+Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the platform TLS certificate once available) before Tilt can push images.
 
-Fetch the dev-cluster kubeconfig after creating `.env.local` from `.env.local.example`:
+Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only.
+
+Fetch the dev-cluster kubeconfig after creating `infra/dev/.env.local` from `infra/dev/.env.example`:
 
 ```sh
-cp .env.local.example .env.local
-# Edit .env.local with the shared cluster host and SSH target.
+cp infra/dev/.env.example infra/dev/.env.local
+# Edit infra/dev/.env.local with your private operator values.
 ./infra/dev/kubeconfig.sh
-export KUBECONFIG="$HOME/.kube/dev-lab.yaml"
+export KUBECONFIG="$HOME/.kube/<shared-context>.yaml"
 kubectl get nodes
 ```
 
-The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://${TADOKU_DEV_K3S_HOST}:6443`, sets the context to `dev-lab`, and stores the result as `~/.kube/dev-lab.yaml`. Override the SSH target with `TADOKU_DEV_K3S_SSH_TARGET` or pass a destination path as the first argument. The host (`TADOKU_DEV_K3S_HOST`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can also be overridden via environment variables.
+The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), context (`TADOKU_DEV_K8S_CONTEXT`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can be set in `infra/dev/.env.local` or as environment variables.
 
 Built images are pushed to `shared.registry` from `tilt_config.json`. The app and auth/admin hostnames come from the `shared.hosts` block.
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -49,7 +49,7 @@ export KUBECONFIG="$HOME/.kube/<shared-context>.yaml"
 kubectl get nodes
 ```
 
-The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), context (`TADOKU_DEV_K8S_CONTEXT`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can be set in `infra/dev/.env.local` or as environment variables.
+The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), context (`TADOKU_DEV_K8S_CONTEXT`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can be set in `infra/dev/.env.local` or as environment variables; environment variables take precedence over `.env.local`.
 
 Built images are pushed to `shared.registry` from `tilt_config.json`. The app and auth/admin hostnames come from the `shared.hosts` block.
 

--- a/infra/dev/.env.example
+++ b/infra/dev/.env.example
@@ -1,0 +1,8 @@
+TADOKU_DEV_K3S_HOST=k3s-server.example
+TADOKU_DEV_K3S_SSH_TARGET=user@k3s-server.example
+TADOKU_DEV_K8S_CONTEXT=shared-context
+
+# Optional overrides:
+# TADOKU_DEV_K3S_READ_CMD="sudo cat /etc/rancher/k3s/k3s.yaml"
+# TADOKU_DEV_K3S_TLS_SERVER_NAME=k3s-server
+# TADOKU_DEV_KUBECONFIG="$HOME/.kube/shared-context.yaml"

--- a/infra/dev/kubeconfig.sh
+++ b/infra/dev/kubeconfig.sh
@@ -4,10 +4,26 @@ set -euo pipefail
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 env_file="${TADOKU_DEV_KUBECONFIG_ENV:-${script_dir}/.env.local}"
 if [[ -f "${env_file}" ]]; then
-  set -a
+  env_vars=(
+    TADOKU_DEV_K3S_HOST
+    TADOKU_DEV_K3S_SSH_TARGET
+    TADOKU_DEV_K8S_CONTEXT
+    TADOKU_SHARED_K8S_CONTEXT
+    TADOKU_DEV_K3S_READ_CMD
+    TADOKU_DEV_K3S_TLS_SERVER_NAME
+    TADOKU_DEV_KUBECONFIG
+  )
+  preset=()
+  for name in "${env_vars[@]}"; do
+    if [[ -n "${!name+x}" ]]; then
+      preset+=("${name}=${!name}")
+    fi
+  done
   # shellcheck source=/dev/null
   source "${env_file}"
-  set +a
+  for entry in ${preset[@]+"${preset[@]}"}; do
+    declare "${entry}"
+  done
 fi
 
 require_env() {

--- a/infra/dev/kubeconfig.sh
+++ b/infra/dev/kubeconfig.sh
@@ -2,27 +2,43 @@
 set -euo pipefail
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-repo_root="$(cd "${script_dir}/../.." && pwd)"
-
-if [[ -f "${repo_root}/.env.local" ]]; then
+env_file="${TADOKU_DEV_KUBECONFIG_ENV:-${script_dir}/.env.local}"
+if [[ -f "${env_file}" ]]; then
   set -a
-  # shellcheck disable=SC1091
-  source "${repo_root}/.env.local"
+  # shellcheck source=/dev/null
+  source "${env_file}"
   set +a
 fi
 
-host="${TADOKU_DEV_K3S_HOST:-cluster-node.example.invalid}"
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    printf '%s is required; set it in the environment or %s\n' "${name}" "${env_file}" >&2
+    exit 1
+  fi
+}
+
+require_env TADOKU_DEV_K3S_HOST
+require_env TADOKU_DEV_K3S_SSH_TARGET
+
+context="${TADOKU_DEV_K8S_CONTEXT:-${TADOKU_SHARED_K8S_CONTEXT:-}}"
+if [[ -z "${context}" ]]; then
+  printf 'TADOKU_DEV_K8S_CONTEXT is required; set it in the environment or %s\n' "${env_file}" >&2
+  exit 1
+fi
+
+host="${TADOKU_DEV_K3S_HOST}"
 server="https://${host}:6443"
-ssh_target="${TADOKU_DEV_K3S_SSH_TARGET:-user@${host}}"
+ssh_target="${TADOKU_DEV_K3S_SSH_TARGET}"
 read_cmd="${TADOKU_DEV_K3S_READ_CMD:-sudo cat /etc/rancher/k3s/k3s.yaml}"
 tls_server_name="${TADOKU_DEV_K3S_TLS_SERVER_NAME:-${host%%.*}}"
-out="${1:-${TADOKU_DEV_KUBECONFIG:-${HOME}/.kube/dev-lab.yaml}}"
+out="${1:-${TADOKU_DEV_KUBECONFIG:-${HOME}/.kube/${context}.yaml}}"
 
 tmp="$(mktemp)"
 trap 'rm -f "${tmp}"' EXIT
 
 if ! command -v kubectl >/dev/null 2>&1; then
-  printf 'kubectl is required to prepare the dev-lab kubeconfig\n' >&2
+  printf 'kubectl is required to prepare the shared-cluster kubeconfig\n' >&2
   exit 1
 fi
 
@@ -31,13 +47,13 @@ mkdir -p "$(dirname "${out}")"
 ssh "${ssh_target}" "${read_cmd}" > "${tmp}"
 
 current_context="$(KUBECONFIG="${tmp}" kubectl config current-context)"
-if [[ "${current_context}" != "dev-lab" ]]; then
-  KUBECONFIG="${tmp}" kubectl config rename-context "${current_context}" dev-lab >/dev/null
+if [[ "${current_context}" != "${context}" ]]; then
+  KUBECONFIG="${tmp}" kubectl config rename-context "${current_context}" "${context}" >/dev/null
 fi
 
-cluster="$(KUBECONFIG="${tmp}" kubectl config view -o jsonpath='{.contexts[?(@.name=="dev-lab")].context.cluster}')"
+cluster="$(KUBECONFIG="${tmp}" kubectl config view -o "jsonpath={.contexts[?(@.name==\"${context}\")].context.cluster}")"
 KUBECONFIG="${tmp}" kubectl config set-cluster "${cluster}" --server="${server}" --tls-server-name="${tls_server_name}" >/dev/null
-KUBECONFIG="${tmp}" kubectl config use-context dev-lab >/dev/null
+KUBECONFIG="${tmp}" kubectl config use-context "${context}" >/dev/null
 
 install -m 600 "${tmp}" "${out}"
 


### PR DESCRIPTION
Move machine-specific development environment settings out of committed Tilt and kubeconfig defaults and into gitignored local config with placeholder examples. Public docs now describe private operator values without naming any real environment.

## Pipeline validation record (no-mistakes)

<details>
<summary>Evidence</summary>

- Run `01KWSAPRJH1HSCFZVN2R9J0BVB` reached `checks-passed`.
- The pipeline applied one review fix: explicit environment variables now take precedence over `.env.local` without exporting the whole file.
- Review, test, document, lint, push, PR, and CI steps completed.
- The PR reports no configured CI checks.

</details>
