### PR TITLE
chore(infra): scrub homelab identifiers from dev config and harden kubeconfig.sh

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -1,4 +1,5 @@
 TADOKU_DEV_K3S_HOST=cluster-node.example.invalid
 TADOKU_DEV_K3S_SSH_TARGET=user@cluster-node.example.invalid
 TADOKU_DEV_K3S_TLS_SERVER_NAME=cluster-node
-TADOKU_DEV_KUBECONFIG=${HOME}/.kube/dev-lab.yaml
+TADOKU_DEV_K8S_CONTEXT=shared-context
+TADOKU_DEV_KUBECONFIG=${HOME}/.kube/shared-context.yaml

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,10 +1,13 @@
 # -*- mode: Python -*-
 
-load('./k8s/dev/config/Tiltfile', 'dev_registry', 'local_k8s_context', 'shared_k8s_context')
+load('./k8s/dev/config/Tiltfile', 'dev_registry', 'is_shared_cluster', 'local_k8s_context', 'shared_k8s_context')
 
-allow_k8s_contexts([local_k8s_context, shared_k8s_context])
+allowed_k8s_contexts = [local_k8s_context]
+if shared_k8s_context != '':
+    allowed_k8s_contexts.append(shared_k8s_context)
+allow_k8s_contexts(allowed_k8s_contexts)
 
-if k8s_context() == shared_k8s_context:
+if is_shared_cluster():
     # Shared cluster: images are pushed to the registry configured in tilt_config.json.
     default_registry(dev_registry())
 else:

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -50,7 +50,7 @@ For local contexts, backend images are built with Bazel and are not pushed to a 
 
 Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the platform TLS certificate once available) before Tilt can push images.
 
-Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only. The context keys can also be set via environment variables (`shared_k8s_context` → `TADOKU_SHARED_K8S_CONTEXT`, `local_k8s_context` → `TADOKU_LOCAL_K8S_CONTEXT`); environment variables take precedence over `tilt_config.json`.
+Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only. The context keys can also be set via environment variables (`shared_k8s_context` → `TADOKU_SHARED_K8S_CONTEXT`, `local_k8s_context` → `TADOKU_LOCAL_K8S_CONTEXT`); environment variables take precedence over `tilt_config.json`. Shared-cluster mode stays disabled until a shared context is configured via `shared_k8s_context` or `TADOKU_SHARED_K8S_CONTEXT`; there is no committed default.
 
 Fetch the dev-cluster kubeconfig after creating `infra/dev/.env.local` from `infra/dev/.env.example`:
 
@@ -62,7 +62,7 @@ export KUBECONFIG="$HOME/.kube/<shared-context>.yaml"
 kubectl get nodes
 ```
 
-The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), context (`TADOKU_DEV_K8S_CONTEXT`), read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) can be set in `infra/dev/.env.local` or as environment variables; environment variables take precedence over `.env.local`. Set `TADOKU_DEV_KUBECONFIG_ENV` to read the env file from a different path.
+The script reads `/etc/rancher/k3s/k3s.yaml` from `TADOKU_DEV_K3S_SSH_TARGET`, rewrites the API server to `https://$TADOKU_DEV_K3S_HOST:6443`, sets the context to `TADOKU_DEV_K8S_CONTEXT`, and stores the result as `~/.kube/<shared-context>.yaml` unless `TADOKU_DEV_KUBECONFIG` or a destination argument is provided. The host (`TADOKU_DEV_K3S_HOST`), SSH target (`TADOKU_DEV_K3S_SSH_TARGET`), and context (`TADOKU_DEV_K8S_CONTEXT`, falling back to `TADOKU_SHARED_K8S_CONTEXT`) are required and the script exits with an error if any is unset. The read command (`TADOKU_DEV_K3S_READ_CMD`), TLS server name (`TADOKU_DEV_K3S_TLS_SERVER_NAME`), and output path (`TADOKU_DEV_KUBECONFIG`) are optional. All of these can be set in `infra/dev/.env.local` or as environment variables; environment variables take precedence over `.env.local`. Set `TADOKU_DEV_KUBECONFIG_ENV` to read the env file from a different path.
 
 Built images are pushed to `shared.registry` from `tilt_config.json`. The app and auth/admin hostnames come from the `shared.hosts` block.
 

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -12,7 +12,7 @@ if not user_config_exists:
 
 tilt_config = read_json(config_path)
 
-shared_k8s_context = os.getenv('TADOKU_SHARED_K8S_CONTEXT', '') or tilt_config.get('shared_k8s_context', 'dev-lab')
+shared_k8s_context = os.getenv('TADOKU_SHARED_K8S_CONTEXT', '') or tilt_config.get('shared_k8s_context', '')
 local_k8s_context_env = os.getenv('TADOKU_LOCAL_K8S_CONTEXT', '')
 local_k8s_context = local_k8s_context_env or tilt_config.get('local_k8s_context', 'orbstack')
 
