### PR TITLE
build(infra): load locally built images into kind and minikube clusters via Tilt

### DIFF
--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -42,7 +42,7 @@ export TADOKU_LOCAL_K8S_CONTEXT=docker-desktop
 export TADOKU_LOCAL_CLUSTER_TYPE=docker-desktop
 ```
 
-For local contexts, backend images are built with Bazel and are not pushed to a registry. OrbStack and Docker Desktop use the daemon-sharing path, while kind and minikube run an image-load step after each backend image build (`kind load docker-image` or `minikube image load`). If your kind cluster or minikube profile name is not obvious from the kubectl context, set `local_cluster_name` in `tilt_config.json` or `TADOKU_LOCAL_CLUSTER_NAME`. The cluster type is inferred from the context name; accepted `local_cluster_type` values are `kind`, `minikube`, and the daemon-sharing types `orbstack`, `docker-desktop`, `shared-daemon`, and `none`. Access the environment using the `local.hosts` values in `tilt_config.json`.
+For local contexts, backend images are built with Bazel and are not pushed to a registry. OrbStack and Docker Desktop use the daemon-sharing path, while kind and minikube run an image-load step after each backend image build (`kind load docker-image` or `minikube image load`). If your kind cluster or minikube profile name is not obvious from the kubectl context, set `local_cluster_name` in `tilt_config.json` or `TADOKU_LOCAL_CLUSTER_NAME`. The cluster type is inferred from the context name; accepted `local_cluster_type` values are `kind`, `minikube`, and the daemon-sharing types `orbstack`, `docker-desktop`, `shared-daemon`, and `none` (the last two skip the image-load step for any other daemon-sharing runtime). Access the environment using the `local.hosts` values in `tilt_config.json`.
 
 ### Option B: Shared lab cluster (`dev-lab`)
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -24,14 +24,25 @@ We use [Tilt](https://tilt.dev/) to deploy all our backend services & dependenci
 
 ### Option A: Local cluster
 
-Run a local Kubernetes cluster and select its kubectl context. Tilt uses `orbstack` by default for local development; set `local_k8s_context` in `tilt_config.json` when your local context has another name (the `TADOKU_LOCAL_K8S_CONTEXT` environment variable overrides it):
+Run a local Kubernetes cluster and select its kubectl context. Tilt uses `orbstack` by default for local development. For a persistent local override, set the context and cluster type in `tilt_config.json`:
+
+```json
+{
+  "local_k8s_context": "kind-tadoku",
+  "local_cluster_type": "kind",
+  "local_cluster_name": "tadoku"
+}
+```
+
+Environment variables still work for one-off runs and take precedence over the file:
 
 ```sh
 kubectl config use-context docker-desktop
-# and in tilt_config.json: "local_k8s_context": "docker-desktop"
+export TADOKU_LOCAL_K8S_CONTEXT=docker-desktop
+export TADOKU_LOCAL_CLUSTER_TYPE=docker-desktop
 ```
 
-Built images stay in your local docker daemon. Because backend images are built with Bazel and never pushed to a registry for local contexts, the cluster must be able to run images straight from the host Docker daemon (e.g. OrbStack or Docker Desktop). Clusters with their own container runtime, such as kind or minikube, would need an extra image-load step (e.g. `kind load`) that is not supported yet. Access the environment using the `local.hosts` values in `tilt_config.json`.
+For local contexts, backend images are built with Bazel and are not pushed to a registry. OrbStack and Docker Desktop use the daemon-sharing path, while kind and minikube run an image-load step after each backend image build (`kind load docker-image` or `minikube image load`). If your kind cluster or minikube profile name is not obvious from the kubectl context, set `local_cluster_name` in `tilt_config.json` or `TADOKU_LOCAL_CLUSTER_NAME`. The cluster type is inferred from the context name; accepted `local_cluster_type` values are `kind`, `minikube`, and the daemon-sharing types `orbstack`, `docker-desktop`, `shared-daemon`, and `none`. Access the environment using the `local.hosts` values in `tilt_config.json`.
 
 ### Option B: Shared lab cluster (`dev-lab`)
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -42,6 +42,8 @@ export TADOKU_LOCAL_K8S_CONTEXT=docker-desktop
 export TADOKU_LOCAL_CLUSTER_TYPE=docker-desktop
 ```
 
