### PR TITLE
ci: group bazel image pushes into a single guarded push_images target

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -23,13 +23,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup cache
         uses: actions/cache@v4
         with:
           path: "/home/runner/.cache/bazel"
-          key: bazel-v4-${{ hashFiles('go.mod', 'go.sum', 'MODULE.bazel') }}
+          key: bazel-v5-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'go.mod', 'go.sum') }}
 
       - name: Build
         run: bazel build //...
@@ -44,13 +44,13 @@ jobs:
     if: github.ref == 'refs/heads/main'
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup cache
         uses: actions/cache@v4
         with:
           path: "/home/runner/.cache/bazel"
-          key: bazel-v4-${{ hashFiles('go.mod', 'go.sum', 'MODULE.bazel') }}
+          key: bazel-v5-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'go.mod', 'go.sum') }}
 
       - name: Push images
         run: |
@@ -60,6 +60,4 @@ jobs:
           cp /home/runner/.docker/config.json /tmp/docker/config.json
 
           # Push images
-          for target in $(bazel query 'kind("oci_push", //services/...)'); do
-            bazel run "$target"
-          done
+          bazel run //:push_images

--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -8,6 +8,7 @@ on:
   push:
     paths:
       - "services/**"
+      - "tools/ci/**"
       - "BUILD.bazel"
       - ".bazelversion"
       - ".bazelrc"
@@ -33,6 +34,13 @@ jobs:
 
       - name: Build
         run: bazel build //...
+
+      - name: Check push_images covers all oci_push targets
+        run: |
+          diff \
+            <(bazel query 'kind("oci_push", //services/...)' | sort) \
+            <(bazel query 'labels(data, //:push_images)' | sort) \
+          || { echo "//:push_images is out of sync with oci_push targets under //services/..." >&2; exit 1; }
 
       - name: Run tests
         run: bazel test //...

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,6 +3,9 @@ load("@gazelle//:def.bzl", "gazelle")
 # gazelle:prefix github.com/tadoku/tadoku
 gazelle(name = "gazelle")
 
