### PR TITLE
Improve mobile navigation

### DIFF
--- a/frontend/apps/webv2/app/ui/Navigation.tsx
+++ b/frontend/apps/webv2/app/ui/Navigation.tsx
@@ -41,6 +41,7 @@ export default function Navigation() {
                 href: routes.logCreate(),
                 IconComponent: PlusIcon,
                 divider: !isAdmin,
+                mobilePrimary: true,
               },
               ...(isAdmin
                 ? [
@@ -62,6 +63,7 @@ export default function Navigation() {
                 href: '#',
                 onClick: onLogout,
                 IconComponent: ArrowRightOnRectangleIcon,
+                mobileBottom: true,
               },
             ],
           },

--- a/frontend/apps/webv2/tailwind.config.js
+++ b/frontend/apps/webv2/tailwind.config.js
@@ -1,5 +1,5 @@
 const config = require('ui/tailwind.config.js')
-config.content.push('./node_modules/ui/components/**/*.{js,ts,jsx,tsx}')
+config.content.push('../../packages/ui/components/**/*.{js,ts,jsx,tsx}')
 
 const activityColors = require('./app/common/variables').activityColors
 activityColors.forEach(color => {

--- a/frontend/packages/ui/components/ActionMenu.tsx
+++ b/frontend/packages/ui/components/ActionMenu.tsx
@@ -40,10 +40,10 @@ export const ActionMenu = ({
                   className={classNames(
                     'reset flex-inline items-center px-3 py-2 text-sm flex font-medium',
                     {
-                      'data-[focus]:bg-secondary': type === 'normal',
+                      'data-[focus]:bg-secondary/5': type === 'normal',
                       'data-[focus]:bg-red-700/80': type === 'danger',
                       'text-red-600 data-[focus]:text-white ': type === 'danger',
-                      'text-gray-700 data-[focus]:text-white': type === 'normal',
+                      'text-gray-700': type === 'normal',
                     },
                   )}
                 >

--- a/frontend/packages/ui/components/Navbar.tsx
+++ b/frontend/packages/ui/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import { ComponentType } from 'react'
+import { ComponentType, useEffect } from 'react'
 import {
   Disclosure,
   DisclosureButton,
@@ -24,6 +24,8 @@ export interface NavigationDropDownProps {
     IconComponent?: ComponentType<any>
     onClick?: () => void
     divider?: boolean
+    mobilePrimary?: boolean
+    mobileBottom?: boolean
   }[]
 }
 
@@ -48,21 +50,26 @@ export function Navbar({
   isLoading = false,
 }: Props) {
   const router = useRouter()
+  const hasMobileBottomLinks = navigation.some(
+    item =>
+      item.type === 'dropdown' && item.links.some(link => link.mobileBottom),
+  )
 
   return (
     <>
       <div className="h-10 sm:h-16 absolute top-0 left-0 right-0 bg-white z-0"></div>
       <Disclosure
         as="nav"
-        className="bg-white sticky top-0 z-40 backdrop-blur bg-white/70 border-b border-black/10 shadow shadow-slate-500/10"
+        className="sticky top-0 z-40 border-b border-black/10 bg-white shadow shadow-slate-500/10"
       >
         {({ open }) => (
           <>
+            <MobileScrollLock active={open} />
             <div className={`mx-auto ${width} px-2 sm:px-6 lg:px-8 z-10`}>
               <div className="relative flex h-10 sm:h-16 items-center justify-between">
                 <div className="absolute inset-y-0 left-0 flex items-center sm:hidden">
                   {/* Mobile menu button*/}
-                  <DisclosureButton className="inline-flex items-center justify-center p-2 text-secondary hover:bg-secondary hover:text-white focus:outline-none focus:ring-3 focus:ring-inset focus:ring-white">
+                  <DisclosureButton className="inline-flex items-center justify-center p-2 text-secondary hover:bg-secondary/5 focus:bg-secondary/5 focus:outline-none focus:ring-3 focus:ring-inset focus:ring-secondary/20">
                     <span className="sr-only">Open main menu</span>
                     {open ? (
                       <XMarkIcon className="block h-6 w-6" aria-hidden="true" />
@@ -97,7 +104,7 @@ export function Navbar({
                               className={classNames(
                                 item.current || router.pathname === item.href
                                   ? 'bg-secondary !text-white hover:bg-secondary/80'
-                                  : 'text-secondary hover:bg-secondary hover:text-white',
+                                  : 'text-secondary hover:bg-secondary/5 focus:bg-secondary/5',
                                 'reset text-xs px-2 py-1 md:px-3 md:py-2 md:text-sm font-bold inline-flex items-center justify-center',
                               )}
                               aria-current={item.current ? 'page' : undefined}
@@ -114,41 +121,135 @@ export function Navbar({
             </div>
 
             <DisclosurePanel className="sm:hidden">
-              <div className="space-y-1 px-2 pt-2 pb-3">
-                {navigation.map(item => {
-                  if (item.type === 'dropdown') {
-                    return (
-                      <div
-                        key={item.label}
-                        className={classNames(
-                          'text-secondary hover:bg-secondary hover:text-white',
-                          'reset block px-3 py-2 text-base font-bold',
-                        )}
-                      >
-                        <DropDownMobile {...item} />
-                      </div>
-                    )
-                  }
+              <div className="fixed inset-x-0 bottom-0 top-10 z-30 overflow-y-auto bg-white p-2 shadow-lg">
+                <div className="flex min-h-full flex-col">
+                  <div className="space-y-1">
+                    {navigation.map(item =>
+                      item.type === 'dropdown'
+                        ? item.links.map(
+                            (
+                              {
+                                label,
+                                href,
+                                IconComponent,
+                                onClick,
+                                mobilePrimary,
+                              },
+                              i,
+                            ) =>
+                              mobilePrimary ? (
+                                <MobileDropDownLink
+                                  key={`${label}-${i}`}
+                                  label={label}
+                                  href={href}
+                                  onClick={onClick}
+                                  IconComponent={IconComponent}
+                                  highlighted
+                                />
+                              ) : null,
+                          )
+                        : null,
+                    )}
+                    <div className="px-3 pb-1 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                      Navigation
+                    </div>
+                    {navigation.map(item => {
+                      if (item.type === 'link') {
+                        return (
+                          <DisclosureButton
+                            key={item.label}
+                            as={Link}
+                            href={item.href}
+                            className={classNames(
+                              item.current
+                                ? 'bg-secondary text-white'
+                                : 'text-secondary hover:bg-secondary/5 focus:bg-secondary/5',
+                              'reset flex min-h-12 w-full items-center px-3 py-2 text-base font-bold transition-[background-color]',
+                            )}
+                            aria-current={item.current ? 'page' : undefined}
+                          >
+                            {item.label}
+                          </DisclosureButton>
+                        )
+                      }
 
-                  if (item.type === 'link') {
-                    return (
-                      <DisclosureButton
-                        key={item.label}
-                        as={Link}
-                        href={item.href}
-                        className={classNames(
-                          item.current
-                            ? 'bg-secondary text-white'
-                            : 'text-secondary hover:bg-secondary hover:text-white',
-                          'reset transition-[background-color] block px-3 py-2 text-base font-bold',
-                        )}
-                        aria-current={item.current ? 'page' : undefined}
-                      >
-                        {item.label}
-                      </DisclosureButton>
-                    )
-                  }
-                })}
+                      return null
+                    })}
+                  </div>
+
+                  {navigation.map(item => {
+                    if (
+                      item.type === 'dropdown' &&
+                      item.links.some(
+                        link => !link.mobilePrimary && !link.mobileBottom,
+                      )
+                    ) {
+                      return (
+                        <div key={item.label} className="pt-3">
+                          <div className="px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+                            {item.label}
+                          </div>
+                          <div>
+                            {item.links.map(
+                              (
+                                {
+                                  label,
+                                  href,
+                                  IconComponent,
+                                  onClick,
+                                  mobilePrimary,
+                                  mobileBottom,
+                                },
+                                i,
+                              ) =>
+                                !mobilePrimary && !mobileBottom ? (
+                                  <MobileDropDownLink
+                                    key={`${label}-${i}`}
+                                    label={label}
+                                    href={href}
+                                    onClick={onClick}
+                                    IconComponent={IconComponent}
+                                  />
+                                ) : null,
+                            )}
+                          </div>
+                        </div>
+                      )
+                    }
+
+                    return null
+                  })}
+
+                  {hasMobileBottomLinks ? (
+                    <div className="mt-auto border-t border-slate-500/20">
+                      {navigation.map(item =>
+                        item.type === 'dropdown'
+                          ? item.links.map(
+                              (
+                                {
+                                  label,
+                                  href,
+                                  IconComponent,
+                                  onClick,
+                                  mobileBottom,
+                                },
+                                i,
+                              ) =>
+                                mobileBottom ? (
+                                  <MobileDropDownLink
+                                    key={`${label}-${i}`}
+                                    label={label}
+                                    href={href}
+                                    onClick={onClick}
+                                    IconComponent={IconComponent}
+                                  />
+                                ) : null,
+                            )
+                          : null,
+                      )}
+                    </div>
+                  ) : null}
+                </div>
               </div>
             </DisclosurePanel>
             <div
@@ -163,11 +264,74 @@ export function Navbar({
   )
 }
 
+const MobileScrollLock = ({ active }: { active: boolean }) => {
+  useEffect(() => {
+    if (!active) return
+
+    const scrollY = window.scrollY
+    const previousOverflow = document.body.style.overflow
+    const previousPosition = document.body.style.position
+    const previousTop = document.body.style.top
+    const previousWidth = document.body.style.width
+
+    document.body.style.overflow = 'hidden'
+    document.body.style.position = 'fixed'
+    document.body.style.top = `-${scrollY}px`
+    document.body.style.width = '100%'
+
+    return () => {
+      document.body.style.overflow = previousOverflow
+      document.body.style.position = previousPosition
+      document.body.style.top = previousTop
+      document.body.style.width = previousWidth
+      window.scrollTo(0, scrollY)
+    }
+  }, [active])
+
+  return null
+}
+
+interface MobileDropDownLinkProps {
+  label: string
+  href: string
+  IconComponent?: ComponentType<any>
+  onClick?: () => void
+  highlighted?: boolean
+}
+
+const MobileDropDownLink = ({
+  label,
+  href,
+  IconComponent,
+  onClick,
+  highlighted = false,
+}: MobileDropDownLinkProps) => (
+  <DisclosureButton
+    as={Link}
+    href={href}
+    onClick={onClick}
+    className={classNames(
+      'reset flex min-h-12 w-full items-center px-3 py-2 text-base font-bold transition-[background-color]',
+      {
+        'mb-3 bg-secondary/5 text-secondary hover:bg-secondary/10 focus:bg-secondary/10':
+          highlighted,
+        'text-secondary hover:bg-secondary/5 focus:bg-secondary/5':
+          !highlighted,
+      },
+    )}
+  >
+    {IconComponent && (
+      <IconComponent className="mr-3 h-5 w-5 shrink-0" aria-hidden="true" />
+    )}
+    {label}
+  </DisclosureButton>
+)
+
 const DropDown = ({ label, links }: NavigationDropDownProps) => (
   <div className="">
     <Menu as="div" className="relative">
       <div>
-        <MenuButton className="text-secondary hover:bg-secondary hover:text-white text-xs px-2 py-1 md:px-3 md:py-2 md:text-sm font-bold flex items-center justify-center">
+        <MenuButton className="text-secondary hover:bg-secondary/5 focus:bg-secondary/5 text-xs px-2 py-1 md:px-3 md:py-2 md:text-sm font-bold flex items-center justify-center">
           <span className="sr-only">Open navigation menu</span>
           {label}
           <ChevronDownIcon
@@ -188,7 +352,7 @@ const DropDown = ({ label, links }: NavigationDropDownProps) => (
               href={href}
               onClick={onClick}
               className={classNames(
-                'reset whitespace-nowrap flex-inline transition-[background-color] items-center px-3 py-2 text-sm text-gray-700 flex font-bold data-[focus]:bg-secondary data-[focus]:text-white',
+                'reset whitespace-nowrap flex-inline transition-[background-color] items-center px-3 py-2 text-sm text-gray-700 flex font-bold data-[focus]:bg-secondary/5',
                 {
                   'border-b border-slate-500/20': !!divider,
                 },
@@ -197,43 +361,6 @@ const DropDown = ({ label, links }: NavigationDropDownProps) => (
               {IconComponent && <IconComponent className="w-4 h-4 mr-3" />}{' '}
               {label}
             </Link>
-          </MenuItem>
-        ))}
-      </MenuItems>
-    </Menu>
-  </div>
-)
-
-const DropDownMobile = ({ label, links }: NavigationDropDownProps) => (
-  <div className="">
-    <Menu as="div" className="relative">
-      <div>
-        <MenuButton className="flex items-center justify-between w-full">
-          <span className="sr-only">Open navigation menu</span>
-          {label}
-          <ChevronDownIcon
-            className="ml-2 h-4 w-3 md:h-5 md:w-4"
-            aria-hidden="true"
-          />
-        </MenuButton>
-      </div>
-      <MenuItems
-        anchor="bottom"
-        modal={false}
-        transition
-        className="absolute left-0 right-0 z-50 mt-2 min-w-48 origin-top-right bg-white py-1 shadow-md shadow-slate-500/20 ring-1 ring-secondary ring-opacity-5 focus:outline-none transition ease-out duration-100 data-[closed]:scale-95 data-[closed]:opacity-0"
-      >
-        {links.map(({ label, href, IconComponent, onClick }, i) => (
-          <MenuItem key={i}>
-            <DisclosureButton
-              as={Link}
-              href={href}
-              onClick={onClick}
-              className="reset transition-[background-color] flex-inline items-center px-3 py-4 text-sm text-gray-700 flex font-bold data-[focus]:bg-secondary data-[focus]:text-white"
-            >
-              {IconComponent && <IconComponent className="w-4 h-4 mr-3" />}{' '}
-              {label}
-            </DisclosureButton>
           </MenuItem>
         ))}
       </MenuItems>

--- a/frontend/packages/ui/package.json
+++ b/frontend/packages/ui/package.json
@@ -1,6 +1,9 @@
 {
   "name": "ui",
   "private": true,
+  "scripts": {
+    "test": "node --test tests/*.test.mjs"
+  },
   "dependencies": {
     "@headlessui/react": "^2.2.0",
     "@heroicons/react": "^2.0.13",

--- a/frontend/packages/ui/tailwind.config.js
+++ b/frontend/packages/ui/tailwind.config.js
@@ -46,6 +46,7 @@ module.exports = {
     'bg-lime-700',
     'bg-neutral-100',
     'bg-neutral-900',
+    'mt-auto',
   ],
   plugins: [require('@tailwindcss/forms')],
 }

--- a/frontend/packages/ui/tests/navbar-mobile.test.mjs
+++ b/frontend/packages/ui/tests/navbar-mobile.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { readFile } from 'node:fs/promises'
+import test from 'node:test'
+
+const navbarSource = await readFile(
+  new URL('../components/Navbar.tsx', import.meta.url),
+  'utf8',
+)
+const actionMenuSource = await readFile(
+  new URL('../components/ActionMenu.tsx', import.meta.url),
+  'utf8',
+)
+
+const mobilePanelStart = navbarSource.indexOf(
+  '<DisclosurePanel className="sm:hidden">',
+)
+const mobilePanelEnd = navbarSource.indexOf(
+  '</DisclosurePanel>',
+  mobilePanelStart,
+)
+const mobilePanelSource = navbarSource.slice(mobilePanelStart, mobilePanelEnd)
+
+test('mobile navigation exposes dropdown links directly in the drawer', () => {
+  assert.ok(mobilePanelStart >= 0, 'expected a mobile disclosure panel')
+  assert.ok(mobilePanelEnd > mobilePanelStart, 'expected the panel to close')
+  assert.doesNotMatch(mobilePanelSource, /<DropDownMobile/)
+  assert.match(mobilePanelSource, /item\.links\.map/)
+})
+
+test('mobile navigation supports primary and bottom account actions', () => {
+  assert.match(navbarSource, /mobilePrimary/)
+  assert.match(navbarSource, /mobileBottom/)
+  assert.match(mobilePanelSource, /mt-auto/)
+})
+
+test('top mobile action uses the drawer link style instead of a primary button', () => {
+  assert.doesNotMatch(mobilePanelSource, /btn primary/)
+})
+
+test('mobile sections have consistent rows and a highlighted top action', () => {
+  assert.match(mobilePanelSource, />\s*Navigation\s*</)
+  assert.match(navbarSource, /const MobileDropDownLink/)
+  assert.match(mobilePanelSource, /highlighted/)
+  assert.match(navbarSource, /bg-secondary\/5/)
+  assert.doesNotMatch(
+    navbarSource.slice(navbarSource.indexOf('const MobileDropDownLink')),
+    /text-primary/,
+  )
+  assert.doesNotMatch(navbarSource, /dividerBefore/)
+  assert.doesNotMatch(navbarSource, /dividerAfter/)
+  assert.doesNotMatch(mobilePanelSource, /!!divider/)
+  assert.match(mobilePanelSource, /bg-white p-2 shadow-lg/)
+  assert.doesNotMatch(mobilePanelSource, /pb-6/)
+  assert.doesNotMatch(
+    mobilePanelSource,
+    /mt-auto border-t border-slate-500\/20 pt-3/,
+  )
+
+  const sharedRowUses = mobilePanelSource.match(/<MobileDropDownLink/g) ?? []
+  assert.ok(
+    sharedRowUses.length >= 3,
+    'expected top, account, and bottom actions to share one row component',
+  )
+})
+
+test('mobile drawer avoids hydration and containing-block boundaries', () => {
+  assert.doesNotMatch(navbarSource, /<Portal>/)
+  assert.doesNotMatch(navbarSource, /backdrop-blur/)
+})
+
+test('opening the mobile drawer locks and restores page scrolling', () => {
+  assert.match(navbarSource, /<MobileScrollLock active={open} \/>/)
+  assert.match(navbarSource, /const MobileScrollLock/)
+  assert.match(navbarSource, /document\.body\.style\.overflow/)
+  assert.match(navbarSource, /window\.scrollTo/)
+})
+
+test('logged-out navigation does not render an empty bottom divider', () => {
+  assert.match(navbarSource, /const hasMobileBottomLinks/)
+  assert.match(mobilePanelSource, /{hasMobileBottomLinks \? \(/)
+})
+
+test('shared navigation uses light hover and focus states', () => {
+  assert.doesNotMatch(
+    navbarSource,
+    /text-secondary hover:bg-secondary hover:text-white/,
+  )
+  assert.match(navbarSource, /text-secondary hover:bg-secondary\/5/)
+  assert.match(navbarSource, /data-\[focus\]:bg-secondary\/5/)
+  assert.doesNotMatch(
+    navbarSource,
+    /data-\[focus\]:bg-secondary data-\[focus\]:text-white/,
+  )
+
+  assert.match(actionMenuSource, /data-\[focus\]:bg-secondary\/5/)
+  assert.doesNotMatch(
+    actionMenuSource,
+    /'data-\[focus\]:bg-secondary': type === 'normal'/,
+  )
+  assert.match(actionMenuSource, /data-\[focus\]:bg-red-700\/80/)
+})


### PR DESCRIPTION
## Summary
- flatten the signed-in mobile account menu into the main drawer and distinguish the New log action without a primary-button treatment
- make the drawer viewport-safe, lock background scrolling, and remove the logged-out bottom divider
- standardize navigation and action-menu hover/focus states on a light background across the shared UI
- ensure webv2 Tailwind watches shared UI source changes and add mobile navigation regression tests

## Verification
- `cd frontend && pnpm build`
- `cd frontend && pnpm --filter ui test`
- `git diff --check`