### PR TITLE
ci: remove frontend image scanning

### DIFF
--- a/.github/workflows/build-frontend-admin.yaml
+++ b/.github/workflows/build-frontend-admin.yaml
@@ -75,20 +75,6 @@ jobs:
             -t ghcr.io/tadoku/tadoku/frontend-admin:latest \
             .
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          version: v0.72.0
-
-      - name: Scan image
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --scanners vuln \
-            --severity CRITICAL,HIGH \
-            ghcr.io/tadoku/tadoku/frontend-admin:latest
-
       - name: Push images
         env:
           IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-admin

--- a/.github/workflows/build-frontend-auth.yaml
+++ b/.github/workflows/build-frontend-auth.yaml
@@ -75,20 +75,6 @@ jobs:
             -t ghcr.io/tadoku/tadoku/frontend-auth:latest \
             .
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          version: v0.72.0
-
-      - name: Scan image
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --scanners vuln \
-            --severity CRITICAL,HIGH \
-            ghcr.io/tadoku/tadoku/frontend-auth:latest
-
       - name: Push images
         env:
           IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-auth

--- a/.github/workflows/build-frontend-styleguide.yaml
+++ b/.github/workflows/build-frontend-styleguide.yaml
@@ -75,20 +75,6 @@ jobs:
             -t ghcr.io/tadoku/tadoku/frontend-styleguide:latest \
             .
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          version: v0.72.0
-
-      - name: Scan image
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --scanners vuln \
-            --severity CRITICAL,HIGH \
-            ghcr.io/tadoku/tadoku/frontend-styleguide:latest
-
       - name: Push images
         env:
           IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-styleguide

--- a/.github/workflows/build-frontend-webv2.yaml
+++ b/.github/workflows/build-frontend-webv2.yaml
@@ -75,20 +75,6 @@ jobs:
             -t ghcr.io/tadoku/tadoku/frontend-webv2:latest \
             .
 
-      - name: Install Trivy
-        uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
-        with:
-          version: v0.72.0
-
-      - name: Scan image
-        run: |
-          trivy image \
-            --exit-code 1 \
-            --ignore-unfixed \
-            --scanners vuln \
-            --severity CRITICAL,HIGH \
-            ghcr.io/tadoku/tadoku/frontend-webv2:latest
-
       - name: Push images
         env:
           IMAGE_NAME: ghcr.io/tadoku/tadoku/frontend-webv2


### PR DESCRIPTION
## Summary
- remove Trivy installation and scanning from all four frontend image workflows
- retain explicit latest, commit-SHA, and prod image publishing
- make no package, lockfile, application, Node, Next.js, or Dockerfile changes

## Validation
- all four workflow YAML files parse successfully
- no Trivy references remain in frontend workflows
- git diff --check