### PR TITLE
[codex] Add adaptive time tracking to V2 log forms

### DIFF
--- a/docs/wip/activity-time-tracking/README.md
+++ b/docs/wip/activity-time-tracking/README.md
@@ -141,7 +141,7 @@ Each step should be merged to `main` and deployable on its own.
 4. [x] Backend config: expose code-owned activity input mode as additive activity metadata.
 5. [x] Backend tests: cover legacy amount logs, amount+duration logs, duration-only time-primary logs, duration-only Reading/Writing fallback scoring, contest attachment, and leaderboard aggregation.
 6. [x] Frontend API types: add optional duration and activity input mode.
-7. [ ] V2 create/edit forms: add adaptive time-tracking UI.
+7. [x] V2 create/edit forms: add adaptive time-tracking UI.
 8. [ ] V2 detail/list views: display duration when present.
 9. [ ] Original form regression check: create and edit logs through the existing amount/unit flow.
 10. [ ] Production rollout check: confirm old logs, new amount logs, and new duration logs aggregate correctly.

--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -121,30 +121,18 @@ export const EditLogForm = ({ options, log }: Props) => {
                   disabled
                 />
               </label>
-              {usesAmountUnit ? (
-                <>
-                  <AmountWithUnit
-                    label="Amount"
-                    name="amount"
-                    defaultValue={log.amount}
-                    min={0}
-                    step="any"
-                    units={unitsAsOptions}
-                    unitsLabel="Unit"
-                  />
-                  {activityInputType === 'amount_primary' ? (
-                    <Input
-                      name="durationMinutes"
-                      label="Time spent"
-                      type="number"
-                      min={0}
-                      step="any"
-                      hint="minutes"
-                      options={{ valueAsNumber: true }}
-                    />
-                  ) : null}
-                </>
-              ) : (
+              {usesAmountUnit && (
+                <AmountWithUnit
+                  label="Amount"
+                  name="amount"
+                  defaultValue={log.amount}
+                  min={0}
+                  step="any"
+                  units={unitsAsOptions}
+                  unitsLabel="Unit"
+                />
+              )}
+              {!isLegacyAmountEdit && (
                 <Input
                   name="durationMinutes"
                   label="Time spent"

--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -6,7 +6,6 @@ import {
   fetchTagSuggestions,
   Log,
   LogConfigurationOptions,
-  UpdateLogPayload,
   useUpdateLog,
 } from '@app/immersion/api'
 import { useRouter } from 'next/router'
@@ -15,6 +14,7 @@ import {
   estimateScore,
   filterUnits,
   NewLogFormV2Schema,
+  NewLogV2APISchema,
 } from '@app/immersion/NewLogFormV2/domain'
 import { formatScore } from '@app/common/format'
 import { useDebouncedCallback } from 'use-debounce'
@@ -28,14 +28,27 @@ interface Props {
 }
 
 export const EditLogForm = ({ options, log }: Props) => {
+  const activity =
+    options.activities.find(it => it.id === log.activity.id) ?? log.activity
+  const activityInputType = activity.input_type ?? 'amount_primary'
+  const isLegacyAmountEdit =
+    activityInputType === 'time_primary' &&
+    log.duration_seconds === undefined
+  const usesAmountUnit =
+    activityInputType === 'amount_primary' || isLegacyAmountEdit
   const defaultValues: Partial<NewLogFormV2Schema> = {
     languageCode: log.language.code,
     activityId: log.activity.id,
     amountValue: log.amount,
     amountUnit: log.unit_id,
+    durationMinutes:
+      log.duration_seconds !== undefined
+        ? log.duration_seconds / 60
+        : undefined,
     tags: log.tags,
     description: log.description ?? '',
     allUnits: options.units,
+    allActivities: options.activities,
   }
 
   const methods = useForm({
@@ -54,7 +67,9 @@ export const EditLogForm = ({ options, log }: Props) => {
     label: it.name,
   }))
   const currentSelectedUnit = units.find(it => it.id === unitId)
-  const estimatedScore = estimateScore(amount, currentSelectedUnit)
+  const estimatedScore = usesAmountUnit
+    ? estimateScore(amount, currentSelectedUnit)
+    : undefined
 
   const router = useRouter()
   const updateLogMutation = useUpdateLog(updatedLog => {
@@ -68,11 +83,15 @@ export const EditLogForm = ({ options, log }: Props) => {
   })
 
   const onSubmit = (data: any) => {
-    const payload: UpdateLogPayload = {
-      amount: data.amountValue,
-      unit_id: data.amountUnit,
-      tags: data.tags,
-      description: data.description || undefined,
+    const parsed = NewLogV2APISchema.parse(data)
+    const payload = {
+      tags: parsed.tags,
+      description: parsed.description,
+      ...('amount' in parsed ? { amount: parsed.amount } : {}),
+      ...('unit_id' in parsed ? { unit_id: parsed.unit_id } : {}),
+      ...('duration_seconds' in parsed
+        ? { duration_seconds: parsed.duration_seconds }
+        : {}),
     }
     updateLog({ logId: log.id, payload })
   }
@@ -102,15 +121,40 @@ export const EditLogForm = ({ options, log }: Props) => {
                   disabled
                 />
               </label>
-              <AmountWithUnit
-                label="Amount"
-                name="amount"
-                defaultValue={log.amount}
-                min={0}
-                step="any"
-                units={unitsAsOptions}
-                unitsLabel="Unit"
-              />
+              {usesAmountUnit ? (
+                <>
+                  <AmountWithUnit
+                    label="Amount"
+                    name="amount"
+                    defaultValue={log.amount}
+                    min={0}
+                    step="any"
+                    units={unitsAsOptions}
+                    unitsLabel="Unit"
+                  />
+                  {activityInputType === 'amount_primary' ? (
+                    <Input
+                      name="durationMinutes"
+                      label="Time spent"
+                      type="number"
+                      min={0}
+                      step="any"
+                      hint="minutes"
+                      options={{ valueAsNumber: true }}
+                    />
+                  ) : null}
+                </>
+              ) : (
+                <Input
+                  name="durationMinutes"
+                  label="Time spent"
+                  type="number"
+                  min={0}
+                  step="any"
+                  hint="minutes"
+                  options={{ valueAsNumber: true }}
+                />
+              )}
               <Input
                 name="description"
                 label="Description"
@@ -133,7 +177,10 @@ export const EditLogForm = ({ options, log }: Props) => {
               </div>
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-              Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+              Estimated score:{' '}
+              <strong>
+                {usesAmountUnit ? formatScore(estimatedScore) : '-'}
+              </strong>
             </div>
           </div>
           <div className="h-stack spaced justify-end">

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -165,38 +165,26 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
                 values={activitiesAsOptions}
                 options={{ valueAsNumber: true }}
               />
-              {usesAmountUnit ? (
-                <>
-                  <AmountWithUnit
-                    label="Amount"
-                    name="amount"
-                    defaultValue={0}
-                    min={0}
-                    step="any"
-                    units={unitsAsOptions}
-                    unitsLabel="Unit"
-                  />
-                  <Input
-                    name="durationMinutes"
-                    label="Time spent"
-                    type="number"
-                    min={0}
-                    step="any"
-                    hint="minutes"
-                    options={{ valueAsNumber: true }}
-                  />
-                </>
-              ) : (
-                <Input
-                  name="durationMinutes"
-                  label="Time spent"
-                  type="number"
+              {usesAmountUnit && (
+                <AmountWithUnit
+                  label="Amount"
+                  name="amount"
+                  defaultValue={0}
                   min={0}
                   step="any"
-                  hint="minutes"
-                  options={{ valueAsNumber: true }}
+                  units={unitsAsOptions}
+                  unitsLabel="Unit"
                 />
               )}
+              <Input
+                name="durationMinutes"
+                label="Time spent"
+                type="number"
+                min={0}
+                step="any"
+                hint="minutes"
+                options={{ valueAsNumber: true }}
+              />
               <Input
                 name="description"
                 label="Description"

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -28,13 +28,19 @@ interface Props {
 }
 
 export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Props) => {
+  const defaultActivity = options.activities[0]
+  const defaultActivityInputType =
+    defaultActivity?.input_type ?? 'amount_primary'
   const defaultValues: Partial<NewLogFormV2Schema> = {
     ...originalDefaultValues,
-    activityId: options.activities[0].id,
-    amountUnit: options.units.filter(
-      it => it.log_activity_id === options.activities[0].id,
-    )[0]?.id,
+    activityId: defaultActivity.id,
+    amountUnit:
+      defaultActivityInputType === 'amount_primary'
+        ? options.units.filter(it => it.log_activity_id === defaultActivity.id)[0]
+            ?.id
+        : undefined,
     allUnits: options.units,
+    allActivities: options.activities,
   }
 
   const methods = useForm({
@@ -67,6 +73,8 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
       : undefined
 
   const activity = options.activities.find(it => it.id === activityId)
+  const activityInputType = activity?.input_type ?? 'amount_primary'
+  const usesAmountUnit = activityInputType === 'amount_primary'
   const units = filterUnits(options.units, activity?.id, languageCode)
   const unitsAsOptions: Option[] = units.map(it => ({
     value: it.id,
@@ -77,7 +85,9 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
     value: it.id.toString(),
     label: it.name,
   }))
-  const estimatedScore = estimateScore(amount, currentSelectedUnit)
+  const estimatedScore = usesAmountUnit
+    ? estimateScore(amount, currentSelectedUnit)
+    : undefined
 
   // Eagerly prefetch ongoing registrations (non-blocking)
   const registrations = useOngoingContestRegistrations()
@@ -109,10 +119,22 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
         (name === 'languageCode' || name === 'activityId') &&
         type === 'change'
       ) {
+        const selectedActivity = options.activities.find(
+          it => it.id === value.activityId,
+        )
+        const selectedInputType =
+          selectedActivity?.input_type ?? 'amount_primary'
+
+        if (selectedInputType === 'time_primary') {
+          methods.setValue('amountValue', undefined)
+          methods.setValue('amountUnit', undefined)
+          return
+        }
+
         const id = filterUnits(
           options.units,
           value.activityId,
-          languageCode,
+          value.languageCode,
         )?.[0]?.id
         if (id !== methods.getValues('amountUnit')) {
           methods.setValue('amountUnit', id)
@@ -120,7 +142,7 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
       }
     })
     return () => subscription.unsubscribe()
-  }, [methods, languageCode, options.units])
+  }, [methods, options.activities, options.units])
 
   return (
     <FormProvider {...methods}>
@@ -143,15 +165,38 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
                 values={activitiesAsOptions}
                 options={{ valueAsNumber: true }}
               />
-              <AmountWithUnit
-                label="Amount"
-                name="amount"
-                defaultValue={0}
-                min={0}
-                step="any"
-                units={unitsAsOptions}
-                unitsLabel="Unit"
-              />
+              {usesAmountUnit ? (
+                <>
+                  <AmountWithUnit
+                    label="Amount"
+                    name="amount"
+                    defaultValue={0}
+                    min={0}
+                    step="any"
+                    units={unitsAsOptions}
+                    unitsLabel="Unit"
+                  />
+                  <Input
+                    name="durationMinutes"
+                    label="Time spent"
+                    type="number"
+                    min={0}
+                    step="any"
+                    hint="minutes"
+                    options={{ valueAsNumber: true }}
+                  />
+                </>
+              ) : (
+                <Input
+                  name="durationMinutes"
+                  label="Time spent"
+                  type="number"
+                  min={0}
+                  step="any"
+                  hint="minutes"
+                  options={{ valueAsNumber: true }}
+                />
+              )}
               <Input
                 name="description"
                 label="Description"
@@ -172,7 +217,10 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
               </div>
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-              Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+              Estimated score:{' '}
+              <strong>
+                {usesAmountUnit ? formatScore(estimatedScore) : '-'}
+              </strong>
             </div>
           </div>
           <div className="h-stack spaced justify-end">

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
@@ -1,41 +1,124 @@
 import { z } from 'zod'
-import { Unit } from '@app/immersion/api'
+import { Activity, Unit } from '@app/immersion/api'
 import { filterUnits, estimateScore } from '@app/immersion/NewLogForm/domain'
 
 export { filterUnits, estimateScore }
+
+const optionalPositiveNumber = z.preprocess(
+  value =>
+    typeof value === 'number' && Number.isNaN(value) ? undefined : value,
+  z.number({ invalid_type_error: 'Please enter a number' }).positive().optional(),
+)
+
+const durationSecondsFromMinutes = (minutes?: number) =>
+  minutes === undefined ? undefined : Math.round(minutes * 60)
 
 export const NewLogFormV2Schema = z
   .object({
     languageCode: z.string().length(3, 'invalid language'),
     activityId: z.number(),
-    amountValue: z
-      .number({ invalid_type_error: 'Please enter a number' })
-      .positive(),
-    amountUnit: z.string(),
+    amountValue: optionalPositiveNumber,
+    amountUnit: z.string().optional(),
+    durationMinutes: optionalPositiveNumber,
     allUnits: z.array(Unit),
+    allActivities: z.array(Activity),
     tags: z.array(z.string().max(50)).max(10, 'Maximum 10 tags allowed'),
     description: z.string().optional(),
   })
-  .refine(
-    log => {
-      const unit = log.allUnits.find(it => it.id === log.amountUnit)
-      return unit?.log_activity_id === log.activityId
-    },
-    {
-      path: ['amountUnit'],
-      message: 'This unit is cannot be used for this activity',
-    },
-  )
+  .superRefine((log, ctx) => {
+    const activity = log.allActivities.find(it => it.id === log.activityId)
+    const inputType = activity?.input_type ?? 'amount_primary'
+    const unit = log.allUnits.find(it => it.id === log.amountUnit)
+    const hasAmount = log.amountValue !== undefined
+    const hasUnit = log.amountUnit !== undefined && log.amountUnit !== ''
+    const hasDuration = log.durationMinutes !== undefined
+    const hasValidAmountUnit =
+      hasAmount && hasUnit && unit?.log_activity_id === log.activityId
+    const durationSeconds = durationSecondsFromMinutes(log.durationMinutes)
+
+    if (durationSeconds !== undefined && durationSeconds <= 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['durationMinutes'],
+        message: 'Time spent must be at least 1 second',
+      })
+    }
+
+    if (inputType === 'time_primary') {
+      if (!hasDuration && !hasValidAmountUnit) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['durationMinutes'],
+          message: 'Time spent is required',
+        })
+      }
+      return
+    }
+
+    if (!hasAmount) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['amountValue'],
+        message: 'Amount is required',
+      })
+    }
+
+    if (!hasUnit) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['amountUnit'],
+        message: 'Unit is required',
+      })
+      return
+    }
+
+    if (unit?.log_activity_id !== log.activityId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['amountUnit'],
+        message: 'This unit cannot be used for this activity',
+      })
+    }
+  })
 
 export type NewLogFormV2Schema = z.infer<typeof NewLogFormV2Schema>
 