@@ -57,7 +57,7 @@ local_cluster_name = (
 )
 
 def is_shared_cluster():
-    return k8s_context() == shared_k8s_context
+    return shared_k8s_context != '' and k8s_context() == shared_k8s_context
 
 def selected_environment():
     if is_shared_cluster():
@@ -69,7 +69,7 @@ def selected_config():
 
 def dev_registry():
     registry = selected_config().get('registry', '')
-    if is_shared_cluster() and (registry == '' or registry.endswith('.example.invalid')):
+    if is_shared_cluster() and (registry == '' or registry.endswith('.example') or registry.endswith('.example.invalid')):
         fail('copy tilt_config.json.example to tilt_config.json and set shared.registry for the shared dev cluster')
     return registry
 

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -68,7 +68,7 @@ def selected_config():
     return tilt_config.get(selected_environment(), {})
 
 def dev_registry():
-    registry = selected_config().get('registry', '')
+    registry = os.getenv('TADOKU_DEV_REGISTRY_HOST', '') or selected_config().get('registry', '')
     if is_shared_cluster() and (registry == '' or registry.endswith('.example') or registry.endswith('.example.invalid')):
         fail('copy tilt_config.json.example to tilt_config.json and set shared.registry for the shared dev cluster')
     return registry

--- a/tilt_config.json.example
+++ b/tilt_config.json.example
@@ -1,5 +1,5 @@
 {
-  "shared_k8s_context": "dev-lab",
+  "shared_k8s_context": "<shared-context>",
   "local_k8s_context": "orbstack",
   "local_cluster_type": "orbstack",
   "local_cluster_name": "",
@@ -15,7 +15,7 @@
   },
   "shared": {
     "ingress_class": "nginx",
-    "registry": "registry.example.invalid",
+    "registry": "registry.internal.example",
     "hosts": {
       "app": "tadoku.example.invalid",
       "auth": "account.tadoku.example.invalid",


### PR DESCRIPTION
## What Changed

- Replaced homelab-specific hostnames, registry hosts, and kube context names across `Tiltfile`, `k8s/dev/config/Tiltfile`, and the example config files (`.env.local.example`, `tilt_config.json.example`) with placeholders, moving real values into ignored local config.
- Reworked `infra/dev/kubeconfig.sh` to load `.env.local` line-by-line without `eval`/`source` (closing a shell-injection path flagged in review), added a `TADOKU_SHARED_K8S_CONTEXT` fallback, and clarified the missing-context error message.
- Updated `docs/docs/local-environment.md` to document the required kubeconfig env vars, the new dev-env config knobs, and the shared-cluster opt-in.

## Risk Assessment

✅ Low: Dev-tooling-only change; the previously flagged eval issue is fixed with a non-executing assignment that preserves env precedence, and the rest of the diff is well-bounded config/docs scrubbing.

## Testing

Exercised infra/dev/kubeconfig.sh end-to-end with a stubbed ssh (4 scenarios: .env.local load, env-var override + arg output path, missing-var error, shared-context fallback), including a command-substitution injection probe that confirmed the eval-free loader is safe; evaluated k8s/dev/config/Tiltfile via tilt alpha tiltfile-result in 3 scenarios confirming empty-shared-context default, env overrides for shared context/registry, and placeholder-registry hard fail; grepped the repo to confirm no dev-lab/homelab identifiers remain. All checks passed; no UI surface exists, so evidence is CLI transcripts.

<details>
<summary>Evidence: kubeconfig.sh end-to-end transcript (4 scenarios + injection probe)</summary>

```text
=== Run 1: kubeconfig.sh with .env.local (TADOKU_DEV_KUBECONFIG_ENV), stubbed ssh ===
ssh-stub: called with: op@my-cluster.internal.example sudo cat /etc/rancher/k3s/k3s.yaml
wrote /var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/home/.kube/my-shared-dev.yaml
use: export KUBECONFIG=/var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/home/.kube/my-shared-dev.yaml

--- resulting kubeconfig ---
apiVersion: v1
clusters:
- cluster:
    server: https://my-cluster.internal.example:6443
    tls-server-name: my-cluster
  name: default
contexts:
- context:
    cluster: default
    user: default
  name: my-shared-dev
current-context: my-shared-dev
kind: Config
users:
- name: default
  user:
    token: fake-token
--- file mode: 600 ---
--- injection probe: OK: $(...) in env file was NOT executed ---

=== Run 2: explicit env var overrides .env.local context; output path as arg ===
ssh-stub: called with: op@my-cluster.internal.example sudo cat /etc/rancher/k3s/k3s.yaml
wrote /var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/out-arg.yaml
use: export KUBECONFIG=/var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/out-arg.yaml
override-ctx

=== Run 3: missing required vars -> clear error ===
TADOKU_DEV_K3S_HOST is required; set it in the environment or /var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/nonexistent.env
(exit 1)

=== Run 4: context supplied via TADOKU_SHARED_K8S_CONTEXT fallback ===
ssh-stub: called with: u@h.example sudo cat /etc/rancher/k3s/k3s.yaml
wrote /var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/home/.kube/fallback-ctx.yaml
use: export KUBECONFIG=/var/folders/9n/wt3rlxms7w31ymtsshyj4mlr0000gn/T/tmp.EBEEPNqZNt/home/.kube/fallback-ctx.yaml
fallback-ctx
```
</details>
<details>
<summary>Evidence: Tilt config module evaluation (3 scenarios)</summary>

```text
=== Scenario A: defaults (committed tilt_config.json.example, no local config) — no shared context leaks; shared mode off even though kube context is my-shared-dev ===
shared_k8s_context=<shared-context>
local_k8s_context=orbstack
k8s_context=my-shared-dev
is_shared_cluster=False
dev_registry=<empty>

=== Scenario B: operator sets TADOKU_SHARED_K8S_CONTEXT=my-shared-dev and TADOKU_DEV_REGISTRY_HOST=registry.mylab.lan via env ===
shared_k8s_context=my-shared-dev
local_k8s_context=orbstack
k8s_context=my-shared-dev
is_shared_cluster=True
dev_registry=registry.mylab.lan

=== Scenario C: shared cluster selected but registry left as committed placeholder (registry.internal.example) -> hard fail ===
Error in fail: copy tilt_config.json.example to tilt_config.json and set shared.registry for the shared dev cluster
```
</details>

## Pipeline

Updates from [git push no-mistakes](https://github.com/kunchenguid/no-mistakes)

<details>
<summary>⏭️ **intent** - skipped</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Rebase** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>🔧 **Review** - 4 issues found → auto-fixed ✅</summary>

- ⚠️ `infra/dev/kubeconfig.sh:16` - load_env_file evals each assignment line; a value with unquoted spaces (FOO=a b) executes the remainder as a command and command substitution in values runs arbitrary code. Same trust level as the previous `source`, but the new line-by-line parser gives a false sense of validation — use printf -v &#34;$name&#34; or declare to assign without execution.
- ℹ️ `infra/dev/kubeconfig.sh:67` - Context name is interpolated into the kubectl jsonpath expression; a context containing a double quote breaks the query. Operator-controlled local config, so low impact.
- ℹ️ `infra/dev/kubeconfig.sh:36` - The missing-context error only mentions TADOKU_DEV_K8S_CONTEXT even though TADOKU_SHARED_K8S_CONTEXT is also accepted as a fallback; mentioning both would aid discovery.
- ℹ️ `infra/dev/kubeconfig.sh:8` - Env-file variables are no longer exported (old code used `set -a`). Nothing in the script currently needs them in child-process environments (ssh/kubectl use explicit args), so this is fine — noting the behavior change.

🔧 Fix: Parse .env.local without eval; clarify context error
✅ Re-checked - no issues remain.

</details>

<details>
<summary>✅ **Test** - passed</summary>

✅ No issues found.
- <code>`infra/dev/kubeconfig.sh` with stubbed `ssh`: .env.local loading via `TADOKU_DEV_KUBECONFIG_ENV`, context rename, server/TLS rewrite, mode-600 output</code>
- <code>`infra/dev/kubeconfig.sh` env-var precedence over .env.local and output-path argument</code>
- <code>`infra/dev/kubeconfig.sh` missing-required-var error and `TADOKU_SHARED_K8S_CONTEXT` fallback</code>
- <code>Shell-injection probe: `$(touch ...)` in .env.local not executed by the loader</code>
- <code>`tilt alpha tiltfile-result` on k8s/dev/config/Tiltfile: default example config (shared mode off), `TADOKU_SHARED_K8S_CONTEXT`/`TADOKU_DEV_REGISTRY_HOST` overrides, placeholder-registry hard fail</code>
- <code>`grep -rniE &#39;dev-lab|homelab&#39; .` confirming scrub of homelab identifiers</code>

</details>

<details>
<summary>✅ **Document** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Lint** - passed</summary>

✅ No issues found.

</details>

<details>
<summary>✅ **Push** - passed</summary>

✅ No issues found.

</details>
