### PR TITLE
ci: publish scanned frontend prod images

### DIFF
--- a/.github/workflows/build-frontend-admin.yaml
+++ b/.github/workflows/build-frontend-admin.yaml
@@ -66,15 +66,37 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg PROJECT_NAME=admin \
+            -t ghcr.io/tadoku/tadoku/frontend-admin:latest \
+            .
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Scan image
+        run: |
+          trivy image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --scanners vuln \
+            --severity CRITICAL,HIGH \
+            ghcr.io/tadoku/tadoku/frontend-admin:latest
 
       - name: Push images
+        env:
+          IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-admin
         run: |
-          # Setup credentials for GitHub packages
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u tadoku --password-stdin
-
-          # Push images
-          IMAGE_NAME=ghcr.io/tadoku/tadoku/frontend-admin
-          docker build --build-arg PROJECT_NAME=admin -t $IMAGE_NAME:latest .
-          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$GITHUB_SHA
-          docker push $IMAGE_NAME
+          echo "${{ secrets.GITHUB_TOKEN }}" |
+            docker login ghcr.io -u tadoku --password-stdin
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:prod"
+          docker push "${IMAGE_NAME}:latest"
+          docker push "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker push "${IMAGE_NAME}:prod"

--- a/.github/workflows/build-frontend-auth.yaml
+++ b/.github/workflows/build-frontend-auth.yaml
@@ -66,15 +66,37 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg PROJECT_NAME=auth \
+            -t ghcr.io/tadoku/tadoku/frontend-auth:latest \
+            .
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Scan image
+        run: |
+          trivy image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --scanners vuln \
+            --severity CRITICAL,HIGH \
+            ghcr.io/tadoku/tadoku/frontend-auth:latest
 
       - name: Push images
+        env:
+          IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-auth
         run: |
-          # Setup credentials for GitHub packages
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u tadoku --password-stdin
-
-          # Push images
-          IMAGE_NAME=ghcr.io/tadoku/tadoku/frontend-auth
-          docker build --build-arg PROJECT_NAME=auth -t $IMAGE_NAME:latest .
-          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$GITHUB_SHA
-          docker push $IMAGE_NAME
+          echo "${{ secrets.GITHUB_TOKEN }}" |
+            docker login ghcr.io -u tadoku --password-stdin
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:prod"
+          docker push "${IMAGE_NAME}:latest"
+          docker push "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker push "${IMAGE_NAME}:prod"

--- a/.github/workflows/build-frontend-styleguide.yaml
+++ b/.github/workflows/build-frontend-styleguide.yaml
@@ -66,15 +66,37 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg PROJECT_NAME=styleguide \
+            -t ghcr.io/tadoku/tadoku/frontend-styleguide:latest \
+            .
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Scan image
+        run: |
+          trivy image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --scanners vuln \
+            --severity CRITICAL,HIGH \
+            ghcr.io/tadoku/tadoku/frontend-styleguide:latest
 
       - name: Push images
+        env:
+          IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-styleguide
         run: |
-          # Setup credentials for GitHub packages
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u tadoku --password-stdin
-
-          # Push images
-          IMAGE_NAME=ghcr.io/tadoku/tadoku/frontend-styleguide
-          docker build --build-arg PROJECT_NAME=styleguide -t $IMAGE_NAME:latest .
-          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$GITHUB_SHA
-          docker push $IMAGE_NAME
+          echo "${{ secrets.GITHUB_TOKEN }}" |
+            docker login ghcr.io -u tadoku --password-stdin
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:prod"
+          docker push "${IMAGE_NAME}:latest"
+          docker push "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker push "${IMAGE_NAME}:prod"

--- a/.github/workflows/build-frontend-webv2.yaml
+++ b/.github/workflows/build-frontend-webv2.yaml
@@ -66,15 +66,37 @@ jobs:
         working-directory: frontend
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+
+      - name: Build image
+        run: |
+          docker build \
+            --build-arg PROJECT_NAME=webv2 \
+            -t ghcr.io/tadoku/tadoku/frontend-webv2:latest \
+            .
+
+      - name: Install Trivy
+        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
+        with:
+          version: v0.72.0
+
+      - name: Scan image
+        run: |
+          trivy image \
+            --exit-code 1 \
+            --ignore-unfixed \
+            --scanners vuln \
+            --severity CRITICAL,HIGH \
+            ghcr.io/tadoku/tadoku/frontend-webv2:latest
 
       - name: Push images
+        env:
+          IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-webv2
         run: |
-          # Setup credentials for GitHub packages
-          echo ${{ secrets.GITHUB_TOKEN }} | docker login ghcr.io -u tadoku --password-stdin
-
-          # Push images
-          IMAGE_NAME=ghcr.io/tadoku/tadoku/frontend-webv2
-          docker build --build-arg PROJECT_NAME=webv2 -t $IMAGE_NAME:latest .
-          docker tag $IMAGE_NAME:latest $IMAGE_NAME:$GITHUB_SHA
-          docker push $IMAGE_NAME
+          echo "${{ secrets.GITHUB_TOKEN }}" |
+            docker login ghcr.io -u tadoku --password-stdin
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:prod"
+          docker push "${IMAGE_NAME}:latest"
+          docker push "${IMAGE_NAME}:${GITHUB_SHA}"
+          docker push "${IMAGE_NAME}:prod"


### PR DESCRIPTION
## Summary
- build and scan every production frontend image with Trivy v0.72.0 before publishing
- fail on fixable HIGH or CRITICAL vulnerabilities
- publish explicit latest, commit-SHA, and prod tags for styleguide, admin, auth, and webv2
- update publish checkouts to actions/checkout v4

This supplies the prod tags required by Argo CD Image Updater for every frontend migration, instead of rediscovering the same missing-tag failure per service.

## Validation
- git diff --check
- all four workflow YAML files parsed successfully