### PR TITLE
ci: serialize docs pages deployments

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -14,7 +14,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-deploy
   cancel-in-progress: false
 
 jobs:


### PR DESCRIPTION
Make the docs deployment workflow queue GitHub Pages publishes under a dedicated concurrency group. We are intentionally not adding a retry: the observed failures were tied to rapid consecutive merges, and retries would hide new deployment failures if the problem changes.

## Pipeline validation record (no-mistakes)

<details>
<summary>Evidence</summary>

- Branch: `fm/docs-deploy-fix-c2`
- Commit: `e6c64a5d`
- Scope: only `.github/workflows/deploy-docs.yaml`
- Workflow validation: actionlint passed; YAML parsed successfully.
- Pages pattern review: required `pages: write` and `id-token: write` permissions plus the `github-pages` environment were already aligned.
- Review/test gates noted that the previous group already serialized this workflow; approved by decision because concurrency-only is the intended fix and no retry should be added.
- Completed no-mistakes steps: intent, rebase, review, test, document, lint, push, PR, CI.
- Outcome: checks passed.

</details>
