### PR TITLE
ci: fix runfiles.bash resolution in the grouped image push wrapper

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -42,7 +42,7 @@ jobs:
         run: |
           diff \
             <(bazel query 'kind("oci_push", //services/...)' | sort) \
-            <(bazel query 'labels(data, //:push_images)' | sort) \
+            <(bazel query 'kind("oci_push", labels(data, //:push_images))' | sort) \
           || { echo "//:push_images is out of sync with oci_push targets under //services/..." >&2; exit 1; }
 
       - name: Run tests

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,6 +17,7 @@ sh_binary(
         "$(rlocationpath //services/token-reflector:push)",
     ],
     data = [
+        "@bazel_tools//tools/bash/runfiles",
         "//services/authz-api:push",
         "//services/content-api:push",
         "//services/immersion-api:push",

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -17,11 +17,11 @@ sh_binary(
         "$(rlocationpath //services/token-reflector:push)",
     ],
     data = [
-        "@bazel_tools//tools/bash/runfiles",
         "//services/authz-api:push",
         "//services/content-api:push",
         "//services/immersion-api:push",
         "//services/profile-api:push",
         "//services/token-reflector:push",
+        "@bazel_tools//tools/bash/runfiles",
     ],
 )

--- a/tools/ci/push_bazel_images.sh
+++ b/tools/ci/push_bazel_images.sh
@@ -8,6 +8,7 @@
 set -uo pipefail
 
 runfiles_bash="bazel_tools/tools/bash/runfiles/runfiles.bash"
+# shellcheck disable=SC1090
 source "${RUNFILES_DIR:-/dev/null}/${runfiles_bash}" 2>/dev/null || \
   source "$(grep -sm1 "^${runfiles_bash} " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -d' ' -f2-)" 2>/dev/null || \
   source "$0.runfiles/${runfiles_bash}" 2>/dev/null || \

--- a/tools/ci/push_bazel_images.sh
+++ b/tools/ci/push_bazel_images.sh
@@ -5,15 +5,17 @@
 # instead of one bazel analysis per image. Invoked by CI in
 # .github/workflows/build-bazel.yaml; each push is wrapped in a GitHub Actions
 # log group.
-set -euo pipefail
+set -uo pipefail
 
-if [[ -n "${RUNFILES_DIR:-}" && -f "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash" ]]; then
-  # shellcheck source=/dev/null
-  source "${RUNFILES_DIR}/bazel_tools/tools/bash/runfiles/runfiles.bash"
-elif [[ -n "${RUNFILES_MANIFEST_FILE:-}" && -f "${RUNFILES_MANIFEST_FILE}" ]]; then
-  # shellcheck source=/dev/null
-  source "$(grep -m1 "^bazel_tools/tools/bash/runfiles/runfiles.bash " "${RUNFILES_MANIFEST_FILE}" | cut -d' ' -f2-)"
-fi
+runfiles_bash="bazel_tools/tools/bash/runfiles/runfiles.bash"
+source "${RUNFILES_DIR:-/dev/null}/${runfiles_bash}" 2>/dev/null || \
+  source "$(grep -sm1 "^${runfiles_bash} " "${RUNFILES_MANIFEST_FILE:-/dev/null}" | cut -d' ' -f2-)" 2>/dev/null || \
+  source "$0.runfiles/${runfiles_bash}" 2>/dev/null || \
+  source "$(grep -sm1 "^${runfiles_bash} " "$0.runfiles_manifest" | cut -d' ' -f2-)" 2>/dev/null || \
+  source "$(grep -sm1 "^${runfiles_bash} " "$0.exe.runfiles_manifest" | cut -d' ' -f2-)" 2>/dev/null || \
+  { echo "ERROR: cannot find ${runfiles_bash}" >&2; exit 1; }
+runfiles_bash=
+set -e
 
 resolve_runfile() {
   local path="$1"


### PR DESCRIPTION
Fixes image publishing on main after PR 698. `bazel run //:push_images` now includes Bazel's runfiles helper and initializes runfiles before invoking the service image push scripts. The drift guard still checks that every service `oci_push` target is listed in `//:push_images`.

## Pipeline validation record (no-mistakes)

<details>
<summary>Evidence</summary>

- Local reproduction: `bazel run //:push_images` failed with `runfiles.bash initializer cannot find bazel_tools/tools/bash/runfiles/runfiles.bash`.
- Local verification: the drift guard query passes, `bazel build //:push_images` passes, and `bazel run //:push_images` now reaches the GHCR push step.
- Expected local limit: the final local push failed only because the local GHCR token was unauthenticated.
- no-mistakes: review, tests, document checks, lint, push, PR creation, and CI completed.
- Pipeline fix: lint added `no-mistakes(lint): fix shellcheck directive and buildifier sort order`.
- PR CI: passed for PR #701.

</details>
