### PR TITLE
Refresh and scan backend image bases

### DIFF
--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -74,6 +74,7 @@ jobs:
         run: |
           scan_status=0
           while read -r image; do
+            [[ -z "${image}" ]] && continue
             trivy image \
               --exit-code 1 \
               --ignore-unfixed \

--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -45,8 +45,43 @@ jobs:
             <(bazel query 'kind("oci_push", labels(data, //:push_images))' | sort) \
           || { echo "//:push_images is out of sync with production oci_push targets named :push under //services/..." >&2; exit 1; }
 
+      - name: Check load_images covers all production oci_load targets
+        run: |
+          diff \
+            <(bazel query 'filter("^//services/[^/]+:load$", attr(name, "^load$", kind("oci_load", //services/...)))' | sort) \
+            <(bazel query 'kind("oci_load", labels(data, //:load_images))' | sort) \
+          || { echo "//:load_images is out of sync with production oci_load targets named :load under //services/..." >&2; exit 1; }
+
       - name: Run tests
         run: bazel test //...
+
+      - name: Load backend images for scanning
+        run: bazel run //:load_images
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Scan backend images
+        env:
+          BACKEND_IMAGES: |
+            ghcr.io/tadoku/tadoku/authz-api:latest
+            ghcr.io/tadoku/tadoku/content-api:latest
+            ghcr.io/tadoku/tadoku/immersion-api:latest
+            ghcr.io/tadoku/tadoku/profile-api:latest
+            ghcr.io/tadoku/tadoku/token-reflector:latest
+        run: |
+          scan_status=0
+          while read -r image; do
+            trivy image \
+              --exit-code 1 \
+              --ignore-unfixed \
+              --scanners vuln \
+              --severity CRITICAL,HIGH \
+              "${image}" || scan_status=1
+          done <<< "${BACKEND_IMAGES}"
+          exit "${scan_status}"
 
   publish:
     name: Publish Tadoku Images
@@ -62,18 +97,6 @@ jobs:
         with:
           path: "/home/runner/.cache/bazel"
           key: bazel-v5-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'go.mod', 'go.sum') }}
-
-      - name: Load token-reflector image for scanning
-        run: bazel run //services/token-reflector:load
-
-      - name: Scan token-reflector image
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: ghcr.io/tadoku/tadoku/token-reflector:latest
-          format: table
-          exit-code: "1"
-          ignore-unfixed: true
-          severity: CRITICAL,HIGH
 
       - name: Push images
         run: |

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -3,12 +3,35 @@ load("@gazelle//:def.bzl", "gazelle")
 # gazelle:prefix github.com/tadoku/tadoku
 gazelle(name = "gazelle")
 
+# Loads all service images in one `bazel run //:load_images` invocation.
+# Used by CI (.github/workflows/build-bazel.yaml); add new production oci_load
+# targets to both args and data below.
+sh_binary(
+    name = "load_images",
+    srcs = ["tools/ci/run_bazel_images.sh"],
+    args = [
+        "$(rlocationpath //services/authz-api:load)",
+        "$(rlocationpath //services/content-api:load)",
+        "$(rlocationpath //services/immersion-api:load)",
+        "$(rlocationpath //services/profile-api:load)",
+        "$(rlocationpath //services/token-reflector:load)",
+    ],
+    data = [
+        "//services/authz-api:load",
+        "//services/content-api:load",
+        "//services/immersion-api:load",
+        "//services/profile-api:load",
+        "//services/token-reflector:load",
+        "@bazel_tools//tools/bash/runfiles",
+    ],
+)
+
 # Pushes all service images in one `bazel run //:push_images` invocation.
