### PR TITLE
build(dev): add private registry pull auth to the Tilt dev stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,6 @@ Seed users are `dev@tadoku.app` and `reader@tadoku.app`, both with password `tad
 Frontend pods use Tilt `live_update` with scoped sync paths and polling file watchers for Next.js.
 Routine edits under a frontend app or `frontend/packages/ui` should sync into the running pod and hot-reload without an image rebuild; package file changes run `pnpm -r install` inside the container.
 
-For clusters that pull from a private registry, set `TADOKU_DEV_REGISTRY_HOST` (or the `registry` value in `tilt_config.json`), `TADOKU_DEV_REGISTRY_USERNAME`, and `TADOKU_DEV_REGISTRY_PASSWORD` before `make dev-up` so Tilt creates the `tadoku-dev-registry-pull` secrets; see `docs/docs/local-environment.md` for details.
+For clusters that use a private registry, set `TADOKU_DEV_REGISTRY_HOST` (or the `registry` value in `tilt_config.json`), pull credentials (`TADOKU_DEV_REGISTRY_USERNAME`/`TADOKU_DEV_REGISTRY_PASSWORD`), and shared-cluster push credentials (`TADOKU_DEV_REGISTRY_PUSH_USERNAME`/`TADOKU_DEV_REGISTRY_PUSH_PASSWORD`) before `make dev-up` so Tilt can create pull secrets and authenticate Docker for pushes; see `docs/docs/local-environment.md` for details.
 
 Registry cache is intentionally skipped for now: the dev stack already pulls from the configured per-environment registry, and there is no committed evidence that image pulls are a bottleneck.

--- a/README.md
+++ b/README.md
@@ -30,4 +30,6 @@ Seed users are `dev@tadoku.app` and `reader@tadoku.app`, both with password `tad
 Frontend pods use Tilt `live_update` with scoped sync paths and polling file watchers for Next.js.
 Routine edits under a frontend app or `frontend/packages/ui` should sync into the running pod and hot-reload without an image rebuild; package file changes run `pnpm -r install` inside the container.
 
+For clusters that pull from a private registry, set `TADOKU_DEV_REGISTRY_HOST` (or the `registry` value in `tilt_config.json`), `TADOKU_DEV_REGISTRY_USERNAME`, and `TADOKU_DEV_REGISTRY_PASSWORD` before `make dev-up` so Tilt creates the `tadoku-dev-registry-pull` secrets; see `docs/docs/local-environment.md` for details.
+
 Registry cache is intentionally skipped for now: the dev stack already pulls from the configured per-environment registry, and there is no committed evidence that image pulls are a bottleneck.

--- a/Tiltfile
+++ b/Tiltfile
@@ -14,6 +14,9 @@ else:
     # Local cluster: images stay in the local docker daemon.
     pass
 
+# Dev registry auth
+include('./infra/dev/registry/Tiltfile')
+
 include('./k8s/dev/Tiltfile')
 
 # Private

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -107,11 +107,14 @@ export TADOKU_DEV_REGISTRY_USERNAME="registry-pull"
 export TADOKU_DEV_REGISTRY_PASSWORD="<registry-pull-password>"
 ```
 
-On the shared cluster the same host is used as Tilt's `default_registry`, so authenticate Docker separately with the push account:
+On the shared cluster the same host is used as Tilt's `default_registry`. To have Tilt authenticate Docker automatically before shared-cluster image pushes, set the push-side credentials too:
 
 ```sh