+When `TADOKU_LOCAL_K8S_CONTEXT` is set, the `local_cluster_type` and `local_cluster_name` values from `tilt_config.json` are ignored (they describe the file's own context, not the override); set the matching `TADOKU_LOCAL_CLUSTER_TYPE`/`TADOKU_LOCAL_CLUSTER_NAME` env vars or rely on inference from the context name. If the type is inferred as `shared-daemon`, Tilt prints a warning since locally built images will not be loaded into the cluster.
+
 For local contexts, backend images are built with Bazel and are not pushed to a registry. OrbStack and Docker Desktop use the daemon-sharing path, while kind and minikube run an image-load step after each backend image build (`kind load docker-image` or `minikube image load`). If your kind cluster or minikube profile name is not obvious from the kubectl context, set `local_cluster_name` in `tilt_config.json` or `TADOKU_LOCAL_CLUSTER_NAME`. The cluster type is inferred from the context name; accepted `local_cluster_type` values are `kind`, `minikube`, and the daemon-sharing types `orbstack`, `docker-desktop`, `shared-daemon`, and `none` (the last two skip the image-load step for any other daemon-sharing runtime). Access the environment using the `local.hosts` values in `tilt_config.json`.
 
 ### Option B: Shared lab cluster (`dev-lab`)

--- a/infra/dev/build/Tiltfile
+++ b/infra/dev/build/Tiltfile
@@ -1,25 +1,69 @@
-load('./../../../k8s/dev/config/Tiltfile', 'is_shared_cluster', 'shared_k8s_context')
+load('./../../../k8s/dev/config/Tiltfile', 'is_shared_cluster', 'local_cluster_name', 'local_cluster_type', 'repo_path')
+
+def _sh_quote(value):
+  return "'" + value.replace("'", "'\"'\"'") + "'"
+
+def _local_image_load_command(image_ref):
+  if local_cluster_type == 'kind':
+    command = 'kind load docker-image'
+    if local_cluster_name:
+      command += ' --name ' + _sh_quote(local_cluster_name)
+    return command + ' ' + image_ref
+
+  if local_cluster_type == 'minikube':
+    command = 'minikube'
+    if local_cluster_name:
+      command += ' -p ' + _sh_quote(local_cluster_name)
+    return command + ' image load ' + image_ref
+
+  if local_cluster_type in ['orbstack', 'docker-desktop', 'shared-daemon', 'none', '']:
+    return ''
+
+  fail('unsupported local_cluster_type %r; expected kind, minikube, or a daemon-sharing type' % local_cluster_type)
 
 def bazel_build(image, target, deps):
   dest = target.replace('//', 'bazel/').replace(':load', ":latest")
   command = (
-    'bazel run --platforms=@rules_go//go/toolchain:linux_amd64 {image_target} && ' +
-    'docker tag {bazel_image} $EXPECTED_REF').format(
+    'bazel run --platforms=@rules_go//go/toolchain:linux_amd64 {image_target}').format(
       image_target=target,
-      bazel_image=dest,
     )
 
   push_to_registry = is_shared_cluster()
+  output_ref_file = ''
   if push_to_registry:
+    command += ' && docker tag {bazel_image} $EXPECTED_REF'.format(bazel_image=dest)
     # Normalize Bazel-loaded image metadata before Tilt pushes to Zot.
     command += (
       ' && cid=$(docker create $EXPECTED_REF)' +
       ' && { docker commit "$cid" $EXPECTED_REF >/dev/null; status=$?;' +
       ' docker rm "$cid" >/dev/null; exit $status; }')
+  else:
+    load_command = _local_image_load_command('"$ref"')
+    if load_command:
+      command += (
+        ' && ref={image}:tilt-$(docker image inspect --format="{{{{.Id}}}}" {bazel_image}' +
+        ' | sed "s/^sha256://" | cut -c1-16)' +
+        ' && docker tag {bazel_image} "$ref"').format(
+          image=image,
+          bazel_image=dest,
+        )
+      command += ' && ' + load_command
+      output_ref_file = repo_path('tmp/tilt-' + image + '-ref')
+      command += (
+        ' && mkdir -p ' + _sh_quote(os.path.dirname(output_ref_file)) +
+        ' && printf "%s" "$ref" > ' + _sh_quote(output_ref_file)
+      )
+    else:
+      command += ' && docker tag {bazel_image} $EXPECTED_REF'.format(bazel_image=dest)
+
+  build_kwargs = {}
+  if output_ref_file:
+    build_kwargs['outputs_image_ref_to'] = output_ref_file
 
   custom_build(
     ref=image,
     disable_push=not push_to_registry,
     command=command,
     deps=deps,
-)
+    **build_kwargs
+  )

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -14,6 +14,34 @@ tilt_config = read_json(config_path)
 shared_k8s_context = os.getenv('TADOKU_SHARED_K8S_CONTEXT', '') or tilt_config.get('shared_k8s_context', 'dev-lab')
 local_k8s_context = os.getenv('TADOKU_LOCAL_K8S_CONTEXT', '') or tilt_config.get('local_k8s_context', 'orbstack')
 
