### PR TITLE
Publish scanned token-reflector prod image

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -63,6 +63,18 @@ jobs:
           path: "/home/runner/.cache/bazel"
           key: bazel-v5-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'go.mod', 'go.sum') }}
 
+      - name: Load token-reflector image for scanning
+        run: bazel run //services/token-reflector:load
+
+      - name: Scan token-reflector image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ghcr.io/tadoku/tadoku/token-reflector:latest
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: CRITICAL,HIGH
+
       - name: Push images
         run: |
           # Setup credentials for GitHub packages

--- a/services/token-reflector/BUILD.bazel
+++ b/services/token-reflector/BUILD.bazel
@@ -45,7 +45,10 @@ oci_push(
 oci_push(
     name = "push",
     image = ":image",
-    remote_tags = ["latest"],
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
     repository = "ghcr.io/tadoku/tadoku/token-reflector",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## What changed

- scan the token-reflector container with pinned Trivy before publishing
- fail publication on fixable high or critical vulnerabilities
- publish the tested image under both latest and the migration-standard prod tag

## Why

Argo CD Image Updater tracks the mutable prod tag by digest, but token-reflector CI only published latest. This establishes the required promotion tag and produces the genuine GHCR package event for the migration canary.

## Validation

- bazel build //services/token-reflector:push
- bazel test //services/token-reflector/...
- verified Trivy Action inputs against v0.36.0 action manifest
- git diff --check