### PR TITLE
Fix dense minute migration aliases

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0019_backfill_stable_unit_keys.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0019_backfill_stable_unit_keys.up.sql
@@ -8,12 +8,12 @@ set unit_key = case
   when log_activity_id = 1 and name = 'Sentence' then 'reading_sentence'
   when log_activity_id = 1 and name = 'Character' then 'reading_character'
   when log_activity_id = 2 and name = 'Minute' then 'listening_minute'
-  when log_activity_id = 2 and name = 'Minute (high density)' then 'listening_dense_minutes'
+  when log_activity_id = 2 and name in ('Minute (high density)', 'Dense minute') then 'listening_dense_minutes'
   when log_activity_id = 3 and name = 'Page' then 'writing_page'
   when log_activity_id = 3 and name = 'Sentence' then 'writing_sentence'
   when log_activity_id = 3 and name = 'Character' then 'writing_character'
   when log_activity_id = 4 and name = 'Minute' then 'speaking_minute'
-  when log_activity_id = 4 and name = 'Minute (high density)' then 'speaking_dense_minutes'
+  when log_activity_id = 4 and name in ('Minute (high density)', 'Dense minute') then 'speaking_dense_minutes'
   when log_activity_id = 5 and name = 'Minute' then 'study_minute'
 end
 where unit_key is null;


### PR DESCRIPTION
## What changed

- accept both `Minute (high density)` and the legacy production label `Dense minute` when backfilling listening and speaking stable unit keys

## Why

Production migration 0019 failed because two existing units use `Dense minute`, while staging uses `Minute (high density)`. The failed migration transaction rolled back and left production at migration version 19 with `dirty=true`.

## Impact

After this change reaches the production image, migration metadata can be safely reset to clean version 18 and Argo CD can retry migration 0019.

## Validation

- `git diff --check`
- `bazel build //services/immersion-api/storage/postgres/migrations:tar`
- `bazel build //services/immersion-api/...`
- read-only production mapping check confirms zero unmatched units with both aliases