### PR TITLE
Enforce stable unit key writes

### DIFF
--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -113,6 +113,14 @@ The following behavior must remain true throughout the rollout:
 - Domain packages must not import storage packages.
 - Time-dependent services use an injected `commondomain.Clock`.
 
+## Stable-unit-key rollout
+
+The stable-unit-key change is intentionally deployed in four steps: add nullable
+columns, backfill existing rows, deploy writers that populate the keys, then
+enforce the non-null and log-tracking constraints. The enforcement migration
+must only run after every live API writer has the preceding application change;
+otherwise a rolling deployment could reject writes from an old pod.
+
 ## Initial parity rule set
 
 The first published platform rule set must reproduce the public scoring manual

--- a/services/immersion-api/storage/postgres/migrations/0020_enforce_stable_unit_keys.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0020_enforce_stable_unit_keys.down.sql
@@ -1,0 +1,22 @@
+begin;
+
+alter table contest_logs drop constraint contest_logs_has_tracking_data;
+alter table contest_logs
+  add constraint contest_logs_has_tracking_data
+  check (
+    duration_seconds is not null
+    or (amount is not null and modifier is not null)
+  );
+
+alter table logs drop constraint logs_has_tracking_data;
+alter table logs
+  add constraint logs_has_tracking_data
+  check (
+    duration_seconds is not null
+    or (amount is not null and unit_id is not null and modifier is not null)
+  );
+
+drop index log_units_unit_key;
+alter table log_units alter column unit_key drop not null;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0020_enforce_stable_unit_keys.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0020_enforce_stable_unit_keys.up.sql
@@ -1,0 +1,58 @@
+begin;
+
+update logs
+set unit_key = log_units.unit_key
+from log_units
+where logs.unit_key is null
+  and logs.unit_id = log_units.id;
+
+update contest_logs
+set unit_key = logs.unit_key
+from logs
+where contest_logs.unit_key is null
+  and contest_logs.log_id = logs.id;
+
+do $$
+begin
+  if exists (select 1 from log_units where unit_key is null) then
+    raise exception 'cannot require stable unit keys while log units are unmapped';
+  end if;
+
+  if exists (select 1 from logs where amount is not null and unit_key is null) then
+    raise exception 'cannot require stable unit keys while amount-tracked logs are unmapped';
+  end if;
+
+  if exists (select 1 from contest_logs where amount is not null and unit_key is null) then
+    raise exception 'cannot require stable unit keys while amount-tracked contest logs are unmapped';
+  end if;
+end $$;
+
+alter table log_units alter column unit_key set not null;
+create index log_units_unit_key on log_units(unit_key);
+
+alter table logs drop constraint logs_has_tracking_data;
+alter table logs
+  add constraint logs_has_tracking_data
+  check (
+    duration_seconds is not null
+    or (
+      amount is not null
+      and unit_id is not null
+      and unit_key is not null
+      and modifier is not null
+    )
+  );
+
+alter table contest_logs drop constraint contest_logs_has_tracking_data;
+alter table contest_logs
+  add constraint contest_logs_has_tracking_data
+  check (
+    duration_seconds is not null
+    or (
+      amount is not null
+      and unit_key is not null
+      and modifier is not null
+    )
+  );
+
+commit;


### PR DESCRIPTION
Final enforcement step in the stable-unit-key rollout.

Repairs parent and contest rows created during the rolling-deploy window, then requires a stable key for amount-tracked logs and contest_logs. Duration-only tracking remains valid without a key.

Deploy only after every live API writer includes #737; an older pod would otherwise have writes rejected.

Validation: full backend build/test, WebV2 typecheck/lint, and Bazel metadata check.