### PR TITLE
Publish prod tags for backend images

### DIFF
--- a/services/authz-api/BUILD.bazel
+++ b/services/authz-api/BUILD.bazel
@@ -70,7 +70,10 @@ oci_push(
 oci_push(
     name = "push",
     image = ":image",
-    remote_tags = ["latest"],
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
     repository = "ghcr.io/tadoku/tadoku/authz-api",
     visibility = ["//visibility:public"],
 )

--- a/services/content-api/BUILD.bazel
+++ b/services/content-api/BUILD.bazel
@@ -71,7 +71,10 @@ oci_push(
 oci_push(
     name = "push",
     image = ":image",
-    remote_tags = ["latest"],
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
     repository = "ghcr.io/tadoku/tadoku/content-api",
     visibility = ["//visibility:public"],
 )

--- a/services/immersion-api/BUILD.bazel
+++ b/services/immersion-api/BUILD.bazel
@@ -74,7 +74,10 @@ oci_push(
 oci_push(
     name = "push",
     image = ":image",
-    remote_tags = ["latest"],
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
     repository = "ghcr.io/tadoku/tadoku/immersion-api",
     visibility = ["//visibility:public"],
 )

--- a/services/profile-api/BUILD.bazel
+++ b/services/profile-api/BUILD.bazel
@@ -69,7 +69,10 @@ oci_push(
 oci_push(
     name = "push",
     image = ":image",
-    remote_tags = ["latest"],
+    remote_tags = [
+        "latest",
+        "prod",
+    ],
     repository = "ghcr.io/tadoku/tadoku/profile-api",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Adds the existing production prod tag to the four backend oci_push targets, matching token-reflector and the Argo CD Image Updater digest strategy. The built image content is unchanged; each push now publishes both latest and prod. Bazel query resolves all four push targets. No frontend code, packages, runtime dependencies, or scanning changes.