-docker login "$TADOKU_DEV_REGISTRY_HOST" --username registry-push
+export TADOKU_DEV_REGISTRY_PUSH_USERNAME="registry-push"
+export TADOKU_DEV_REGISTRY_PUSH_PASSWORD="<registry-push-password>"
 ```
+
+Tilt runs `docker login` with `--password-stdin` before the image-building resources that push to the shared registry. If the push password is unset, Tilt skips this login resource and Docker must already have valid credentials for the registry.
 
 When the host, username, or password is missing, Tilt skips creating the pull secrets and prints a notice — local clusters that keep images in the local Docker daemon work unchanged without any of these variables.
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -48,7 +48,7 @@ For local contexts, backend images are built with Bazel and are not pushed to a 
 
 ### Option B: Shared development cluster
 
-Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the platform TLS certificate once available) before Tilt can push images.
+Prerequisite: the configured registry hostname must resolve from your machine, and your Docker daemon must trust the registry endpoint (via an insecure-registry entry for HTTP, or the platform TLS certificate once available) before Tilt can push images. If the registry requires authentication, also set up the push and pull credentials described in [Private development registry](#private-development-registry).
 
 Copy `tilt_config.json.example` to the gitignored `tilt_config.json`, then replace the placeholder values with your private operator values. Keep real hostnames, registry names, and context names in private config only. The context keys can also be set via environment variables (`shared_k8s_context` → `TADOKU_SHARED_K8S_CONTEXT`, `local_k8s_context` → `TADOKU_LOCAL_K8S_CONTEXT`); environment variables take precedence over `tilt_config.json`. Shared-cluster mode stays disabled until a shared context is configured via `shared_k8s_context` or `TADOKU_SHARED_K8S_CONTEXT`; there is no committed default.
 
@@ -99,7 +99,7 @@ Resetting (`dev-reset`, also available as a manual-only `dev-reset` Tilt resourc
 
 ## Private development registry
 
-Tilt can push dev images to a private registry and create pull secrets for the namespaces that run Tilt-built images. The registry host is resolved the same way as the shared-cluster `default_registry`: the `TADOKU_DEV_REGISTRY_HOST` environment variable if set, otherwise the `registry` value in `tilt_config.json`. Configure the pull-side credentials with local environment variables before running Tilt:
+Tilt can push dev images to a private registry and create `tadoku-dev-registry-pull` docker-registry pull secrets for the namespaces that run Tilt-built images. The registry host is resolved the same way as the shared-cluster `default_registry`: the `TADOKU_DEV_REGISTRY_HOST` environment variable if set, otherwise the `registry` value in `tilt_config.json`. Configure the pull-side credentials with local environment variables before running Tilt:
 
 ```sh
 export TADOKU_DEV_REGISTRY_HOST="<registry-host>" # optional when registry is set in tilt_config.json
@@ -112,6 +112,8 @@ On the shared cluster the same host is used as Tilt's `default_registry`, so aut
 ```sh
 docker login "$TADOKU_DEV_REGISTRY_HOST" --username registry-push
 ```
