### PR TITLE
Add stable scoring unit keys

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0018_stable_unit_key_columns.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0018_stable_unit_key_columns.down.sql
@@ -1,0 +1,7 @@
+begin;
+
+alter table contest_logs drop column unit_key;
+alter table logs drop column unit_key;
+alter table log_units drop column unit_key;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0018_stable_unit_key_columns.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0018_stable_unit_key_columns.up.sql
@@ -1,0 +1,7 @@
+begin;
+
+alter table log_units add column unit_key text;
+alter table logs add column unit_key text;
+alter table contest_logs add column unit_key text;
+
+commit;


### PR DESCRIPTION
First, additive schema step in the stable-unit-key rollout.

Adds nullable unit_key columns to log_units, logs, and contest_logs. It contains no backfill, application write change, or stricter constraint, so existing API pods remain compatible.

Followed by #736, #737, and #738.