### PR TITLE
build: restore gazelle-managed BUILD files and add CI staleness check

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -31,6 +31,9 @@ jobs:
           path: "/home/runner/.cache/bazel"
           key: bazel-v4-${{ hashFiles('go.mod', 'go.sum', 'MODULE.bazel') }}
 
+      - name: Verify Gazelle
+        run: bazel run //:gazelle -- -mode=diff
+
       - name: Build
         run: bazel build //...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,6 +65,7 @@ bazel test //services/immersion-api/domain/command:command_test --test_filter=Te
 gofmt -w services/
 
 # 5. Regenerate BUILD.bazel files (after adding/removing Go files or changing deps/imports)
+# CI fails if these are stale (it runs `bazel run //:gazelle -- -mode=diff`)
 bazel run //:gazelle
 
 # 6. Regenerate sqlc code (after modifying SQL queries)

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -29,3 +29,5 @@ $ bazel test //...
 ```sh
 bazel run //:gazelle
 ```
+
+CI verifies that BUILD files are up to date with `bazel run //:gazelle -- -mode=diff`, so run this after adding or removing Go files or changing imports.

--- a/services/authz-api/domain/BUILD.bazel
+++ b/services/authz-api/domain/BUILD.bazel
@@ -2,10 +2,15 @@ load("@rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "domain",
-    srcs = glob(
-        ["*.go"],
-        exclude = ["*_test.go"],
-    ),
+    srcs = [
+        "allowlist.go",
+        "moderationaudit.go",
+        "permissioncheck_internal.go",
+        "permissioncheck_public.go",
+        "relationshipwrite.go",
+        "roleget.go",
+        "roleupdate.go",
+    ],
     importpath = "github.com/tadoku/tadoku/services/authz-api/domain",
     visibility = ["//visibility:public"],
     deps = [
@@ -18,7 +23,10 @@ go_library(
 
 go_test(
     name = "domain_test",
-    srcs = glob(["*_test.go"]),
+    srcs = [
+        "permissioncheck_public_test.go",
+        "roleupdate_test.go",
+    ],
     deps = [
         ":domain",
         "//services/common/authz/roles",

--- a/services/authz-api/http/rest/BUILD.bazel
+++ b/services/authz-api/http/rest/BUILD.bazel
@@ -2,7 +2,15 @@ load("@rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "rest",
-    srcs = glob(["*.go"]),
+    srcs = [
+        "errors.go",
+        "server.go",
+        "server_internal.go",
+        "server_permissioncheck.go",
+        "server_ping.go",
+        "server_roleget.go",
+        "server_roleupdate.go",
+    ],
     importpath = "github.com/tadoku/tadoku/services/authz-api/http/rest",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
Repair Gazelle as the BUILD-file maintenance tool for audit finding 3.

This replaces the authz Go source globs that Gazelle could not merge with explicit source lists. I used explicit lists instead of Gazelle directives because this repo already favors Gazelle-managed Go target metadata, and explicit Go source lists keep `gazelle -mode=fix` and `gazelle -mode=diff` able to maintain the BUILD files directly.

The Bazel workflow now runs `bazel run //:gazelle -- -mode=diff` before build/test so BUILD-file drift fails CI. The grouped `oci_push` and cache-key cleanup noted by review are intentionally out of scope and handled by the parallel `bazel-ci-cleanup` crew.

## Pipeline validation record (no-mistakes)

<details>
<summary>Evidence</summary>

- no-mistakes run: `01KWSQCD9X4YMPMA3TH92Y1NZD`
- PR: https://github.com/tadoku/tadoku/pull/696
- Review gate: approved `review-1` after firstmate confirmed grouped `oci_push` and cache-key work is intentionally split out.
- Pipeline steps completed: intent, rebase, review, test, document, lint, push, PR.
- CI outcome: checks passed.
- Local pre-pipeline verification: `bazel run //:gazelle -- -mode=diff`, `bazel build //...`, `bazel test //...`.

</details>
