### PR TITLE
Add guarded database migration recovery workflow

### DIFF
--- a/docs/docs/database-migration-recovery.md
+++ b/docs/docs/database-migration-recovery.md
@@ -1,0 +1,220 @@
+---
+title: Database migration recovery
+---
+
+# Database migration recovery
+
+This runbook applies when an API image's Argo CD `PreSync` migration Job fails
+and `schema_migrations.dirty` is `true`.
+
+The normal `/migrate` command deliberately supports only forward `up`
+migrations. The separate `/migrate-recovery` command supports:
+
+- `inspect`, which reads the current migration version and dirty state;
+- `force`, which changes migration metadata without running SQL.
+
+It does not support `down`, `drop`, or arbitrary migration steps.
+
+## Safety rules
+
+1. Never use `force` to make an error disappear. It changes only
+   `schema_migrations`; it does not repair tables or data.
+2. Stop automated retries before inspecting or repairing the database.
+3. Ensure exactly one migration or recovery process can access the affected
+   database.
+4. Record the failed image digest, migration version, Job logs, Git revision,
+   database state, and recovery commands in the incident.
+5. Take and verify a database backup or PITR recovery point before manual SQL
+   or metadata repair.
+6. Have a second engineer review the physical schema assessment, repair SQL,
+   and selected target version.
+7. Prefer a forward fix. Do not run destructive down migrations during an
+   incident.
+
+## 1. Contain the rollout
+
+1. Terminate the affected Argo CD sync operation.
+2. Disable automated sync and image updates for the affected Application.
+3. Confirm that the failed PreSync Job did not deploy the new API image.
+4. Confirm that the previous API Deployment is available and passes basic
+   health checks.
+5. Confirm that no migration or recovery Pod is currently running.
+
+Do not start another Argo sync while recovery is in progress.
+
+## 2. Preserve evidence and backup
+
+Capture:
+
+- the failed Job YAML and Pod logs;
+- the Application operation result;
+- the API image digest;
+- the migration filenames embedded in that image;
+- the current database backup status and PITR recovery point.
+
+Create an incident-specific backup before modifying the database. Verify that
+the backup can be listed or restored in an isolated environment.
+
+## 3. Inspect migration metadata
+
+Run the failed release's exact API image with `/migrate-recovery`. Use the same
+database owner Secret and migration source as the PreSync Job:
+
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: content-api-migration-inspect
+  namespace: tdk-prod-content-api
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: inspect
+          image: ghcr.io/tadoku/tadoku/content-api@sha256:REPLACE_ME
+          command: ["/migrate-recovery"]
+          args:
+            - "-source"
+            - "file:///migrations"
+            - "-database"
+            - "postgres://$(POSTGRES_USER):$(POSTGRES_PASSWORD)@io-postgres.shared.svc.cluster.local:5432/tadoku_prod_content"
+            - "inspect"
+          env:
+            - name: POSTGRES_USER
+              valueFrom:
+                secretKeyRef:
+                  name: tadoku-prod-content-owner-user.io-postgres.credentials.postgresql.acid.zalan.do
+                  key: username
+            - name: POSTGRES_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: tadoku-prod-content-owner-user.io-postgres.credentials.postgresql.acid.zalan.do
+                  key: password
+```
+
+Expected dirty output:
+
+```text
+version=13 dirty=true
+```
+
+Cross-check it directly:
+
+```sql
+select version, dirty from schema_migrations;
+```
+
+If the two results disagree, stop and investigate the database URL,
+`search_path`, and migration table configuration.
+
+## 4. Determine the physical database state
+
+A dirty version means migration `V` started but did not complete cleanly. It
+does not prove whether zero, some, or all statements took effect.
+
+Compare the failed `V.up.sql` with:
+
+- tables, columns, constraints, indexes, functions, and types;
+- affected row counts and data invariants;
+- migration logs and PostgreSQL logs;
+- the pre-migration backup.
+
+Classify the database into exactly one state:
+
+| State | Required action |
+| --- | --- |
+| Migration rolled back completely | Verify the schema matches the previous successful version. |
+| Migration completed physically | Verify every intended schema and data effect. |
+| Migration partially applied but repairable | Apply reviewed SQL to finish it or restore the previous physical state. |
+| Physical state or data integrity is uncertain | Restore the database from backup/PITR. Do not use `force`. |
+
+Do not select a target metadata version until the physical state matches that
+version exactly.
+
+## 5. Repair the physical state
+
+The preferred options are:
+
+1. finish the failed migration manually so the database exactly matches `V`;
+2. reverse only the known partial effects so it exactly matches the previous
+   successful version;
+3. restore from the pre-migration backup or PITR point.
+
+Save reviewed repair SQL in the incident record before execution. Run it in an
+explicit transaction when PostgreSQL supports transactional execution for all
+included statements.
+
+After the repair, repeat all schema and data checks before changing migration
+metadata.
+
+## 6. Repair migration metadata
+
+Only after the physical database has been verified, run `force`. The command
+requires:
+
+- the dirty version observed by `inspect`;
+- the target version matching the verified physical schema;
+- a second copy of the target version as explicit confirmation.
+
+For a dirty version `13` whose physical changes were completely reverted to
+version `12`:
+
+```text
+/migrate-recovery \
+  -source file:///migrations \
+  -database "$DATABASE_URL" \
+  -expected-version 13 \
+  -target-version 12 \
+  -confirm-target-version 12 \
+  force
+```
+
+The command refuses to run if:
+
+- the database is not dirty;
+- the observed dirty version is not `13`;
+- the target version is newer than the observed dirty version;
+- the confirmation does not match the target;
+- any guard is omitted.
+
+The command reads the metadata again after `force` and fails if the target is
+not clean. Run a separate `inspect` Job as an independent check. Expected
+output:
+
+```text
+version=12 dirty=false
+```
+
+Retain the recovery Job and logs as evidence until the incident is closed.
+
+## 7. Ship a forward fix
+
+1. Never edit a migration that succeeded in another environment.
+2. Add a new forward migration that is safe from the verified database state.
+3. Test first-run, dirty-recovery, forward-fix, and no-op behavior against a
+   disposable PostgreSQL database.
+4. Publish a reviewed API image containing the corrected migrations.
+5. Manually sync the Application while automated sync remains disabled.
+6. Verify:
+   - the PreSync Job succeeds;
+   - `schema_migrations.dirty` is `false`;
+   - the Deployment rolls out only after migration success;
+   - API and data-integrity smoke checks pass;
+   - a subsequent migration run reports `no change`.
+7. Restore image updates and automated sync only after the soak period.
+
+## Migration authoring requirement
+
+PostgreSQL migrations must use explicit `begin` and `commit` when every
+statement in the migration supports transactional execution. Migrations that
+cannot be transactional must document:
+
+- why;
+- possible partial states;
+- detection queries;
+- compensating or completion SQL;
+- backup and restore expectations.
+
+Test both failure and recovery paths before production adoption.

--- a/docs/sidebars.ts
+++ b/docs/sidebars.ts
@@ -39,7 +39,7 @@ const sidebars: SidebarsConfig = {
     {
       type: 'category',
       label: 'Administration',
-      items: ['account-deletion'],
+      items: ['account-deletion', 'database-migration-recovery'],
     },
   ],
 };

--- a/services/authz-api/BUILD.bazel
+++ b/services/authz-api/BUILD.bazel
@@ -45,6 +45,7 @@ oci_image(
     entrypoint = ["/authz-api"],
     tars = [
         ":app_layer",
+        "//services/common/migrate-recovery:layer",
         "//services/common/migrate-runner:layer",
         "//services/authz-api/storage/postgres/migrations:tar",
     ],

--- a/services/common/migrate-recovery/BUILD.bazel
+++ b/services/common/migrate-recovery/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+go_library(
+    name = "migrate-recovery_lib",
+    srcs = ["main.go"],
+    importpath = "github.com/tadoku/tadoku/services/common/migrate-recovery",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_golang_migrate_migrate_v4//:migrate",
+        "@com_github_golang_migrate_migrate_v4//database/postgres",
+        "@com_github_golang_migrate_migrate_v4//source/file",
+    ],
+)
+
+go_binary(
+    name = "migrate-recovery",
+    embed = [":migrate-recovery_lib"],
+    pure = "on",
+    static = "on",
+    visibility = ["//visibility:private"],
+)
+
+go_test(
+    name = "migrate-recovery_test",
+    srcs = ["main_test.go"],
+    embed = [":migrate-recovery_lib"],
+    deps = [
+        "@com_github_golang_migrate_migrate_v4//:migrate",
+        "@com_github_stretchr_testify//assert",
+    ],
+)
+
+pkg_tar(
+    name = "layer",
+    srcs = [":migrate-recovery"],
+    mode = "0755",
+    package_dir = "/",
+    visibility = [
+        "//services/authz-api:__pkg__",
+        "//services/content-api:__pkg__",
+        "//services/immersion-api:__pkg__",
+        "//services/profile-api:__pkg__",
+    ],
+)

--- a/services/common/migrate-recovery/main.go
+++ b/services/common/migrate-recovery/main.go
@@ -1,0 +1,180 @@
+package main
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+
+	"github.com/golang-migrate/migrate/v4"
+	_ "github.com/golang-migrate/migrate/v4/database/postgres"
+	_ "github.com/golang-migrate/migrate/v4/source/file"
+)
+
+type migration interface {
+	Version() (version uint, dirty bool, err error)
+	Force(version int) error
+	Close() (sourceErr error, databaseErr error)
+}
+
+type migrationFactory func(sourceURL, databaseURL string) (migration, error)
+
+func newMigration(sourceURL, databaseURL string) (migration, error) {
+	return migrate.New(sourceURL, databaseURL)
+}
+
+func closeMigration(runner migration, stderr io.Writer) bool {
+	sourceErr, databaseErr := runner.Close()
+	if sourceErr != nil {
+		fmt.Fprintf(stderr, "migrate-recovery: close source: %v\n", sourceErr)
+	}
+	if databaseErr != nil {
+		fmt.Fprintf(stderr, "migrate-recovery: close database: %v\n", databaseErr)
+	}
+	return sourceErr == nil && databaseErr == nil
+}
+
+func run(args []string, stdout, stderr io.Writer, factory migrationFactory) int {
+	flags := flag.NewFlagSet("migrate-recovery", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	sourceURL := flags.String("source", "", "migration source URL")
+	databaseURL := flags.String("database", "", "database URL")
+	expectedVersion := flags.Int("expected-version", 0, "dirty version observed during inspection")
+	targetVersion := flags.Int("target-version", 0, "version matching the verified physical schema")
+	confirmation := flags.String("confirm-target-version", "", "repeat target version to confirm metadata repair")
+
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if *sourceURL == "" {
+		fmt.Fprintln(stderr, "migrate-recovery: -source is required")
+		return 2
+	}
+	if *databaseURL == "" {
+		fmt.Fprintln(stderr, "migrate-recovery: -database is required")
+		return 2
+	}
+	if flags.NArg() != 1 {
+		fmt.Fprintln(stderr, "migrate-recovery: expected command: inspect or force")
+		return 2
+	}
+
+	command := flags.Arg(0)
+	if command != "inspect" && command != "force" {
+		fmt.Fprintln(stderr, "migrate-recovery: expected command: inspect or force")
+		return 2
+	}
+
+	setFlags := map[string]bool{}
+	flags.Visit(func(current *flag.Flag) {
+		setFlags[current.Name] = true
+	})
+
+	if command == "inspect" &&
+		(setFlags["expected-version"] || setFlags["target-version"] || setFlags["confirm-target-version"]) {
+		fmt.Fprintln(stderr, "migrate-recovery: force flags are not valid with inspect")
+		return 2
+	}
+	if command == "force" {
+		for _, name := range []string{"expected-version", "target-version", "confirm-target-version"} {
+			if !setFlags[name] {
+				fmt.Fprintf(stderr, "migrate-recovery: -%s is required with force\n", name)
+				return 2
+			}
+		}
+		if *targetVersion < -1 {
+			fmt.Fprintln(stderr, "migrate-recovery: -target-version must be at least -1")
+			return 2
+		}
+		if *expectedVersion < 0 {
+			fmt.Fprintln(stderr, "migrate-recovery: -expected-version must be non-negative")
+			return 2
+		}
+		if *targetVersion > *expectedVersion {
+			fmt.Fprintln(stderr, "migrate-recovery: -target-version cannot exceed -expected-version")
+			return 2
+		}
+		if *confirmation != strconv.Itoa(*targetVersion) {
+			fmt.Fprintln(stderr, "migrate-recovery: confirmation does not match target version")
+			return 2
+		}
+	}
+
+	runner, err := factory(*sourceURL, *databaseURL)
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate-recovery: initialize: %v\n", err)
+		return 1
+	}
+
+	version, dirty, versionErr := runner.Version()
+	if versionErr != nil && !errors.Is(versionErr, migrate.ErrNilVersion) {
+		fmt.Fprintf(stderr, "migrate-recovery: inspect: %v\n", versionErr)
+		closeMigration(runner, stderr)
+		return 1
+	}
+
+	if command == "inspect" {
+		if errors.Is(versionErr, migrate.ErrNilVersion) {
+			fmt.Fprintln(stdout, "version=nil dirty=false")
+		} else {
+			fmt.Fprintf(stdout, "version=%d dirty=%t\n", version, dirty)
+		}
+		if !closeMigration(runner, stderr) {
+			return 1
+		}
+		return 0
+	}
+
+	if errors.Is(versionErr, migrate.ErrNilVersion) {
+		fmt.Fprintln(stderr, "migrate-recovery: refusing force: database has no migration version")
+		closeMigration(runner, stderr)
+		return 1
+	}
+	if !dirty {
+		fmt.Fprintf(stderr, "migrate-recovery: refusing force: version %d is not dirty\n", version)
+		closeMigration(runner, stderr)
+		return 1
+	}
+	if int(version) != *expectedVersion {
+		fmt.Fprintf(
+			stderr,
+			"migrate-recovery: refusing force: expected dirty version %d, found %d\n",
+			*expectedVersion,
+			version,
+		)
+		closeMigration(runner, stderr)
+		return 1
+	}
+
+	if err := runner.Force(*targetVersion); err != nil {
+		fmt.Fprintf(stderr, "migrate-recovery: force: %v\n", err)
+		closeMigration(runner, stderr)
+		return 1
+	}
+
+	forcedVersion, forcedDirty, forcedVersionErr := runner.Version()
+	if *targetVersion == -1 {
+		if !errors.Is(forcedVersionErr, migrate.ErrNilVersion) || forcedDirty {
+			fmt.Fprintln(stderr, "migrate-recovery: force verification failed")
+			closeMigration(runner, stderr)
+			return 1
+		}
+	} else if forcedVersionErr != nil || forcedDirty || int(forcedVersion) != *targetVersion {
+		fmt.Fprintln(stderr, "migrate-recovery: force verification failed")
+		closeMigration(runner, stderr)
+		return 1
+	}
+
+	if !closeMigration(runner, stderr) {
+		return 1
+	}
+	fmt.Fprintf(stdout, "forced version=%d dirty=false\n", *targetVersion)
+	return 0
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr, newMigration))
+}

--- a/services/common/migrate-recovery/main_test.go
+++ b/services/common/migrate-recovery/main_test.go
@@ -1,0 +1,347 @@
+package main
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/golang-migrate/migrate/v4"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeMigration struct {
+	version            uint
+	dirty              bool
+	versionErr         error
+	forceErr           error
+	sourceCloseErr     error
+	databaseCloseErr   error
+	forcedVersion      int
+	forceCalled        bool
+	closeCalled        bool
+	forceDoesNotUpdate bool
+}
+
+func (m *fakeMigration) Version() (uint, bool, error) {
+	return m.version, m.dirty, m.versionErr
+}
+
+func (m *fakeMigration) Force(version int) error {
+	m.forceCalled = true
+	m.forcedVersion = version
+	if m.forceErr == nil && !m.forceDoesNotUpdate {
+		m.dirty = false
+		if version == -1 {
+			m.version = 0
+			m.versionErr = migrate.ErrNilVersion
+		} else {
+			m.version = uint(version)
+			m.versionErr = nil
+		}
+	}
+	return m.forceErr
+}
+
+func (m *fakeMigration) Close() (error, error) {
+	m.closeCalled = true
+	return m.sourceCloseErr, m.databaseCloseErr
+}
+
+func runWithFake(t *testing.T, args []string, runner *fakeMigration) (int, string, string) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	exitCode := run(
+		args,
+		&stdout,
+		&stderr,
+		func(sourceURL, databaseURL string) (migration, error) {
+			assert.Equal(t, "file:///migrations", sourceURL)
+			assert.Equal(t, "postgres://database", databaseURL)
+			return runner, nil
+		},
+	)
+	return exitCode, stdout.String(), stderr.String()
+}
+
+func TestInspectCleanVersion(t *testing.T) {
+	runner := &fakeMigration{version: 12}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		runner,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "version=12 dirty=false\n", stdout)
+	assert.Empty(t, stderr)
+	assert.True(t, runner.closeCalled)
+}
+
+func TestInspectDirtyVersion(t *testing.T) {
+	runner := &fakeMigration{version: 13, dirty: true}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		runner,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "version=13 dirty=true\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestInspectDatabaseWithoutVersion(t *testing.T) {
+	runner := &fakeMigration{versionErr: migrate.ErrNilVersion}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		runner,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "version=nil dirty=false\n", stdout)
+	assert.Empty(t, stderr)
+}
+
+func TestForceDirtyVersion(t *testing.T) {
+	runner := &fakeMigration{version: 13, dirty: true}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"-confirm-target-version", "12",
+			"force",
+		},
+		runner,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "forced version=12 dirty=false\n", stdout)
+	assert.Empty(t, stderr)
+	assert.True(t, runner.forceCalled)
+	assert.Equal(t, 12, runner.forcedVersion)
+	assert.True(t, runner.closeCalled)
+}
+
+func TestForceCanResetToNilVersion(t *testing.T) {
+	runner := &fakeMigration{version: 1, dirty: true}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "1",
+			"-target-version", "-1",
+			"-confirm-target-version", "-1",
+			"force",
+		},
+		runner,
+	)
+
+	assert.Equal(t, 0, exitCode)
+	assert.Equal(t, "forced version=-1 dirty=false\n", stdout)
+	assert.Empty(t, stderr)
+	assert.Equal(t, -1, runner.forcedVersion)
+}
+
+func TestForceRejectsCleanDatabase(t *testing.T) {
+	runner := &fakeMigration{version: 13}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"-confirm-target-version", "12",
+			"force",
+		},
+		runner,
+	)
+
+	assert.Equal(t, 1, exitCode)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "version 13 is not dirty")
+	assert.False(t, runner.forceCalled)
+}
+
+func TestForceRejectsUnexpectedDirtyVersion(t *testing.T) {
+	runner := &fakeMigration{version: 14, dirty: true}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"-confirm-target-version", "12",
+			"force",
+		},
+		runner,
+	)
+
+	assert.Equal(t, 1, exitCode)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "expected dirty version 13, found 14")
+	assert.False(t, runner.forceCalled)
+}
+
+func TestForceRejectsConfirmationMismatchBeforeInitialization(t *testing.T) {
+	var stderr bytes.Buffer
+	factoryCalled := false
+	exitCode := run(
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"-confirm-target-version", "11",
+			"force",
+		},
+		&bytes.Buffer{},
+		&stderr,
+		func(string, string) (migration, error) {
+			factoryCalled = true
+			return nil, nil
+		},
+	)
+
+	assert.Equal(t, 2, exitCode)
+	assert.False(t, factoryCalled)
+	assert.Contains(t, stderr.String(), "confirmation does not match")
+}
+
+func TestForceRequiresEveryGuard(t *testing.T) {
+	var stderr bytes.Buffer
+	exitCode := run(
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"force",
+		},
+		&bytes.Buffer{},
+		&stderr,
+		func(string, string) (migration, error) {
+			return nil, nil
+		},
+	)
+
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr.String(), "-confirm-target-version is required")
+}
+
+func TestForceRejectsTargetBeyondDirtyVersion(t *testing.T) {
+	var stderr bytes.Buffer
+	exitCode := run(
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "14",
+			"-confirm-target-version", "14",
+			"force",
+		},
+		&bytes.Buffer{},
+		&stderr,
+		func(string, string) (migration, error) {
+			return nil, nil
+		},
+	)
+
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr.String(), "cannot exceed")
+}
+
+func TestInspectReportsVersionAndCloseFailures(t *testing.T) {
+	runner := &fakeMigration{
+		versionErr:       errors.New("cannot inspect"),
+		sourceCloseErr:   errors.New("cannot close source"),
+		databaseCloseErr: errors.New("cannot close database"),
+	}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		runner,
+	)
+
+	assert.Equal(t, 1, exitCode)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "cannot inspect")
+	assert.Contains(t, stderr, "cannot close source")
+	assert.Contains(t, stderr, "cannot close database")
+}
+
+func TestForceReportsFailureAndCloses(t *testing.T) {
+	runner := &fakeMigration{
+		version:  13,
+		dirty:    true,
+		forceErr: errors.New("cannot force"),
+	}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"-confirm-target-version", "12",
+			"force",
+		},
+		runner,
+	)
+
+	assert.Equal(t, 1, exitCode)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "cannot force")
+	assert.True(t, runner.closeCalled)
+}
+
+func TestForceVerifiesUpdatedMetadata(t *testing.T) {
+	runner := &fakeMigration{
+		version:            13,
+		dirty:              true,
+		forceDoesNotUpdate: true,
+	}
+	exitCode, stdout, stderr := runWithFake(
+		t,
+		[]string{
+			"-source", "file:///migrations",
+			"-database", "postgres://database",
+			"-expected-version", "13",
+			"-target-version", "12",
+			"-confirm-target-version", "12",
+			"force",
+		},
+		runner,
+	)
+
+	assert.Equal(t, 1, exitCode)
+	assert.Empty(t, stdout)
+	assert.Contains(t, stderr, "force verification failed")
+	assert.True(t, runner.closeCalled)
+}
+
+func TestRejectsUnsupportedCommandBeforeInitialization(t *testing.T) {
+	var stderr bytes.Buffer
+	factoryCalled := false
+	exitCode := run(
+		[]string{"-source", "file:///migrations", "-database", "postgres://database", "down"},
+		&bytes.Buffer{},
+		&stderr,
+		func(string, string) (migration, error) {
+			factoryCalled = true
+			return nil, nil
+		},
+	)
+
+	assert.Equal(t, 2, exitCode)
+	assert.False(t, factoryCalled)
+	assert.Contains(t, stderr.String(), "expected command: inspect or force")
+}

--- a/services/content-api/BUILD.bazel
+++ b/services/content-api/BUILD.bazel
@@ -45,6 +45,7 @@ oci_image(
     entrypoint = ["/content-api"],
     tars = [
         ":app_layer",
+        "//services/common/migrate-recovery:layer",
         "//services/common/migrate-runner:layer",
         "//services/content-api/storage/postgres/migrations:tar",
     ],

--- a/services/immersion-api/BUILD.bazel
+++ b/services/immersion-api/BUILD.bazel
@@ -48,6 +48,7 @@ oci_image(
     entrypoint = ["/immersion-api"],
     tars = [
         ":app_layer",
+        "//services/common/migrate-recovery:layer",
         "//services/common/migrate-runner:layer",
         "//services/immersion-api/storage/postgres/migrations:tar",
     ],

--- a/services/profile-api/BUILD.bazel
+++ b/services/profile-api/BUILD.bazel
@@ -44,6 +44,7 @@ oci_image(
     entrypoint = ["/profile-api"],
     tars = [
         ":app_layer",
+        "//services/common/migrate-recovery:layer",
         "//services/common/migrate-runner:layer",
         "//services/profile-api/storage/postgres/migrations:tar",
     ],


### PR DESCRIPTION
## What changed

- Add a separate `/migrate-recovery` binary while keeping automated `/migrate ... up` unchanged.
- Support read-only `inspect` and guarded metadata-only `force`; do not expose `down`, `drop`, or arbitrary steps.
- Require the observed dirty version, a target version no newer than it, and a duplicate target confirmation before forcing.
- Refuse force against clean or unversioned databases, and re-read metadata after force to verify the target is clean.
- Embed the recovery binary in the content, profile, authz, and immersion API images without changing their normal entrypoints.
- Add an operational runbook covering containment, evidence, backup/PITR, physical schema classification, reviewed repair SQL, guarded metadata repair, forward fixes, resumption, and transactional migration requirements.

## Why

The automated migration wrapper intentionally accepts only `up`, which is safe for Argo CD PreSync execution but left dirty or partially applied migration recovery dependent on an improvised external tool. This adds a constrained, image-pinned recovery path without turning the automated runner into a general destructive migration CLI.

`force` still repairs metadata only. The runbook requires operators to verify or repair the physical schema first, and to restore from backup/PITR whenever data integrity is uncertain.

## Validation

- `bazel build //services/...` passed.
- `bazel test //services/...` passed: 15/15 tests.
- `bazel run //:gazelle -- -mode=diff` passed.
- `pnpm --dir docs typecheck` passed.
- OCI audit confirmed `/migrate-recovery` is executable in the layer and all four API entrypoints remain unchanged.
- Disposable PostgreSQL 17.5 integration test passed:
  - produced a real partial migration and `version=2 dirty=true`;
  - verified the partially committed table and row;
  - rejected a force with an incorrect expected dirty version;
  - manually completed the verified physical schema;
  - forced version 2 clean with all guards and post-force verification;
  - applied a forward migration to version 3 clean;
  - repeated `up` as `no change`;
  - rejected force against the clean database.

## Known documentation build issue

The Docusaurus production build fails before document compilation because the existing dependency graph resolves incompatible ProgressPlugin/Webpack options. Retrying from the committed package lock produced the same tooling error. The sidebar TypeScript check passes; this PR does not modify those dependencies.