+
+When the host, username, or password is missing, Tilt skips creating the pull secrets and prints a notice — local clusters that keep images in the local Docker daemon work unchanged without any of these variables.
 
 Do not commit real registry hosts, usernames beyond the documented role names, passwords, or generated Secret YAML.
 

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -99,15 +99,15 @@ Resetting (`dev-reset`, also available as a manual-only `dev-reset` Tilt resourc
 
 ## Private development registry
 
-Tilt can push dev images to a private registry and create pull secrets for the namespaces that run Tilt-built images. Configure the pull-side credentials with local environment variables before running Tilt:
+Tilt can push dev images to a private registry and create pull secrets for the namespaces that run Tilt-built images. The registry host is resolved the same way as the shared-cluster `default_registry`: the `TADOKU_DEV_REGISTRY_HOST` environment variable if set, otherwise the `registry` value in `tilt_config.json`. Configure the pull-side credentials with local environment variables before running Tilt:
 
 ```sh
-export TADOKU_DEV_REGISTRY_HOST="<registry-host>"
+export TADOKU_DEV_REGISTRY_HOST="<registry-host>" # optional when registry is set in tilt_config.json
 export TADOKU_DEV_REGISTRY_USERNAME="registry-pull"
 export TADOKU_DEV_REGISTRY_PASSWORD="<registry-pull-password>"
 ```
 
-The host value is also used as Tilt's `default_registry`, so authenticate Docker separately with the push account:
+On the shared cluster the same host is used as Tilt's `default_registry`, so authenticate Docker separately with the push account:
 
 ```sh
 docker login "$TADOKU_DEV_REGISTRY_HOST" --username registry-push

--- a/docs/docs/local-environment.md
+++ b/docs/docs/local-environment.md
@@ -97,6 +97,24 @@ Seeding (`dev-seed`, also a Tilt resource that runs automatically once the backe
 
 Resetting (`dev-reset`, also available as a manual-only `dev-reset` Tilt resource) is destructive: it deletes the Zalando operator-managed `tadoku-dev-db` cluster and its persistent volume claims, reapplies the `postgresql` custom resource, restarts the backend services so their startup migrations run against the fresh database, and then reseeds. The script refuses to run unless the current kubectl context matches a known dev context (`shared_k8s_context`/`local_k8s_context` from `tilt_config.json`, or the `TADOKU_SHARED_K8S_CONTEXT`/`TADOKU_LOCAL_K8S_CONTEXT` env vars), and requires typing the context name to confirm when targeting the shared cluster. Ordinary `tilt down`/`tilt up` keeps data since the database uses persistent volumes.
 
+## Private development registry
+
+Tilt can push dev images to a private registry and create pull secrets for the namespaces that run Tilt-built images. Configure the pull-side credentials with local environment variables before running Tilt:
+
+```sh
+export TADOKU_DEV_REGISTRY_HOST="<registry-host>"
+export TADOKU_DEV_REGISTRY_USERNAME="registry-pull"
+export TADOKU_DEV_REGISTRY_PASSWORD="<registry-pull-password>"
+```
+
+The host value is also used as Tilt's `default_registry`, so authenticate Docker separately with the push account:
+
+```sh
+docker login "$TADOKU_DEV_REGISTRY_HOST" --username registry-push
+```
+
+Do not commit real registry hosts, usernames beyond the documented role names, passwords, or generated Secret YAML.
+
 ## Can't connect connect to service/database
 
 It's possible that the containers for a particular service or database have been shut down due resource constraints. In this case you can restart the service manually from the Tilt dashboard. If a database is unreachable it might be useful to restart the Tilt cluster.

--- a/frontend/Tiltfile
+++ b/frontend/Tiltfile
@@ -1,4 +1,4 @@
-load('./../k8s/dev/config/Tiltfile', 'is_shared_cluster', 'render_template')
+load('./../k8s/dev/config/Tiltfile', 'dev_registry_push_resource_deps', 'is_shared_cluster', 'render_template')
 
 def frontend_build(image, project_name, package_trigger):
   command = (
@@ -48,17 +48,17 @@ def frontend_build(image, project_name, package_trigger):
 # webv2
 frontend_webv2 = render_template('frontend/apps/webv2/deployments/frontend-webv2.yaml', '.tilt/rendered/frontend/apps/webv2/deployments/frontend-webv2.yaml')
 k8s_yaml(frontend_webv2)
-k8s_resource("frontend-webv2", labels=["frontend"])
+k8s_resource("frontend-webv2", labels=["frontend"], resource_deps=dev_registry_push_resource_deps())
 frontend_build('frontend-webv2', 'webv2', './apps/webv2/package.json')
 
 # auth
 frontend_auth = render_template('frontend/apps/auth/deployments/frontend-auth.yaml', '.tilt/rendered/frontend/apps/auth/deployments/frontend-auth.yaml')
 k8s_yaml(frontend_auth)
-k8s_resource("frontend-auth", labels=["auth"])
+k8s_resource("frontend-auth", labels=["auth"], resource_deps=dev_registry_push_resource_deps())
 frontend_build('frontend-auth', 'auth', './apps/auth/package.json')
 
 # admin
 frontend_admin = render_template('frontend/apps/admin/deployments/frontend-admin.yaml', '.tilt/rendered/frontend/apps/admin/deployments/frontend-admin.yaml')
 k8s_yaml(frontend_admin)
-k8s_resource("frontend-admin", labels=["frontend"])
+k8s_resource("frontend-admin", labels=["frontend"], resource_deps=dev_registry_push_resource_deps())
 frontend_build('frontend-admin', 'admin', './apps/admin/package.json')

--- a/frontend/apps/admin/deployments/frontend-admin.yaml
+++ b/frontend/apps/admin/deployments/frontend-admin.yaml
@@ -14,6 +14,8 @@ spec:
         app: frontend-admin
         tier: web
     spec:
+      imagePullSecrets:
+      - name: tadoku-dev-registry-pull
       containers:
       - name: frontend-admin
         image: frontend-admin

--- a/frontend/apps/auth/deployments/frontend-auth.yaml
+++ b/frontend/apps/auth/deployments/frontend-auth.yaml
@@ -14,6 +14,8 @@ spec:
         app: frontend-auth
         tier: web
     spec:
+      imagePullSecrets:
+      - name: tadoku-dev-registry-pull
       containers:
       - name: frontend-auth
         image: frontend-auth

--- a/frontend/apps/webv2/deployments/frontend-webv2.yaml
+++ b/frontend/apps/webv2/deployments/frontend-webv2.yaml
@@ -14,6 +14,8 @@ spec:
         app: frontend-webv2
         tier: web
     spec:
+      imagePullSecrets:
+      - name: tadoku-dev-registry-pull
       containers:
       - name: frontend-webv2
         image: frontend-webv2

--- a/infra/dev/registry/Tiltfile
+++ b/infra/dev/registry/Tiltfile
@@ -1,0 +1,32 @@
+# -*- mode: Python -*-
+
+load('ext://secret', 'secret_yaml_docker_registry')
+
+DEV_REGISTRY_PULL_SECRET = 'tadoku-dev-registry-pull'
+DEV_REGISTRY_NAMESPACES = [
+  '',
+  'tdk-authz-api',
+  'tdk-content-api',
+  'tdk-immersion-api',
+  'tdk-profile-api',
+  'tdk-token-reflector',
+]
+
+registry_host = os.getenv('TADOKU_DEV_REGISTRY_HOST', '')
+registry_username = os.getenv('TADOKU_DEV_REGISTRY_USERNAME', 'registry-pull')
+registry_password = os.getenv('TADOKU_DEV_REGISTRY_PASSWORD', '')
+
+if registry_host:
+  default_registry(registry_host)
+
+if registry_host and registry_username and registry_password:
+  for namespace in DEV_REGISTRY_NAMESPACES:
+    k8s_yaml(secret_yaml_docker_registry(
+      DEV_REGISTRY_PULL_SECRET,
+      username=registry_username,
+      password=registry_password,
+      server=registry_host,
+      namespace=namespace,
+    ))
+else:
+  print('Skipping Tadoku dev registry pull secrets; set TADOKU_DEV_REGISTRY_HOST, TADOKU_DEV_REGISTRY_USERNAME, and TADOKU_DEV_REGISTRY_PASSWORD to pull private Tilt images.')

--- a/infra/dev/registry/Tiltfile
+++ b/infra/dev/registry/Tiltfile
@@ -1,7 +1,7 @@
 # -*- mode: Python -*-
 
 load('ext://secret', 'secret_yaml_docker_registry')
-load('./../../../k8s/dev/config/Tiltfile', 'dev_registry')
+load('./../../../k8s/dev/config/Tiltfile', 'DEV_REGISTRY_PUSH_RESOURCE', 'dev_registry', 'is_shared_cluster')
 
 DEV_REGISTRY_PULL_SECRET = 'tadoku-dev-registry-pull'
 DEV_REGISTRY_NAMESPACES = [
@@ -16,6 +16,24 @@ DEV_REGISTRY_NAMESPACES = [
 registry_host = dev_registry()
 registry_username = os.getenv('TADOKU_DEV_REGISTRY_USERNAME', 'registry-pull')
 registry_password = os.getenv('TADOKU_DEV_REGISTRY_PASSWORD', '')
+registry_push_username = os.getenv('TADOKU_DEV_REGISTRY_PUSH_USERNAME', 'registry-push')
+registry_push_password = os.getenv('TADOKU_DEV_REGISTRY_PUSH_PASSWORD', '')
+
+def _sh_quote(value):
+  return "'" + value.replace("'", "'\"'\"'") + "'"
+
+if is_shared_cluster() and registry_host and registry_push_username and registry_push_password:
+  local_resource(
+    DEV_REGISTRY_PUSH_RESOURCE,
+    cmd=(
+      'registry_host=' + _sh_quote(registry_host) +
+      '; registry_username="${TADOKU_DEV_REGISTRY_PUSH_USERNAME:-registry-push}"; ' +
+      'printf "%s" "$TADOKU_DEV_REGISTRY_PUSH_PASSWORD" | docker login "$registry_host" --username "$registry_username" --password-stdin'
+    ),
+    labels=['infra'],
+  )
+elif is_shared_cluster():
+  print('Skipping Tadoku dev registry push login; set TADOKU_DEV_REGISTRY_PUSH_USERNAME and TADOKU_DEV_REGISTRY_PUSH_PASSWORD to have Tilt authenticate Docker automatically before pushing shared-cluster images.')
 
 if registry_host and registry_username and registry_password:
   # Group the tdk-* Namespace objects with the pull secrets in a single

--- a/infra/dev/registry/Tiltfile
+++ b/infra/dev/registry/Tiltfile
@@ -1,6 +1,7 @@
 # -*- mode: Python -*-
 
 load('ext://secret', 'secret_yaml_docker_registry')
+load('./../../../k8s/dev/config/Tiltfile', 'dev_registry')
 
 DEV_REGISTRY_PULL_SECRET = 'tadoku-dev-registry-pull'
 DEV_REGISTRY_NAMESPACES = [
@@ -12,14 +13,15 @@ DEV_REGISTRY_NAMESPACES = [
   'tdk-token-reflector',
 ]
 
-registry_host = os.getenv('TADOKU_DEV_REGISTRY_HOST', '')
+registry_host = dev_registry()
 registry_username = os.getenv('TADOKU_DEV_REGISTRY_USERNAME', 'registry-pull')
 registry_password = os.getenv('TADOKU_DEV_REGISTRY_PASSWORD', '')
 
-if registry_host:
-  default_registry(registry_host)
-
 if registry_host and registry_username and registry_password:
+  # Group the tdk-* Namespace objects with the pull secrets in a single
+  # resource so Tilt applies the namespaces before the secrets that live in
+  # them (entities within a resource are applied in kind order).
+  registry_auth_objects = []
   for namespace in DEV_REGISTRY_NAMESPACES:
     k8s_yaml(secret_yaml_docker_registry(
       DEV_REGISTRY_PULL_SECRET,
@@ -28,5 +30,13 @@ if registry_host and registry_username and registry_password:
       server=registry_host,
       namespace=namespace,
     ))
+    registry_auth_objects.append('%s:secret:%s' % (DEV_REGISTRY_PULL_SECRET, namespace or 'default'))
+    if namespace:
+      registry_auth_objects.append('%s:namespace' % namespace)
+  k8s_resource(
+    new_name='dev-registry-auth',
+    objects=registry_auth_objects,
+    labels=['infra'],
+  )
 else:
-  print('Skipping Tadoku dev registry pull secrets; set TADOKU_DEV_REGISTRY_HOST, TADOKU_DEV_REGISTRY_USERNAME, and TADOKU_DEV_REGISTRY_PASSWORD to pull private Tilt images.')
+  print('Skipping Tadoku dev registry pull secrets; set TADOKU_DEV_REGISTRY_HOST (or the registry in tilt_config.json), TADOKU_DEV_REGISTRY_USERNAME, and TADOKU_DEV_REGISTRY_PASSWORD to pull private Tilt images.')

--- a/k8s/dev/config/Tiltfile
+++ b/k8s/dev/config/Tiltfile
@@ -56,6 +56,8 @@ local_cluster_name = (
     _default_local_cluster_name(local_cluster_type, local_k8s_context)
 )
 
+DEV_REGISTRY_PUSH_RESOURCE = 'dev-registry-push-login'
+
 def is_shared_cluster():
     return shared_k8s_context != '' and k8s_context() == shared_k8s_context
 
@@ -72,6 +74,11 @@ def dev_registry():
     if is_shared_cluster() and (registry == '' or registry.endswith('.example') or registry.endswith('.example.invalid')):
         fail('copy tilt_config.json.example to tilt_config.json and set shared.registry for the shared dev cluster')
     return registry
+
+def dev_registry_push_resource_deps():
+    if is_shared_cluster() and os.getenv('TADOKU_DEV_REGISTRY_PUSH_PASSWORD', ''):
+        return [DEV_REGISTRY_PUSH_RESOURCE]
+    return []
 
 def render_template(src, dst):
     read_file(repo_path(src))

--- a/services/authz-api/Tiltfile
+++ b/services/authz-api/Tiltfile
@@ -1,4 +1,5 @@
 load("./../../infra/dev/build/Tiltfile", "bazel_build")
+load("./../../k8s/dev/config/Tiltfile", "dev_registry_push_resource_deps")
 
 watch_file("./deployments/api.yaml")
 k8s_yaml(local("cat ./deployments/api.yaml"))
@@ -15,4 +16,4 @@ bazel_build(
   deps=["./", "./../common/"],
 )
 
-k8s_resource("authz-api", labels=["backend"], resource_deps=["tadoku-dev-db", "kratos", "keto"])
+k8s_resource("authz-api", labels=["backend"], resource_deps=dev_registry_push_resource_deps() + ["tadoku-dev-db", "kratos", "keto"])

--- a/services/authz-api/deployments/api.yaml
+++ b/services/authz-api/deployments/api.yaml
@@ -87,3 +87,5 @@ kind: ServiceAccount
 metadata:
   name: authz-api
   namespace: tdk-authz-api
+imagePullSecrets:
+  - name: tadoku-dev-registry-pull

--- a/services/content-api/Tiltfile
+++ b/services/content-api/Tiltfile
@@ -1,4 +1,5 @@
 load("./../../infra/dev/build/Tiltfile", "bazel_build")
+load("./../../k8s/dev/config/Tiltfile", "dev_registry_push_resource_deps")
 
 # Api container
 watch_file('./deployments/api.yaml')
@@ -16,4 +17,4 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('content-api', labels=["backend"], resource_deps=["tadoku-dev-db", "keto"])
+k8s_resource('content-api', labels=["backend"], resource_deps=dev_registry_push_resource_deps() + ["tadoku-dev-db", "keto"])

--- a/services/content-api/deployments/api.yaml
+++ b/services/content-api/deployments/api.yaml
@@ -92,3 +92,5 @@ kind: ServiceAccount
 metadata:
   name: content-api
   namespace: tdk-content-api
+imagePullSecrets:
+  - name: tadoku-dev-registry-pull

--- a/services/immersion-api/Tiltfile
+++ b/services/immersion-api/Tiltfile
@@ -1,4 +1,5 @@
 load("./../../infra/dev/build/Tiltfile", "bazel_build")
+load("./../../k8s/dev/config/Tiltfile", "dev_registry_push_resource_deps")
 
 # Api container
 watch_file('./deployments/api.yaml')
@@ -16,4 +17,4 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('immersion-api', labels=["backend"], resource_deps=["tadoku-dev-db", "kratos", "keto", "valkey-immersion"])
+k8s_resource('immersion-api', labels=["backend"], resource_deps=dev_registry_push_resource_deps() + ["tadoku-dev-db", "kratos", "keto", "valkey-immersion"])

--- a/services/immersion-api/deployments/api.yaml
+++ b/services/immersion-api/deployments/api.yaml
@@ -102,3 +102,5 @@ kind: ServiceAccount
 metadata:
   name: immersion-api
   namespace: tdk-immersion-api
+imagePullSecrets:
+  - name: tadoku-dev-registry-pull

--- a/services/profile-api/Tiltfile
+++ b/services/profile-api/Tiltfile
@@ -1,4 +1,5 @@
 load("./../../infra/dev/build/Tiltfile", "bazel_build")
+load("./../../k8s/dev/config/Tiltfile", "dev_registry_push_resource_deps")
 
 # Api container
 watch_file('./deployments/api.yaml')
@@ -16,4 +17,4 @@ bazel_build(
   deps=['./', './../common/'],
 )
 
-k8s_resource('profile-api', labels=["backend"], resource_deps=["tadoku-dev-db", "kratos", "keto"])
+k8s_resource('profile-api', labels=["backend"], resource_deps=dev_registry_push_resource_deps() + ["tadoku-dev-db", "kratos", "keto"])

--- a/services/profile-api/deployments/api.yaml
+++ b/services/profile-api/deployments/api.yaml
@@ -98,3 +98,5 @@ kind: ServiceAccount
 metadata:
   name: profile-api
   namespace: tdk-profile-api
+imagePullSecrets:
+  - name: tadoku-dev-registry-pull

--- a/services/token-reflector/Tiltfile
+++ b/services/token-reflector/Tiltfile
@@ -1,4 +1,5 @@
 load("./../../infra/dev/build/Tiltfile", "bazel_build")
+load("./../../k8s/dev/config/Tiltfile", "dev_registry_push_resource_deps")
 
 watch_file('./deployments/api.yaml')
 k8s_yaml(local('cat ./deployments/api.yaml'))
@@ -9,4 +10,4 @@ bazel_build(
   deps=['./'],
 )
 
-k8s_resource('token-reflector', labels=["infra"])
+k8s_resource('token-reflector', labels=["infra"], resource_deps=dev_registry_push_resource_deps())

--- a/services/token-reflector/deployments/api.yaml
+++ b/services/token-reflector/deployments/api.yaml
@@ -50,3 +50,5 @@ kind: ServiceAccount
 metadata:
   name: token-reflector
   namespace: tdk-token-reflector
+imagePullSecrets:
+  - name: tadoku-dev-registry-pull


### PR DESCRIPTION
## Summary

Adds dev-only Tilt registry authentication for private dev registries without committing real registry hosts, usernames beyond role names, passwords, or generated Secret YAML.

## What changed

- Generates `tadoku-dev-registry-pull` docker-registry secrets from `TADOKU_DEV_REGISTRY_*` env vars in every dev namespace that pulls Tilt-built images.
- Groups dev namespace creation with registry pull secrets so fresh clusters do not rely on namespace-not-found retries.
- Wires Tilt-built frontend Deployments and backend ServiceAccounts to reference the pull secret.
- Adds an optional shared-cluster `dev-registry-push-login` Tilt resource that runs `docker login --password-stdin` before image-building resources when `TADOKU_DEV_REGISTRY_PUSH_PASSWORD` is set.
- Documents pull-side and push-side env vars with placeholders only.

## How verified

- `git diff --check`
- Privacy scan of `git diff` for private hosts, IPs, generated docker config JSON, and real secret-looking values
- YAML parse of touched dev manifests
- `tilt alpha tiltfile-result` with no registry credentials: passed, no registry resources generated
- `tilt alpha tiltfile-result` with placeholder pull credentials: passed, pull secrets rendered
- `tilt alpha tiltfile-result` with placeholder shared-cluster pull and push credentials: passed, `default_registry`, pull secrets, `dev-registry-push-login`, and build-resource dependencies rendered
- no-mistakes test step from the earlier commit: passed Tiltfile evaluation scenarios for env credentials, no credentials, shared-cluster/default-registry behavior, and config-file host fallback

## Remaining notes/commands that could not run

- Did not run full `tilt ci`; it would build/push/apply against a live dev cluster and private registry. Used safe Tiltfile evaluation instead.
- Latest push-login follow-up was committed and pushed directly because firstmate requested skipping no-mistakes for that change.
- The latest GitHub build for commit `45f05807` is running.

<details>
<summary>no-mistakes validation record</summary>

- Rebase: fixed conflicts from rebasing onto `origin/main`.
- Review: fixed duplicate `default_registry`, config host fallback, and namespace/secret ordering.
- Test: passed safe Tiltfile evaluation scenarios.
- Document: passed.
- Lint: passed.
- Push: passed.
- PR: created https://github.com/tadoku/tadoku/pull/703.
- CI before the direct follow-up: all GitHub checks passed; no-mistakes continued monitoring because the PR is intentionally unmerged.

</details>