+# Pushes all service images in one `bazel run //:push_images` invocation.
+# Used by CI (.github/workflows/build-bazel.yaml); add new oci_push targets
+# to both args and data below.
 sh_binary(
     name = "push_images",
     srcs = ["tools/ci/push_bazel_images.sh"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,3 +2,22 @@ load("@gazelle//:def.bzl", "gazelle")
 
 # gazelle:prefix github.com/tadoku/tadoku
 gazelle(name = "gazelle")
+
+sh_binary(
+    name = "push_images",
+    srcs = ["tools/ci/push_bazel_images.sh"],
+    args = [
+        "$(rlocationpath //services/authz-api:push)",
+        "$(rlocationpath //services/content-api:push)",
+        "$(rlocationpath //services/immersion-api:push)",
+        "$(rlocationpath //services/profile-api:push)",
+        "$(rlocationpath //services/token-reflector:push)",
+    ],
+    data = [
+        "//services/authz-api:push",
+        "//services/content-api:push",
+        "//services/immersion-api:push",
+        "//services/profile-api:push",
+        "//services/token-reflector:push",
+    ],
+)

--- a/services/authz-api/BUILD.bazel
+++ b/services/authz-api/BUILD.bazel
@@ -60,4 +60,5 @@ oci_push(
     image = ":image",
     remote_tags = ["latest"],
     repository = "ghcr.io/tadoku/tadoku/authz-api",
+    visibility = ["//visibility:public"],
 )

--- a/services/content-api/BUILD.bazel
+++ b/services/content-api/BUILD.bazel
@@ -61,4 +61,5 @@ oci_push(
     image = ":image",
     remote_tags = ["latest"],
     repository = "ghcr.io/tadoku/tadoku/content-api",
+    visibility = ["//visibility:public"],
 )

--- a/services/immersion-api/BUILD.bazel
+++ b/services/immersion-api/BUILD.bazel
@@ -64,4 +64,5 @@ oci_push(
     image = ":image",
     remote_tags = ["latest"],
     repository = "ghcr.io/tadoku/tadoku/immersion-api",
+    visibility = ["//visibility:public"],
 )

--- a/services/profile-api/BUILD.bazel
+++ b/services/profile-api/BUILD.bazel
@@ -59,4 +59,5 @@ oci_push(
     image = ":image",
     remote_tags = ["latest"],
     repository = "ghcr.io/tadoku/tadoku/profile-api",
+    visibility = ["//visibility:public"],
 )

--- a/services/token-reflector/BUILD.bazel
+++ b/services/token-reflector/BUILD.bazel
@@ -41,4 +41,5 @@ oci_push(
     image = ":image",
     remote_tags = ["latest"],
     repository = "ghcr.io/tadoku/tadoku/token-reflector",
+    visibility = ["//visibility:public"],
 )

--- a/tools/ci/push_bazel_images.sh
+++ b/tools/ci/push_bazel_images.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+#
+# Runs a list of oci_push binaries (passed as runfiles paths in "$@") so all
+# service images are pushed in a single `bazel run //:push_images` invocation,
+# instead of one bazel analysis per image. Invoked by CI in
+# .github/workflows/build-bazel.yaml; each push is wrapped in a GitHub Actions
+# log group.
 set -euo pipefail
 
 if [[ -n "${RUNFILES_DIR:-}" && -f "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then

--- a/tools/ci/push_bazel_images.sh
+++ b/tools/ci/push_bazel_images.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -n "${RUNFILES_DIR:-}" && -f "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
+  # shellcheck source=/dev/null
+  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
+elif [[ -n "${RUNFILES_MANIFEST_FILE:-}" && -f "${RUNFILES_MANIFEST_FILE}" ]]; then
+  # shellcheck source=/dev/null
+  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " "${RUNFILES_MANIFEST_FILE}" | cut -d' ' -f2-)"
+fi
+
+resolve_runfile() {
+  local path="$1"
+  local resolved=""
+
+  if command -v rlocation >/dev/null 2>&1; then
+    resolved="$(rlocation "${path}")"
+    if [[ -n "${resolved}" && -x "${resolved}" ]]; then
+      echo "${resolved}"
+      return 0
+    fi
+  fi
+
+  if [[ -x "${path}" ]]; then
+    echo "${path}"
+    return 0
+  fi
+
+  if [[ -x "../${path}" ]]; then
+    echo "../${path}"
+    return 0
+  fi
+
+  return 1
+}
+
+for pusher in "$@"; do
+  if ! resolved_pusher="$(resolve_runfile "${pusher}")"; then
+    echo "could not resolve ${pusher}" >&2
+    exit 1
+  fi
+
+  echo "::group::${pusher}"
+  "${resolved_pusher}"
+  echo "::endgroup::"
+done


### PR DESCRIPTION
## Intent

This PR cleans up Bazel image publishing for audit finding 5. CI now uses one guarded `//:push_images` invocation instead of querying and running each `oci_push` target separately, and the Bazel cache key now includes the Bazel and module inputs that affect reuse.

The image rules stay as they are. A dev-cluster remote cache is not built here; it would need an authenticated cache service, retention policy, monitoring, and a rollout plan before any pilot.

## Pipeline validation record (no-mistakes)

<details>
<summary>Evidence</summary>

- Run: `01KWTD9CGSGRWE710DWBCBRSWH`
- Branch: `fm/bazel-ci-cleanup`
- Head: `9f130378`
- PR: `https://github.com/tadoku/tadoku/pull/698`
- Review: completed; pipeline fixed the original drift risk by guarding `//:push_images` coverage and added CI triggering for `tools/ci` changes.
- Test: completed.
- Document: completed.
- Lint: completed.
- Push: completed.
- PR: completed.
- CI: checks passed.
- Local pre-pipeline verification: `bazel build //...` passed; `bazel test //...` passed with 13 of 13 tests.

</details>