+def _default_local_cluster_type(context):
+    context = context.lower()
+    if context == 'orbstack' or context == 'docker-desktop':
+        return context
+    if context == 'kind' or context.startswith('kind-'):
+        return 'kind'
+    if context == 'minikube' or context.startswith('minikube-'):
+        return 'minikube'
+    return 'shared-daemon'
+
+def _default_local_cluster_name(cluster_type, context):
+    if cluster_type == 'kind' and context.startswith('kind-'):
+        return context[len('kind-'):]
+    if cluster_type == 'minikube' and context != 'minikube':
+        return context
+    return ''
+
+local_cluster_type = (
+    os.getenv('TADOKU_LOCAL_CLUSTER_TYPE', '') or
+    tilt_config.get('local_cluster_type', '') or
+    _default_local_cluster_type(local_k8s_context)
+).lower()
+local_cluster_name = (
+    os.getenv('TADOKU_LOCAL_CLUSTER_NAME', '') or
+    tilt_config.get('local_cluster_name', '') or
+    _default_local_cluster_name(local_cluster_type, local_k8s_context)
+)
+
 def is_shared_cluster():
     return k8s_context() == shared_k8s_context
 

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -6,13 +6,15 @@ def repo_path(path):
     return os.path.join(repo_root, path)
 
 config_path = repo_path('tilt_config.json')
-if not os.path.exists(config_path):
+user_config_exists = os.path.exists(config_path)
+if not user_config_exists:
     config_path = repo_path('tilt_config.json.example')
 
 tilt_config = read_json(config_path)
 
 shared_k8s_context = os.getenv('TADOKU_SHARED_K8S_CONTEXT', '') or tilt_config.get('shared_k8s_context', 'dev-lab')
-local_k8s_context = os.getenv('TADOKU_LOCAL_K8S_CONTEXT', '') or tilt_config.get('local_k8s_context', 'orbstack')
+local_k8s_context_env = os.getenv('TADOKU_LOCAL_K8S_CONTEXT', '')
+local_k8s_context = local_k8s_context_env or tilt_config.get('local_k8s_context', 'orbstack')
 
 def _default_local_cluster_type(context):
     context = context.lower()