-# Used by CI (.github/workflows/build-bazel.yaml); add new oci_push targets
-# to both args and data below.
+# Used by CI (.github/workflows/build-bazel.yaml); add new production oci_push
+# targets to both args and data below.
 sh_binary(
     name = "push_images",
-    srcs = ["tools/ci/push_bazel_images.sh"],
+    srcs = ["tools/ci/run_bazel_images.sh"],
     args = [
         "$(rlocationpath //services/authz-api:push)",
         "$(rlocationpath //services/content-api:push)",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -54,7 +54,7 @@ bazel_dep(name = "rules_oci", version = "2.3.0")
 oci = use_extension("@rules_oci//oci:extensions.bzl", "oci")
 oci.pull(
     name = "distroless_base",
-    digest = "sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44",
+    digest = "sha256:62730825d3cf03571e0a1b8f014748de94d0404500f063593b614c23da38841d",
     image = "gcr.io/distroless/base-debian12",
     platforms = [
         "linux/amd64",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -383,7 +383,7 @@
     "@@rules_oci+//oci:extensions.bzl%oci": {
       "general": {
         "bzlTransitiveDigest": "NjU8ig/65ZjS88ZpHsCWZ9gLuCjepnPvN0WUdDyTD64=",
-        "usagesDigest": "u3GWq/2IFqzonWuSggDLz2KySEqLdaiYJjVYe3XskH0=",
+        "usagesDigest": "Dk27dyM1RlwMZE0R5V3I9faK25Hx9CdrqCj97d0xg7U=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -395,7 +395,7 @@
               "scheme": "https",
               "registry": "gcr.io",
               "repository": "distroless/base-debian12",
-              "identifier": "sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44",
+              "identifier": "sha256:62730825d3cf03571e0a1b8f014748de94d0404500f063593b614c23da38841d",
               "platform": "linux/amd64",
               "target_name": "distroless_base_linux_amd64",
               "bazel_tags": []
@@ -409,7 +409,7 @@
               "scheme": "https",
               "registry": "gcr.io",
               "repository": "distroless/base-debian12",
-              "identifier": "sha256:27769871031f67460f1545a52dfacead6d18a9f197db77110cfc649ca2a91f44",
+              "identifier": "sha256:62730825d3cf03571e0a1b8f014748de94d0404500f063593b614c23da38841d",
               "platforms": {
                 "@@platforms//cpu:x86_64": "@distroless_base_linux_amd64"
               },
@@ -3513,162 +3513,162 @@
           "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
         ]
       },
-      "1.26.4": {
+      "1.26.5": {
         "aix_ppc64": [
-          "go1.26.4.aix-ppc64.tar.gz",
-          "881bf44c07203fc1759d477412c2dfae425e5d2023acdd79299d5de5b4de8e77"
+          "go1.26.5.aix-ppc64.tar.gz",
+          "e7f3c518fd7a8bc17f4389e342554016785f95ce447f8f09a260328de0d0f06c"
         ],
         "darwin_amd64": [
-          "go1.26.4.darwin-amd64.tar.gz",
-          "05dc9b5f9997744520aaebb3d5deaa7c755371aebbfb7f97c2511a9f3367538d"
+          "go1.26.5.darwin-amd64.tar.gz",
+          "6231d8d3b8f5552ec6cbf6d685bdd5482e1e703214b120e89b3bf0d7bf1ef725"
         ],
         "darwin_arm64": [
-          "go1.26.4.darwin-arm64.tar.gz",
-          "b62ad2b6d7d2464f12a5bcad7ff47f19d08325773b5efd21610e445a05a9bf53"
+          "go1.26.5.darwin-arm64.tar.gz",
+          "efb87ff28af9a188d0536ef5d42e63dd52ba8263cd7344a993cc48dd11dedb6a"
         ],
         "dragonfly_amd64": [
-          "go1.26.4.dragonfly-amd64.tar.gz",
-          "bcc3ee1cfb6dd03a2d5abf07174212df1764ae54406c389b71a7fd2d05a8f0c8"
+          "go1.26.5.dragonfly-amd64.tar.gz",
+          "96b53091297bd3a9ec8ed39f5f76b074c813dd74a6f429c03c667877ff27fdf8"
         ],
         "freebsd_386": [
-          "go1.26.4.freebsd-386.tar.gz",
-          "f4325e0f9a5894e79c60b5e692af55a1e6f261b8ea73dcd20eced8372ad08233"
+          "go1.26.5.freebsd-386.tar.gz",
+          "1a0226fc025d97d30a112ad0d09b13dcacedc5b24b04bf8f21a0cd29aac4d947"
         ],
         "freebsd_amd64": [
-          "go1.26.4.freebsd-amd64.tar.gz",
-          "e91e96c0d3bd8f770e5a0facaf21d010a84e1c9440d830210cb3c223f0b7fb50"
+          "go1.26.5.freebsd-amd64.tar.gz",
+          "0e5ddc51a62018211d461d6bf409939b04eaa4d6dd6d7097910090ef755ed947"
         ],
         "freebsd_arm": [
-          "go1.26.4.freebsd-arm.tar.gz",
-          "36e45b3a843087f0f95a71f2ed453ea7e1727e684644d13f8b4c6c93fd977d41"
+          "go1.26.5.freebsd-arm.tar.gz",
+          "f8a59e86427158d89b2ba158d7f6004881e378fa3d7e4aefd4df17e4ee3a6bd1"
         ],
         "freebsd_arm64": [
-          "go1.26.4.freebsd-arm64.tar.gz",
-          "34aee1071d74cc23703d1b415c5fa44f840d29fd3733dac34944d83cfada3ff3"
+          "go1.26.5.freebsd-arm64.tar.gz",
+          "ae3825c8c57cc0e64c2233bfb9bba2e091f2126728e4c33492592c24b60dfcd0"
         ],
         "illumos_amd64": [
-          "go1.26.4.illumos-amd64.tar.gz",
-          "27603bcd431afab272a5ed81cc951146181e8139640c46ed2ea5b560e1097038"
+          "go1.26.5.illumos-amd64.tar.gz",
+          "fcd06289bd8a5a9962e5acab2f30e7daa74952327b01366fa9f6e07007e65be1"
         ],
         "linux_386": [
-          "go1.26.4.linux-386.tar.gz",
-          "5ca0982791791559d11a0eba939617a94c3f37c21aa514a55c415b9167efc658"
+          "go1.26.5.linux-386.tar.gz",
+          "88c162b204e6eefcc32499453b492e80209f4a4c78c33092636901c540fb0d05"
         ],
         "linux_amd64": [
-          "go1.26.4.linux-amd64.tar.gz",
-          "1153d3d50e0ac764b447adfe05c2bcf08e889d42a02e0fe0259bd47f6733ad7f"
+          "go1.26.5.linux-amd64.tar.gz",
+          "5c2c3b16caefa1d968a94c1daca04a7ca301a496d9b086e17ad77bb81393f053"
         ],
         "linux_arm64": [
-          "go1.26.4.linux-arm64.tar.gz",
-          "ef758ae7c6cf9267c9c0ef080b8965f453d89ab2d25d9eb22de4405925238768"
+          "go1.26.5.linux-arm64.tar.gz",
+          "fe4789e92b1f33358680864bbe8704289e7bb5fc207d80623c308935bd696d49"
         ],
         "linux_armv6l": [
-          "go1.26.4.linux-armv6l.tar.gz",
-          "8db458e995f18a9427a745cefe7a3323962fa2548c4715148963311f300d3b1a"
+          "go1.26.5.linux-armv6l.tar.gz",
+          "6dae9edab81c13bccf962dec15f1fd2ec26c14a6821b4d2c92dab4130c289d7a"
         ],
         "linux_loong64": [
-          "go1.26.4.linux-loong64.tar.gz",
-          "9f6d288d8972dd649ff3ecfdd3ed98e0664b5efb432e841408c054c25af26ed3"
+          "go1.26.5.linux-loong64.tar.gz",
+          "82736bb7794547a73372ddfeb1b370cfea4d17f04782a65e82a389a01ff0f7aa"
         ],
         "linux_mips": [
-          "go1.26.4.linux-mips.tar.gz",
-          "3435d0d8424562dfcf12517040b6a2388ee0f6f20b9d66b2349a6c5034d57997"
+          "go1.26.5.linux-mips.tar.gz",
+          "3d313aefb8b7547beae18bb69febcf1571f775146209332a48a2942993655417"
         ],
         "linux_mips64": [
-          "go1.26.4.linux-mips64.tar.gz",
-          "691263ab84943aff78d1422dfae66f352d907fc67560e66e7ceec3898fb7d5e6"
+          "go1.26.5.linux-mips64.tar.gz",
+          "7e5547e99a891e338fa5490b72d46ea7fd0593259df51561d7f55d4698503a8c"
         ],
         "linux_mips64le": [
-          "go1.26.4.linux-mips64le.tar.gz",
-          "23946b019b118ed85676090fd9110cfa091667c8c52d3d5276b73f3dd46d31f4"
+          "go1.26.5.linux-mips64le.tar.gz",
+          "7e05aceb9dea6033bc2f6dde29139293d8247cc2db749a206472b3916b1765a1"
         ],
         "linux_mipsle": [
-          "go1.26.4.linux-mipsle.tar.gz",
-          "4436df043e2a448f8937d1f944a3cd786d815c872fdce38dd892269845c1c54f"
+          "go1.26.5.linux-mipsle.tar.gz",
+          "e481470951e3a22a014ee70aebaae0c35aae4193a253d22ecf59d58f4bdbc450"
         ],
         "linux_ppc64": [
-          "go1.26.4.linux-ppc64.tar.gz",
-          "d7c3970c1818d63b7b3473a01b9f5f208da1e793a902d3b2e26d5e5174eb6026"
+          "go1.26.5.linux-ppc64.tar.gz",
+          "8ef02abd6f2b4040b7eb001b64597d16b9fa9aa563baaecf181ad8d9806c9991"
         ],
         "linux_ppc64le": [
-          "go1.26.4.linux-ppc64le.tar.gz",
-          "53f49b8c7eace2d30389327b4a516b13321f90377fdf5929a6b63174609bc22e"
+          "go1.26.5.linux-ppc64le.tar.gz",
+          "c5d60e2b303bb612f20cd82786594b64874e73b35134025e27d3390bf284ae43"
         ],
         "linux_riscv64": [
-          "go1.26.4.linux-riscv64.tar.gz",
-          "2b9ba137baaa3031fd74330cb36ab54c5abe380867ca9fbab7c552f3db740555"
+          "go1.26.5.linux-riscv64.tar.gz",
+          "d4a24dd4484d3f86b99c2d300af0dea5d184557e6d61eb7aba19ff61662750e3"
         ],
         "linux_s390x": [
-          "go1.26.4.linux-s390x.tar.gz",
-          "1e12a2318f3dd4c57027c865f6cb51f5d1e36b02d10f3e6316ce7b61a27b3ca1"
+          "go1.26.5.linux-s390x.tar.gz",
+          "09ce3c504c0323968b75a717244dca4f25cd4cf0443e5ff6bc0bfa74add89fa7"
         ],
         "netbsd_386": [
-          "go1.26.4.netbsd-386.tar.gz",
-          "67a172e4780d1b2a5412b73e86798937f2eb2f85aba6d740df4fbe6d6b555fa2"
+          "go1.26.5.netbsd-386.tar.gz",
+          "6df082b6dd877c3e71af3c44e67b8684f8592cb0fc50aed3ea9e58968bc3165f"
         ],
         "netbsd_amd64": [
-          "go1.26.4.netbsd-amd64.tar.gz",
-          "3321f16e91c7d6d9c8df556690fbe8aef028aac9a0d6d466af9d3c20bd599503"
+          "go1.26.5.netbsd-amd64.tar.gz",
+          "daed1cb730d52e8b40866253b6271fd215f6128372dccc61d7784d4d3fb4a1bf"
         ],
         "netbsd_arm": [
-          "go1.26.4.netbsd-arm.tar.gz",
-          "a3830f9f0f9fb00648346508d4d2c6fa2d7c1cd4c478fb88051ff6f1b49f0610"
+          "go1.26.5.netbsd-arm.tar.gz",
+          "d8a18f2d5afb6aaf47b79135221a964c21ee5cf5d568301a718904d887b1c96f"
         ],
         "netbsd_arm64": [
-          "go1.26.4.netbsd-arm64.tar.gz",
-          "f240a98583a12f16cd6ea4799d29e5ccdc96892314263c0065e6511c783e26ab"
+          "go1.26.5.netbsd-arm64.tar.gz",
+          "60520191abd288fb0f22b279ee63497b3a81318134e41f2bb80f548c9227bd6a"
         ],
         "openbsd_386": [
-          "go1.26.4.openbsd-386.tar.gz",
-          "c0c892180ebc9038637f158a010bdc2d962d303d9c0346ae5856fcd2088b16c7"
+          "go1.26.5.openbsd-386.tar.gz",
+          "723a35e81882ddd8bdcb2539111f53ab4b03d4dbc114a2420d47963163465843"
         ],
         "openbsd_amd64": [
-          "go1.26.4.openbsd-amd64.tar.gz",
-          "cd33f8f7f103cc9151d69795a7f20482335a88cf4eb76a3c56c12afbb5b1b2f0"
+          "go1.26.5.openbsd-amd64.tar.gz",
+          "27721c64efcb571ecfbf52ee77f133ec73dca96015b315199be104ed2dfafd87"
         ],
         "openbsd_arm": [
-          "go1.26.4.openbsd-arm.tar.gz",
-          "5ab1a54a1dc4f425006101b81c12cd88a457b22496add2bb8b6f6e73b58cf1f1"
+          "go1.26.5.openbsd-arm.tar.gz",
+          "2de3fb692c74c68a40d8c92ec6a077a18c14a44e8e41a8c22edeb286b3a4dfce"
         ],
         "openbsd_arm64": [
-          "go1.26.4.openbsd-arm64.tar.gz",
-          "cf8b0f5d6a043771df53fe70054d2b2b792f4c7693ad6cd5a891c252d813bc33"
+          "go1.26.5.openbsd-arm64.tar.gz",
+          "969a90bc34bda3ec06c0c3278ae00cdaa9b747b100cadec9f3f8c2cb36f01c69"
         ],
         "openbsd_ppc64": [
-          "go1.26.4.openbsd-ppc64.tar.gz",
-          "dcf7c6962c43ff67a0d804b989589fe4f3fd574c92b932659c95b1bb32c66f82"
+          "go1.26.5.openbsd-ppc64.tar.gz",
+          "cb3908dd5904df453ebce07cfc660b7a14b7fed9525463521f01a04affd49eb8"
         ],
         "openbsd_riscv64": [
-          "go1.26.4.openbsd-riscv64.tar.gz",
-          "e6ba2daf626770f7d453e7974058dee4b85cb198613ecbb97048a730dc1d5497"
+          "go1.26.5.openbsd-riscv64.tar.gz",
+          "922864dbcb3ec989f456b2c313a46a4c0b0bd93b398603dc0db2d5a72b5ca47c"
         ],
         "plan9_386": [
-          "go1.26.4.plan9-386.tar.gz",
-          "003b912f269786612ad01088178ffcb6f03421fdd61cc4d8b71922571aabd09a"
+          "go1.26.5.plan9-386.tar.gz",
+          "7858fe6515a8e71050a3b59211b6c6f6947822497ecbe1ab81f4e4503b67a635"
         ],
         "plan9_amd64": [
-          "go1.26.4.plan9-amd64.tar.gz",
-          "663871da0f2263d6553828e695be5346f816015f1a6fe7ead22db538ebb6b293"
+          "go1.26.5.plan9-amd64.tar.gz",
+          "513acf2518947e51210772145436e62eb67cc44738c5df3b6218dfeb66f6416c"
         ],
         "plan9_arm": [
-          "go1.26.4.plan9-arm.tar.gz",
-          "9b350fc94bb0c17fe30604e41c7573a9a70bbab258646f0e262a4c6851e4d2b8"
+          "go1.26.5.plan9-arm.tar.gz",
+          "131c06ed5b7ce904ff7b121c63ffd76a699fff43b96e019914f093ede1be9e4a"
         ],
         "solaris_amd64": [
-          "go1.26.4.solaris-amd64.tar.gz",
-          "92eb3f7e224e5dd7ac9e0fb9455f8619c3999faf1e350a9505bb2ed5f7e41b7e"
+          "go1.26.5.solaris-amd64.tar.gz",
+          "33a1fc532f8d5fc5964b28a056729bc50a59657b653a5f1b04c2aeb2ac54c149"
         ],
         "windows_386": [
-          "go1.26.4.windows-386.zip",
-          "2064a4a249fd2ee2db23e7080dc19b42768969f2830541841d0f7a9c80996946"
+          "go1.26.5.windows-386.zip",
+          "cab0f6847c17f4c904c0bacb6ec6b84e730fc797f4ba885f42383d580fc2d399"
         ],
         "windows_amd64": [
-          "go1.26.4.windows-amd64.zip",
-          "3ca8fb4630b07c419cbdd51f754e31363cfcfb83b3a5354d9e895c90be2cc345"
+          "go1.26.5.windows-amd64.zip",
+          "97e6b2a833b6d89f9ff17d25419ac0a7e3b482a044e9ab18cdef834bd834fd38"
         ],
         "windows_arm64": [
-          "go1.26.4.windows-arm64.zip",
-          "62247f56fb7d7b827d237152c4e3fcd69a24d0fa9430dc73dbda7593ae82bc8d"
+          "go1.26.5.windows-arm64.zip",
+          "f96ee46396d69f1e231c8d981ec6a70216238a646a1f2cd74aea0d0016bbc017"
         ]
       }
     }

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/tadoku/tadoku
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/MicahParks/keyfunc v1.7.0

--- a/services/authz-api/BUILD.bazel
+++ b/services/authz-api/BUILD.bazel
@@ -58,6 +58,7 @@ oci_load(
         "ghcr.io/tadoku/tadoku/authz-api:latest",
         "bazel/services/authz-api:latest",
     ],
+    visibility = ["//visibility:public"],
 )
 
 oci_push(

--- a/services/content-api/BUILD.bazel
+++ b/services/content-api/BUILD.bazel
@@ -59,6 +59,7 @@ oci_load(
         "ghcr.io/tadoku/tadoku/content-api:latest",
         "bazel/services/content-api:latest",
     ],
+    visibility = ["//visibility:public"],
 )
 
 oci_push(

--- a/services/immersion-api/BUILD.bazel
+++ b/services/immersion-api/BUILD.bazel
@@ -62,6 +62,7 @@ oci_load(
         "ghcr.io/tadoku/tadoku/immersion-api:latest",
         "bazel/services/immersion-api:latest",
     ],
+    visibility = ["//visibility:public"],
 )
 
 oci_push(

--- a/services/profile-api/BUILD.bazel
+++ b/services/profile-api/BUILD.bazel
@@ -57,6 +57,7 @@ oci_load(
         "ghcr.io/tadoku/tadoku/profile-api:latest",
         "bazel/services/profile-api:latest",
     ],
+    visibility = ["//visibility:public"],
 )
 
 oci_push(

--- a/services/token-reflector/BUILD.bazel
+++ b/services/token-reflector/BUILD.bazel
@@ -34,6 +34,7 @@ oci_load(
         "ghcr.io/tadoku/tadoku/token-reflector:latest",
         "bazel/services/token-reflector:latest",
     ],
+    visibility = ["//visibility:public"],
 )
 
 oci_push(

--- a/tools/ci/run_bazel_images.sh
+++ b/tools/ci/run_bazel_images.sh
@@ -1,10 +1,8 @@
 #!/usr/bin/env bash
 #
-# Runs a list of oci_push binaries (passed as runfiles paths in "$@") so all
-# service images are pushed in a single `bazel run //:push_images` invocation,
-# instead of one bazel analysis per image. Invoked by CI in
-# .github/workflows/build-bazel.yaml; each push is wrapped in a GitHub Actions
-# log group.
+# Runs a list of oci_load or oci_push binaries passed as runfiles paths in
+# "$@", allowing CI to load or push all service images after one Bazel
+# analysis. Each operation is wrapped in a GitHub Actions log group.
 set -uo pipefail
 
 runfiles_bash="bazel_tools/tools/bash/runfiles/runfiles.bash"
@@ -43,13 +41,13 @@ resolve_runfile() {
   return 1
 }
 
-for pusher in "$@"; do
-  if ! resolved_pusher="$(resolve_runfile "${pusher}")"; then
-    echo "could not resolve ${pusher}" >&2
+for image_operation in "$@"; do
+  if ! resolved_operation="$(resolve_runfile "${image_operation}")"; then
+    echo "could not resolve ${image_operation}" >&2
     exit 1
   fi
 
-  echo "::group::${pusher}"
-  "${resolved_pusher}"
+  echo "::group::${image_operation}"
+  "${resolved_operation}"
   echo "::endgroup::"
 done


### PR DESCRIPTION
## What changed

- upgrade the project-wide Go toolchain from 1.26.4 to 1.26.5
- refresh the shared distroless Debian 12 base to the patched digest
- aggregate all five production backend image loads in Bazel
- scan authz-api, content-api, immersion-api, profile-api, and token-reflector on every CI build
- require zero fixable HIGH/CRITICAL findings before the publish job can run
- retain the token-reflector prod promotion added for the Argo migration canary

## Why

The first token-reflector production scan found fixable OpenSSL vulnerabilities in the shared base and a fixed Go standard-library vulnerability. Updating shared inputs fixes every backend image, while the aggregate coverage check prevents future production service images from silently skipping the scan.

## Validation

- bazel mod tidy
- bazel run //:gazelle -- -mode=diff
- bazel build //...
- bazel test //... (15/15 passed)
- bazel run //:load_images through OrbStack
- Trivy 0.72.0: zero fixable HIGH/CRITICAL findings in all five backend images
- push/load aggregate Bazel query coverage checks passed
- Actionlint 1.7.12 passed
- ShellCheck passed
- git diff --check passed