### PR TITLE
Remember language in v2 log form

### DIFF
--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -27,7 +27,37 @@ interface Props {
   defaultValues?: Partial<NewLogFormV2Schema>
 }
 
-export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Props) => {
+const LAST_LOGGED_LANGUAGE_STORAGE_KEY = 'log-form-v2:last-logged-language'
+
+const getLastLoggedLanguage = () => {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  try {
+    return window.localStorage.getItem(LAST_LOGGED_LANGUAGE_STORAGE_KEY)
+  } catch {
+    return null
+  }
+}
+
+const storeLastLoggedLanguage = (languageCode: string) => {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  try {
+    window.localStorage.setItem(
+      LAST_LOGGED_LANGUAGE_STORAGE_KEY,
+      languageCode,
+    )
+  } catch {}
+}
+
+export const LogFormV2 = ({
+  options,
+  defaultValues: originalDefaultValues,
+}: Props) => {
   const defaultActivity = options.activities[0]
   const defaultActivityInputType =
     defaultActivity?.input_type ?? 'amount_primary'
@@ -94,6 +124,8 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
 
   const router = useRouter()
   const createLogMutation = useCreateLogV2(log => {
+    storeLastLoggedLanguage(log.language.code)
+
     const hasRegistrations =
       registrations.data &&
       registrations.data.registrations.length > 0
@@ -112,6 +144,35 @@ export const LogFormV2 = ({ options, defaultValues: originalDefaultValues }: Pro
   const onSubmit = (data: any) => {
     createLog(NewLogV2APISchema.parse(data))
   }
+
+  useEffect(() => {
+    if (originalDefaultValues?.languageCode !== undefined) {
+      return
+    }
+
+    const lastLoggedLanguage = getLastLoggedLanguage()
+    if (
+      lastLoggedLanguage === null ||
+      !options.languages.some(language => language.code === lastLoggedLanguage)
+    ) {
+      return
+    }
+
+    methods.setValue('languageCode', lastLoggedLanguage)
+    methods.setValue(
+      'amountUnit',
+      filterUnits(
+        options.units,
+        methods.getValues('activityId'),
+        lastLoggedLanguage,
+      )[0]?.id,
+    )
+  }, [
+    methods,
+    options.languages,
+    options.units,
+    originalDefaultValues?.languageCode,
+  ])
 
   useEffect(() => {
     const subscription = methods.watch((value, { name, type }) => {


### PR DESCRIPTION
## Summary

- store the confirmed language code in `localStorage` after a successful v2 log submission
- restore the stored language when it is still available and recalculate the compatible default unit
- preserve explicit form defaults and leave the legacy log form unchanged

## Why

Frequent loggers should not need to reselect the same language each time they open the v2 log form. This keeps the preference entirely client-side without adding or changing APIs.

## Validation

- `pnpm --filter webv2 lint`
- `pnpm build`
- `git diff --check`

The standalone `pnpm --filter webv2 exec tsc --noEmit` remains blocked by existing missing declarations for `ui/components/logo.svg` and `logo-light.svg`; the full Next.js production build, including webv2 type and lint validation, passes.