@@ -33,12 +35,12 @@ def _default_local_cluster_name(cluster_type, context):
 
 local_cluster_type = (
     os.getenv('TADOKU_LOCAL_CLUSTER_TYPE', '') or
-    tilt_config.get('local_cluster_type', '') or
+    ('' if local_k8s_context_env else tilt_config.get('local_cluster_type', '')) or
     _default_local_cluster_type(local_k8s_context)
 ).lower()
 local_cluster_name = (
     os.getenv('TADOKU_LOCAL_CLUSTER_NAME', '') or
-    tilt_config.get('local_cluster_name', '') or
+    ('' if local_k8s_context_env else tilt_config.get('local_cluster_name', '')) or
     _default_local_cluster_name(local_cluster_type, local_k8s_context)
 )
 

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -29,15 +29,27 @@ def _default_local_cluster_type(context):
 def _default_local_cluster_name(cluster_type, context):
     if cluster_type == 'kind' and context.startswith('kind-'):
         return context[len('kind-'):]
-    if cluster_type == 'minikube' and context != 'minikube':
-        return context
+    if cluster_type == 'minikube':
+        if context.startswith('minikube-'):
+            return context[len('minikube-'):]
+        if context != 'minikube':
+            return context
     return ''
 
-local_cluster_type = (
+_explicit_local_cluster_type = (
     os.getenv('TADOKU_LOCAL_CLUSTER_TYPE', '') or
-    ('' if local_k8s_context_env else tilt_config.get('local_cluster_type', '')) or
+    ('' if local_k8s_context_env else tilt_config.get('local_cluster_type', ''))
+)
+local_cluster_type = (
+    _explicit_local_cluster_type or
     _default_local_cluster_type(local_k8s_context)
 ).lower()
+if not _explicit_local_cluster_type and local_cluster_type == 'shared-daemon':
+    warn((
+        'local_cluster_type inferred as "shared-daemon" for context "{}"; ' +
+        'locally built images will not be loaded into the cluster. ' +
+        'Set TADOKU_LOCAL_CLUSTER_TYPE or local_cluster_type in tilt_config.json if this is wrong.'
+    ).format(local_k8s_context))
 local_cluster_name = (
     os.getenv('TADOKU_LOCAL_CLUSTER_NAME', '') or
     ('' if local_k8s_context_env else tilt_config.get('local_cluster_name', '')) or

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -1,6 +1,8 @@
 {
   "shared_k8s_context": "dev-lab",
   "local_k8s_context": "orbstack",
+  "local_cluster_type": "orbstack",
+  "local_cluster_name": "",
   "local": {
     "ingress_class": "kong",
     "registry": "",


### PR DESCRIPTION
This rebases the local image-loading work onto the Phase 5 dev-environment structure while keeping main's templated `k8s/dev` layout intact. Tilt now loads Bazel-built backend images into kind/minikube local clusters and leaves daemon-sharing local runtimes plus the shared registry path unchanged.

- Keeps local/shared config centralized in `k8s/dev/config/Tiltfile`, including `local_cluster_type` and `local_cluster_name`.
- Uses content-tagged local image refs with `kind load docker-image` or `minikube image load`, then passes Tilt the exact loaded ref.
- Preserves Phase 5 templated manifests and documents the config precedence and supported local cluster types.

## Pipeline validation record (no-mistakes)

<details>
<summary>Evidence</summary>

- Run `01KWSESFB554JAJVTMQE1EZ8HM` reached `checks-passed` for PR #691.
- Review fixes applied by the pipeline: strip inferred `minikube-` profile prefixes and warn when an unknown local context infers `shared-daemon`.
- Pipeline steps completed: rebase, review, test, document, lint, push, PR, and CI monitoring.
- Local rebase verification: focused `token-reflector` Tilt CI against a disposable real kind cluster built, loaded, deployed, and reached healthy.
- GitHub reports no repository CI checks configured for this PR.

</details>