-export const NewLogV2APISchema = NewLogFormV2Schema.transform(log => ({
-  language_code: log.languageCode,
-  activity_id: log.activityId,
-  amount: log.amountValue,
-  unit_id: log.amountUnit,
-  tags: log.tags,
-  description: log.description,
-}))
+export const NewLogV2APISchema = NewLogFormV2Schema.transform(log => {
+  const activity = log.allActivities.find(it => it.id === log.activityId)
+  const inputType = activity?.input_type ?? 'amount_primary'
+  const unit = log.allUnits.find(it => it.id === log.amountUnit)
+  const hasValidAmountUnit =
+    log.amountValue !== undefined &&
+    log.amountUnit !== undefined &&
+    log.amountUnit !== '' &&
+    unit?.log_activity_id === log.activityId
+  const durationSeconds = durationSecondsFromMinutes(log.durationMinutes)
+  const base = {
+    language_code: log.languageCode,
+    activity_id: log.activityId,
+    tags: log.tags,
+    description: log.description,
+  }
+
+  if (inputType === 'time_primary' && durationSeconds !== undefined) {
+    return {
+      ...base,
+      duration_seconds: durationSeconds,
+    }
+  }
+
+  if (hasValidAmountUnit) {
+    return {
+      ...base,
+      amount: log.amountValue,
+      unit_id: log.amountUnit,
+      ...(durationSeconds !== undefined
+        ? { duration_seconds: durationSeconds }
+        : {}),
+    }
+  }
+
+  return base
+})
 
 export type NewLogV2APISchema = z.infer<typeof NewLogV2APISchema>

--- a/frontend/apps/webv2/app/immersion/api.ts
+++ b/frontend/apps/webv2/app/immersion/api.ts
@@ -762,8 +762,8 @@ export const useCreateLog = (onSuccess: (id: string) => void) =>
 export type CreateLogV2Payload = {
   language_code: string
   activity_id: number
-  amount: number
-  unit_id: string
+  amount?: number
+  unit_id?: string
   duration_seconds?: number
   tags: string[]
   description?: string
@@ -791,8 +791,8 @@ export const useCreateLogV2 = (onSuccess: (log: Log) => void) =>
   })
 
 export type UpdateLogPayload = {
-  amount: number
-  unit_id: string
+  amount?: number
+  unit_id?: string
   duration_seconds?: number
   tags: string[]
   description?: string

--- a/services/immersion-api/http/rest/mappers.go
+++ b/services/immersion-api/http/rest/mappers.go
@@ -74,6 +74,7 @@ func logToAPI(log *domain.Log) *openapi.Log {
 		Amount:          log.Amount,
 		Modifier:        log.Modifier,
 		Score:           log.Score,
+		DurationSeconds: log.DurationSeconds,
 		Tags:            log.Tags,
 		UnitId:          log.UnitID,
 		UnitName:        log.UnitName,

--- a/services/immersion-api/http/rest/openapi/api.gen.go
+++ b/services/immersion-api/http/rest/openapi/api.gen.go
@@ -214,6 +214,7 @@ type Log struct {
 	CreatedAt       time.Time                       `json:"created_at"`
 	Deleted         bool                            `json:"deleted"`
 	Description     *string                         `json:"description,omitempty"`
+	DurationSeconds *int32                          `json:"duration_seconds,omitempty"`
 	Id              openapi_types.UUID              `json:"id"`
 	Language        Language                        `json:"language"`
 	Modifier        float32                         `json:"modifier"`

--- a/services/immersion-api/http/rest/openapi/api.yaml
+++ b/services/immersion-api/http/rest/openapi/api.yaml
@@ -1478,6 +1478,9 @@ components:
         score:
           type: number
           format: float
+        duration_seconds:
+          type: integer
+          format: int32
         registrations:
           type: array
           items:


### PR DESCRIPTION
## Summary

This PR implements step 7 of the activity time-tracking rollout: adaptive time-tracking inputs in the V2 create/edit log flows.

The original logging form remains unchanged. V2 now uses code-owned activity metadata (`input_type`) to decide whether the primary input should be amount/unit or time.

## What changed

- Adds `duration_seconds` to the backend OpenAPI `Log` response schema and generated Go type.
- Populates `duration_seconds` in the REST log mapper from `domain.Log.DurationSeconds`.
- Relaxes V2 frontend create/update payload types so `amount` and `unit_id` are optional for duration-only submissions.
- Updates the V2 form schema/transform to normalize UI data into API payloads:
  - `time_primary` activities submit `duration_seconds` and omit amount/unit.
  - `amount_primary` activities submit amount/unit and optionally include `duration_seconds` as metadata.
  - duration minutes entered in the UI are rounded to seconds at the API boundary.
- Updates the V2 create form:
  - Listening, Speaking, and Study show `Time spent` in minutes.
  - Reading and Writing keep amount/unit and show optional `Time spent`.
  - duration-only entries blank the estimated score instead of duplicating backend fallback scoring constants in the frontend.
  - activity/language changes clear hidden stale fields before submit.
- Updates the V2 edit form:
  - logs with `duration_seconds` seed the minutes field from the response.
  - legacy time-primary logs without duration stay on the amount/unit edit path, so existing data is not silently converted.
- Marks step 7 complete in `docs/wip/activity-time-tracking/README.md`.

## Rollout context

This is part of the trunk-based activity time-tracking rollout tracked in `docs/wip/activity-time-tracking/README.md`.

Completed before this PR:

1. Backend schema supports nullable duration/effective-score snapshots.
2. Backend reads use effective score.
3. Backend writes accept optional `duration_seconds` and write `computed_score`.
4. Activity API responses expose code-owned `input_type` metadata.
5. Backend coverage was added for duration/computed-score groundwork.
6. Frontend API/Zod types parse duration and activity input modes.

This PR completes:

7. V2 create/edit forms: adaptive time-tracking UI.

Still remaining after this PR:

8. V2 detail/list views: display duration when present.
9. Original form regression check.
10. Production rollout check.
11. ADR 005 scoring rules and removal of the interim scoring bridge.

## User impact

- Existing non-admin/original log form behavior should remain unchanged.
- V2/admin log creation becomes activity-aware:
  - Reading/Writing stay amount-first.
  - Listening/Speaking/Study become time-first.
- Existing legacy logs remain editable without automatic conversion.

## Scoring notes

The frontend intentionally does not duplicate backend duration fallback scoring constants. Duration-only V2 entries show a blank/dash estimated score, and the backend remains the source of truth for interim `computed_score` until ADR 005 scoring rules are implemented.

## Validation

Passed after implementation before rebasing:

- `cd services/immersion-api/http/rest/openapi && go generate`
- `bazel test //services/immersion-api/http/rest:rest_test`
- `bazel build //services/...`
- `cd frontend && pnpm --filter webv2 exec tsc --noEmit`
- `cd frontend && pnpm --filter webv2 lint`
- `git diff --check`

Passed again after rebasing onto current `origin/main`:

- `cd frontend && pnpm --filter webv2 exec tsc --noEmit`
- `cd frontend && pnpm --filter webv2 lint`
- `git diff --check`

Could not rerun backend Bazel checks after rebasing because current `origin/main` now requires Bazel 8.7.0 via `.bazelversion`, but the local machine only has Bazel 8.2.1 installed under Homebrew. Bazel exits before analysis with:

```text
ERROR: The project you're trying to build requires Bazel 8.7.0 (specified in /Users/io/xdev/tadoku/.bazelversion), but it wasn't found in /opt/homebrew/Cellar/bazel/8.2.1/libexec/bin.
```

## Review focus

- V2 form normalization in `frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx`.
- Legacy edit behavior for time-primary logs without `duration_seconds`.
- Whether showing optional time for Reading/Writing in the compact form is the desired UX for this rollout step.
