### PR TITLE
Add score provenance snapshots

### DIFF
--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -379,13 +379,13 @@ endpoint. All form changes must use `react-hook-form` and components from the
   - [x] Use `0.4` per minute for duration-only Listening.
   - [x] Do not introduce dense-tag scoring in this plan.
 
-- [ ] Add score provenance snapshots.
-  - [ ] Keep `computed_score` as the authoritative score.
-  - [ ] Add the applied rule-set ID and ordered rule IDs.
-  - [ ] Add the ordered applied rates.
-  - [ ] Add `score_source`.
-  - [ ] Add the same fields independently to `contest_logs`.
-  - [ ] Allow rule fields to be null when the score is zero because no rule matched.
+- [x] Add score provenance snapshots.
+  - [x] Keep `computed_score` as the authoritative score.
+  - [x] Add the applied rule-set ID and ordered rule IDs.
+  - [x] Add the ordered applied rates.
+  - [x] Add `score_source`.
+  - [x] Add the same fields independently to `contest_logs`.
+  - [x] Allow rule fields to be null when the score is zero because no rule matched.
 
 - [ ] Switch platform log scoring to the engine behind the feature flag.
   - [ ] Use the active platform rule set for create and update.

--- a/services/immersion-api/domain/logtracking.go
+++ b/services/immersion-api/domain/logtracking.go
@@ -31,6 +31,14 @@ type LogTracking struct {
 	DurationSeconds int32
 	Modifier        float32
 	ComputedScore   float32
+	ScoreProvenance *ScoreProvenance
+}
+
+type ScoreProvenance struct {
+	RuleSetID *uuid.UUID
+	RuleIDs   []uuid.UUID
+	Rates     []float32
+	Source    ScoreSource
 }
 
 type LogTrackingInput struct {

--- a/services/immersion-api/storage/postgres/logs.sql.go
+++ b/services/immersion-api/storage/postgres/logs.sql.go
@@ -45,7 +45,11 @@ insert into contest_logs (
   amount,
   modifier,
   duration_seconds,
-  computed_score
+  computed_score,
+  score_rule_set_id,
+  score_rule_ids,
+  score_rates,
+  score_source
 ) values (
   (select contest_id from contest_registrations where id = $1),
   $2,
@@ -53,7 +57,11 @@ insert into contest_logs (
   $4,
   $5,
   $6,
-  $7
+  $7,
+  $8,
+  $9,
+  $10
+  $11
 )
 `
 
@@ -65,6 +73,10 @@ type CreateContestLogRelationParams struct {
 	Modifier        sql.NullFloat64
 	DurationSeconds sql.NullInt32
 	ComputedScore   sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
 }
 
 func (q *Queries) CreateContestLogRelation(ctx context.Context, arg CreateContestLogRelationParams) error {
@@ -76,6 +88,10 @@ func (q *Queries) CreateContestLogRelation(ctx context.Context, arg CreateContes
 		arg.Modifier,
 		arg.DurationSeconds,
 		arg.ComputedScore,
+		arg.ScoreRuleSetID,
+		pq.Array(arg.ScoreRuleIds),
+		pq.Array(arg.ScoreRates),
+		arg.ScoreSource,
 	)
 	return err
 }
@@ -92,6 +108,10 @@ insert into logs (
   modifier,
   duration_seconds,
   computed_score,
+  score_rule_set_id,
+  score_rule_ids,
+  score_rates,
+  score_source,
   eligible_official_leaderboard,
   "description"
 ) values (
@@ -106,7 +126,11 @@ insert into logs (
   $9,
   $10,
   $11,
-  $12
+  $12,
+  $13,
+  $14,
+  $15,
+  $16
 ) returning id
 `
 
@@ -121,6 +145,10 @@ type CreateLogParams struct {
 	Modifier                    sql.NullFloat64
 	DurationSeconds             sql.NullInt32
 	ComputedScore               sql.NullFloat64
+	ScoreRuleSetID              uuid.NullUUID
+	ScoreRuleIds                []uuid.UUID
+	ScoreRates                  []float32
+	ScoreSource                 sql.NullString
 	EligibleOfficialLeaderboard bool
 	Description                 sql.NullString
 }
@@ -137,6 +165,10 @@ func (q *Queries) CreateLog(ctx context.Context, arg CreateLogParams) (uuid.UUID
 		arg.Modifier,
 		arg.DurationSeconds,
 		arg.ComputedScore,
+		arg.ScoreRuleSetID,
+		pq.Array(arg.ScoreRuleIds),
+		pq.Array(arg.ScoreRates),
+		arg.ScoreSource,
 		arg.EligibleOfficialLeaderboard,
 		arg.Description,
 	)
@@ -421,6 +453,10 @@ select
   logs.modifier,
   logs.duration_seconds,
   coalesce(logs.computed_score, logs.score) as score,
+  logs.score_rule_set_id,
+  logs.score_rule_ids,
+  logs.score_rates,
+  logs.score_source,
   logs.eligible_official_leaderboard,
   logs.created_at,
   logs.updated_at,
@@ -458,6 +494,10 @@ type FindLogByIDRow struct {
 	Modifier                    sql.NullFloat64
 	DurationSeconds             sql.NullInt32
 	Score                       sql.NullFloat64
+	ScoreRuleSetID              uuid.NullUUID
+	ScoreRuleIds                []uuid.UUID
+	ScoreRates                  []float32
+	ScoreSource                 sql.NullString
 	EligibleOfficialLeaderboard bool
 	CreatedAt                   time.Time
 	UpdatedAt                   time.Time
@@ -483,6 +523,10 @@ func (q *Queries) FindLogByID(ctx context.Context, arg FindLogByIDParams) (FindL
 		&i.Modifier,
 		&i.DurationSeconds,
 		&i.Score,
+		&i.ScoreRuleSetID,
+		pq.Array(&i.ScoreRuleIds),
+		pq.Array(&i.ScoreRates),
+		&i.ScoreSource,
 		&i.EligibleOfficialLeaderboard,
 		&i.CreatedAt,
 		&i.UpdatedAt,
@@ -508,6 +552,10 @@ with eligible_logs as (
     contest_logs.modifier,
     contest_logs.duration_seconds,
     coalesce(contest_logs.computed_score, contest_logs.score) as score,
+    contest_logs.score_rule_set_id,
+    contest_logs.score_rule_ids,
+    contest_logs.score_rates,
+    contest_logs.score_source,
     logs.created_at,
     logs.updated_at,
     logs.deleted_at,
@@ -527,7 +575,7 @@ with eligible_logs as (
     and contest_logs.contest_id = $5
 )
 select
-  id, user_id, language_code, language_name, activity_id, unit_id, unit_key, unit_name, description, amount, modifier, duration_seconds, score, created_at, updated_at, deleted_at, user_display_name, tags,
+  id, user_id, language_code, language_name, activity_id, unit_id, unit_key, unit_name, description, amount, modifier, duration_seconds, score, score_rule_set_id, score_rule_ids, score_rates, score_source, created_at, updated_at, deleted_at, user_display_name, tags,
   (select count(eligible_logs.id) from eligible_logs) as total_size
 from eligible_logs
 order by created_at desc
@@ -557,6 +605,10 @@ type ListLogsForContestRow struct {
 	Modifier        sql.NullFloat64
 	DurationSeconds sql.NullInt32
 	Score           sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	DeletedAt       sql.NullTime
@@ -594,6 +646,10 @@ func (q *Queries) ListLogsForContest(ctx context.Context, arg ListLogsForContest
 			&i.Modifier,
 			&i.DurationSeconds,
 			&i.Score,
+			&i.ScoreRuleSetID,
+			pq.Array(&i.ScoreRuleIds),
+			pq.Array(&i.ScoreRates),
+			&i.ScoreSource,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -630,6 +686,10 @@ with eligible_logs as (
     logs.modifier,
     logs.duration_seconds,
     coalesce(logs.computed_score, logs.score) as score,
+    logs.score_rule_set_id,
+    logs.score_rule_ids,
+    logs.score_rates,
+    logs.score_source,
     logs.created_at,
     logs.updated_at,
     logs.deleted_at,
@@ -645,7 +705,7 @@ with eligible_logs as (
     and logs.user_id = $4
 )
 select
-  id, user_id, language_code, language_name, activity_id, unit_id, unit_key, unit_name, description, amount, modifier, duration_seconds, score, created_at, updated_at, deleted_at, tags,
+  id, user_id, language_code, language_name, activity_id, unit_id, unit_key, unit_name, description, amount, modifier, duration_seconds, score, score_rule_set_id, score_rule_ids, score_rates, score_source, created_at, updated_at, deleted_at, tags,
   (select count(eligible_logs.id) from eligible_logs) as total_size
 from eligible_logs
 order by created_at desc
@@ -674,6 +734,10 @@ type ListLogsForUserRow struct {
 	Modifier        sql.NullFloat64
 	DurationSeconds sql.NullInt32
 	Score           sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
 	CreatedAt       time.Time
 	UpdatedAt       time.Time
 	DeletedAt       sql.NullTime
@@ -709,6 +773,10 @@ func (q *Queries) ListLogsForUser(ctx context.Context, arg ListLogsForUserParams
 			&i.Modifier,
 			&i.DurationSeconds,
 			&i.Score,
+			&i.ScoreRuleSetID,
+			pq.Array(&i.ScoreRuleIds),
+			pq.Array(&i.ScoreRates),
+			&i.ScoreSource,
 			&i.CreatedAt,
 			&i.UpdatedAt,
 			&i.DeletedAt,
@@ -737,10 +805,14 @@ set
   unit_key = $4,
   duration_seconds = $5,
   computed_score = $6,
-  "description" = $7,
-  updated_at = $8
+  score_rule_set_id = $7,
+  score_rule_ids = $8,
+  score_rates = $9,
+  score_source = $10,
+  "description" = $11,
+  updated_at = $12
 where
-  id = $9
+  id = $13
   and deleted_at is null
 `
 
@@ -751,6 +823,10 @@ type UpdateLogParams struct {
 	UnitKey         sql.NullString
 	DurationSeconds sql.NullInt32
 	ComputedScore   sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
 	Description     sql.NullString
 	Now             time.Time
 	LogID           uuid.UUID
@@ -764,6 +840,10 @@ func (q *Queries) UpdateLog(ctx context.Context, arg UpdateLogParams) error {
 		arg.UnitKey,
 		arg.DurationSeconds,
 		arg.ComputedScore,
+		arg.ScoreRuleSetID,
+		pq.Array(arg.ScoreRuleIds),
+		pq.Array(arg.ScoreRates),
+		arg.ScoreSource,
 		arg.Description,
 		arg.Now,
 		arg.LogID,
@@ -795,12 +875,16 @@ set
   amount = $2,
   modifier = $3,
   duration_seconds = $4,
-  computed_score = $5
+  computed_score = $5,
+  score_rule_set_id = $6,
+  score_rule_ids = $7,
+  score_rates = $8,
+  score_source = $9
 from contests
 where
-  contest_logs.log_id = $6
+  contest_logs.log_id = $10
   and contest_logs.contest_id = contests.id
-  and contests.contest_end >= $7
+  and contests.contest_end >= $11
 `
 
 type UpdateOngoingContestLogsParams struct {
@@ -809,6 +893,10 @@ type UpdateOngoingContestLogsParams struct {
 	Modifier        sql.NullFloat64
 	DurationSeconds sql.NullInt32
 	ComputedScore   sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
 	LogID           uuid.UUID
 	Now             time.Time
 }
@@ -820,6 +908,10 @@ func (q *Queries) UpdateOngoingContestLogs(ctx context.Context, arg UpdateOngoin
 		arg.Modifier,
 		arg.DurationSeconds,
 		arg.ComputedScore,
+		arg.ScoreRuleSetID,
+		pq.Array(arg.ScoreRuleIds),
+		pq.Array(arg.ScoreRates),
+		arg.ScoreSource,
 		arg.LogID,
 		arg.Now,
 	)

--- a/services/immersion-api/storage/postgres/models.go
+++ b/services/immersion-api/storage/postgres/models.go
@@ -39,6 +39,10 @@ type ContestLog struct {
 	Score           sql.NullFloat64
 	DurationSeconds sql.NullInt32
 	ComputedScore   sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
 }
 
 type ContestRegistration struct {
@@ -85,6 +89,10 @@ type Log struct {
 	DurationSeconds             sql.NullInt32
 	ComputedScore               sql.NullFloat64
 	UnitKey                     sql.NullString
+	ScoreRuleSetID              uuid.NullUUID
+	ScoreRuleIds                []uuid.UUID
+	ScoreRates                  []float32
+	ScoreSource                 sql.NullString
 }
 
 type LogTag struct {

--- a/services/immersion-api/storage/postgres/queries/logs.sql
+++ b/services/immersion-api/storage/postgres/queries/logs.sql
@@ -10,6 +10,10 @@ insert into logs (
   modifier,
   duration_seconds,
   computed_score,
+  score_rule_set_id,
+  score_rule_ids,
+  score_rates,
+  score_source,
   eligible_official_leaderboard,
   "description"
 ) values (
@@ -23,6 +27,10 @@ insert into logs (
   sqlc.arg('modifier'),
   sqlc.arg('duration_seconds'),
   sqlc.arg('computed_score'),
+  sqlc.arg('score_rule_set_id'),
+  sqlc.arg('score_rule_ids'),
+  sqlc.arg('score_rates'),
+  sqlc.arg('score_source'),
   sqlc.arg('eligible_official_leaderboard'),
   sqlc.arg('description')
 ) returning id;
@@ -35,7 +43,11 @@ insert into contest_logs (
   amount,
   modifier,
   duration_seconds,
-  computed_score
+  computed_score,
+  score_rule_set_id,
+  score_rule_ids,
+  score_rates,
+  score_source
 ) values (
   (select contest_id from contest_registrations where id = sqlc.arg('registration_id')),
   sqlc.arg('log_id'),
@@ -43,7 +55,11 @@ insert into contest_logs (
   sqlc.arg('amount'),
   sqlc.arg('modifier'),
   sqlc.arg('duration_seconds'),
-  sqlc.arg('computed_score')
+  sqlc.arg('computed_score'),
+  sqlc.arg('score_rule_set_id'),
+  sqlc.arg('score_rule_ids'),
+  sqlc.arg('score_rates'),
+  sqlc.arg('score_source')
 );
 
 -- name: ListLogsForContest :many
@@ -62,6 +78,10 @@ with eligible_logs as (
     contest_logs.modifier,
     contest_logs.duration_seconds,
     coalesce(contest_logs.computed_score, contest_logs.score) as score,
+    contest_logs.score_rule_set_id,
+    contest_logs.score_rule_ids,
+    contest_logs.score_rates,
+    contest_logs.score_source,
     logs.created_at,
     logs.updated_at,
     logs.deleted_at,
@@ -104,6 +124,10 @@ with eligible_logs as (
     logs.modifier,
     logs.duration_seconds,
     coalesce(logs.computed_score, logs.score) as score,
+    logs.score_rule_set_id,
+    logs.score_rule_ids,
+    logs.score_rates,
+    logs.score_source,
     logs.created_at,
     logs.updated_at,
     logs.deleted_at,
@@ -142,6 +166,10 @@ select
   logs.modifier,
   logs.duration_seconds,
   coalesce(logs.computed_score, logs.score) as score,
+  logs.score_rule_set_id,
+  logs.score_rule_ids,
+  logs.score_rates,
+  logs.score_source,
   logs.eligible_official_leaderboard,
   logs.created_at,
   logs.updated_at,
@@ -273,6 +301,10 @@ set
   unit_key = sqlc.arg('unit_key'),
   duration_seconds = sqlc.arg('duration_seconds'),
   computed_score = sqlc.arg('computed_score'),
+  score_rule_set_id = sqlc.arg('score_rule_set_id'),
+  score_rule_ids = sqlc.arg('score_rule_ids'),
+  score_rates = sqlc.arg('score_rates'),
+  score_source = sqlc.arg('score_source'),
   "description" = sqlc.arg('description'),
   updated_at = sqlc.arg('now')
 where
@@ -286,7 +318,11 @@ set
   amount = sqlc.arg('amount'),
   modifier = sqlc.arg('modifier'),
   duration_seconds = sqlc.arg('duration_seconds'),
-  computed_score = sqlc.arg('computed_score')
+  computed_score = sqlc.arg('computed_score'),
+  score_rule_set_id = sqlc.arg('score_rule_set_id'),
+  score_rule_ids = sqlc.arg('score_rule_ids'),
+  score_rates = sqlc.arg('score_rates'),
+  score_source = sqlc.arg('score_source')
 from contests
 where
   contest_logs.log_id = sqlc.arg('log_id')

--- a/services/immersion-api/storage/postgres/repository/logtracking.go
+++ b/services/immersion-api/storage/postgres/repository/logtracking.go
@@ -43,6 +43,34 @@ func trackingDurationSeconds(tracking domain.LogTracking) sql.NullInt32 {
 	return sql.NullInt32{Valid: true, Int32: tracking.DurationSeconds}
 }
 
+func scoreRuleSetID(provenance *domain.ScoreProvenance) uuid.NullUUID {
+	if provenance == nil || provenance.RuleSetID == nil {
+		return uuid.NullUUID{}
+	}
+	return postgres.NewNullUUID(*provenance.RuleSetID)
+}
+
+func scoreRuleIDs(provenance *domain.ScoreProvenance) []uuid.UUID {
+	if provenance == nil {
+		return nil
+	}
+	return provenance.RuleIDs
+}
+
+func scoreRates(provenance *domain.ScoreProvenance) []float32 {
+	if provenance == nil {
+		return nil
+	}
+	return provenance.Rates
+}
+
+func scoreSource(provenance *domain.ScoreProvenance) sql.NullString {
+	if provenance == nil || provenance.Source == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: string(provenance.Source), Valid: true}
+}
+
 func readLogTracking(
 	unitID uuid.NullUUID,
 	unitKey string,
@@ -50,9 +78,24 @@ func readLogTracking(
 	modifier sql.NullFloat64,
 	durationSeconds sql.NullInt32,
 	score sql.NullFloat64,
+	scoreRuleSetID uuid.NullUUID,
+	scoreRuleIDs []uuid.UUID,
+	scoreRates []float32,
+	scoreSource sql.NullString,
 ) domain.LogTracking {
 	tracking := domain.LogTracking{
 		ComputedScore: postgres.NewFloat32FromNullFloat64(score),
+	}
+	if scoreRuleSetID.Valid || scoreSource.Valid || len(scoreRuleIDs) > 0 || len(scoreRates) > 0 {
+		tracking.ScoreProvenance = &domain.ScoreProvenance{
+			RuleIDs: append([]uuid.UUID(nil), scoreRuleIDs...),
+			Rates:   append([]float32(nil), scoreRates...),
+			Source:  domain.ScoreSource(scoreSource.String),
+		}
+		if scoreRuleSetID.Valid {
+			ruleSetID := scoreRuleSetID.UUID
+			tracking.ScoreProvenance.RuleSetID = &ruleSetID
+		}
 	}
 	hasAmountUnit := amount.Valid && modifier.Valid
 	if hasAmountUnit {

--- a/services/immersion-api/storage/postgres/repository/logtracking_test.go
+++ b/services/immersion-api/storage/postgres/repository/logtracking_test.go
@@ -139,7 +139,18 @@ func TestReadLogTracking(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tracking := readLogTracking(tt.unitID, unitKey, tt.amount, tt.modifier, tt.durationSeconds, tt.score)
+			tracking := readLogTracking(
+				tt.unitID,
+				unitKey,
+				tt.amount,
+				tt.modifier,
+				tt.durationSeconds,
+				tt.score,
+				uuid.NullUUID{},
+				nil,
+				nil,
+				sql.NullString{},
+			)
 
 			require.Equal(t, tt.expectedTracking.Kind, tracking.Kind)
 			assert.Equal(t, tt.expectedTracking.UnitID, tracking.UnitID)
@@ -150,4 +161,52 @@ func TestReadLogTracking(t *testing.T) {
 			assert.InDelta(t, tt.expectedTracking.ComputedScore, tracking.ComputedScore, 0.0001)
 		})
 	}
+}
+
+func TestScoreProvenanceConversions(t *testing.T) {
+	ruleSetID := uuid.New()
+	ruleIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	rates := []float32{1, 1.5}
+	provenance := &domain.ScoreProvenance{
+		RuleSetID: &ruleSetID,
+		RuleIDs:   ruleIDs,
+		Rates:     rates,
+		Source:    domain.ScoreSourceAmount,
+	}
+
+	assert.Equal(t, ruleSetID, scoreRuleSetID(provenance).UUID)
+	assert.Equal(t, ruleIDs, scoreRuleIDs(provenance))
+	assert.Equal(t, rates, scoreRates(provenance))
+	assert.Equal(t, string(domain.ScoreSourceAmount), scoreSource(provenance).String)
+
+	assert.False(t, scoreRuleSetID(nil).Valid)
+	assert.Nil(t, scoreRuleIDs(nil))
+	assert.Nil(t, scoreRates(nil))
+	assert.False(t, scoreSource(nil).Valid)
+}
+
+func TestReadLogTrackingWithScoreProvenance(t *testing.T) {
+	ruleSetID := uuid.New()
+	ruleIDs := []uuid.UUID{uuid.New(), uuid.New()}
+	rates := []float32{1, 1.5}
+
+	tracking := readLogTracking(
+		uuid.NullUUID{},
+		"",
+		sql.NullFloat64{},
+		sql.NullFloat64{},
+		sql.NullInt32{Int32: 600, Valid: true},
+		sql.NullFloat64{Float64: 4, Valid: true},
+		uuid.NullUUID{UUID: ruleSetID, Valid: true},
+		ruleIDs,
+		rates,
+		sql.NullString{String: string(domain.ScoreSourceDurationMinutes), Valid: true},
+	)
+
+	require.NotNil(t, tracking.ScoreProvenance)
+	require.NotNil(t, tracking.ScoreProvenance.RuleSetID)
+	assert.Equal(t, ruleSetID, *tracking.ScoreProvenance.RuleSetID)
+	assert.Equal(t, ruleIDs, tracking.ScoreProvenance.RuleIDs)
+	assert.Equal(t, rates, tracking.ScoreProvenance.Rates)
+	assert.Equal(t, domain.ScoreSourceDurationMinutes, tracking.ScoreProvenance.Source)
 }

--- a/services/immersion-api/storage/postgres/repository/repo_createlog.go
+++ b/services/immersion-api/storage/postgres/repository/repo_createlog.go
@@ -29,6 +29,10 @@ func (r *Repository) CreateLog(ctx context.Context, req *domain.LogCreateRequest
 		Modifier:                    trackingModifier(tracking),
 		DurationSeconds:             trackingDurationSeconds(tracking),
 		ComputedScore:               postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
+		ScoreRuleSetID:              scoreRuleSetID(tracking.ScoreProvenance),
+		ScoreRuleIds:                scoreRuleIDs(tracking.ScoreProvenance),
+		ScoreRates:                  scoreRates(tracking.ScoreProvenance),
+		ScoreSource:                 scoreSource(tracking.ScoreProvenance),
 		EligibleOfficialLeaderboard: req.EligibleOfficialLeaderboard(),
 		Description:                 postgres.NewNullString(req.Description),
 	})
@@ -49,6 +53,10 @@ func (r *Repository) CreateLog(ctx context.Context, req *domain.LogCreateRequest
 			Modifier:        trackingModifier(tracking),
 			DurationSeconds: trackingDurationSeconds(tracking),
 			ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
+			ScoreRuleSetID:  scoreRuleSetID(nil),
+			ScoreRuleIds:    scoreRuleIDs(nil),
+			ScoreRates:      scoreRates(nil),
+			ScoreSource:     scoreSource(nil),
 		}); err != nil {
 			_ = tx.Rollback()
 			return nil, fmt.Errorf("could not create log: %w", err)

--- a/services/immersion-api/storage/postgres/repository/repo_findlogbyid.go
+++ b/services/immersion-api/storage/postgres/repository/repo_findlogbyid.go
@@ -41,7 +41,18 @@ func (r *Repository) FindLogByID(ctx context.Context, req *domain.LogFindRequest
 		}
 	}
 
-	tracking := readLogTracking(log.UnitID, log.UnitKey, log.Amount, log.Modifier, log.DurationSeconds, log.Score)
+	tracking := readLogTracking(
+		log.UnitID,
+		log.UnitKey,
+		log.Amount,
+		log.Modifier,
+		log.DurationSeconds,
+		log.Score,
+		log.ScoreRuleSetID,
+		log.ScoreRuleIds,
+		log.ScoreRates,
+		log.ScoreSource,
+	)
 
 	return &domain.Log{
 		ID:                          log.ID,

--- a/services/immersion-api/storage/postgres/repository/repo_listlogsforcontest.go
+++ b/services/immersion-api/storage/postgres/repository/repo_listlogsforcontest.go
@@ -40,7 +40,18 @@ func (r *Repository) ListLogsForContest(ctx context.Context, req *domain.LogList
 
 	res := make([]domain.Log, len(entries))
 	for i, it := range entries {
-		tracking := readLogTracking(it.UnitID, it.UnitKey, it.Amount, it.Modifier, it.DurationSeconds, it.Score)
+		tracking := readLogTracking(
+			it.UnitID,
+			it.UnitKey,
+			it.Amount,
+			it.Modifier,
+			it.DurationSeconds,
+			it.Score,
+			it.ScoreRuleSetID,
+			it.ScoreRuleIds,
+			it.ScoreRates,
+			it.ScoreSource,
+		)
 		res[i] = domain.Log{
 			ID:              it.ID,
 			UserID:          it.UserID,

--- a/services/immersion-api/storage/postgres/repository/repo_listlogsforuser.go
+++ b/services/immersion-api/storage/postgres/repository/repo_listlogsforuser.go
@@ -30,7 +30,18 @@ func (r *Repository) ListLogsForUser(ctx context.Context, req *domain.LogListFor
 
 	res := make([]domain.Log, len(entries))
 	for i, it := range entries {
-		tracking := readLogTracking(it.UnitID, it.UnitKey, it.Amount, it.Modifier, it.DurationSeconds, it.Score)
+		tracking := readLogTracking(
+			it.UnitID,
+			it.UnitKey,
+			it.Amount,
+			it.Modifier,
+			it.DurationSeconds,
+			it.Score,
+			it.ScoreRuleSetID,
+			it.ScoreRuleIds,
+			it.ScoreRates,
+			it.ScoreSource,
+		)
 		res[i] = domain.Log{
 			ID:              it.ID,
 			UserID:          it.UserID,

--- a/services/immersion-api/storage/postgres/repository/repo_updatelog.go
+++ b/services/immersion-api/storage/postgres/repository/repo_updatelog.go
@@ -33,6 +33,10 @@ func (r *Repository) UpdateLog(ctx context.Context, req *domain.LogUpdateRequest
 		UnitKey:         trackingUnitKey(tracking),
 		DurationSeconds: trackingDurationSeconds(tracking),
 		ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
+		ScoreRuleSetID:  scoreRuleSetID(tracking.ScoreProvenance),
+		ScoreRuleIds:    scoreRuleIDs(tracking.ScoreProvenance),
+		ScoreRates:      scoreRates(tracking.ScoreProvenance),
+		ScoreSource:     scoreSource(tracking.ScoreProvenance),
 		Description:     postgres.NewNullString(req.Description),
 		Now:             req.Now(),
 	}); err != nil {
@@ -48,6 +52,10 @@ func (r *Repository) UpdateLog(ctx context.Context, req *domain.LogUpdateRequest
 		Modifier:        trackingModifier(tracking),
 		DurationSeconds: trackingDurationSeconds(tracking),
 		ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
+		ScoreRuleSetID:  scoreRuleSetID(nil),
+		ScoreRuleIds:    scoreRuleIDs(nil),
+		ScoreRates:      scoreRates(nil),
+		ScoreSource:     scoreSource(nil),
 		Now:             req.Now(),
 	}); err != nil {
 		_ = tx.Rollback()


### PR DESCRIPTION
Stacked after migration PR #754.

## Deployment boundary

#754 contains only `0022_score_provenance`. Merge and deploy #754 independently before merging this code slice. Once #754 merges, GitHub will retarget this PR toward `main`.

## What changed

Persist the rule-set ID, applied rule IDs, rates, and score source used for log and contest score snapshots.

## Why

Published scores need immutable provenance so later rule versions cannot obscure how a historical score was produced.

## Validation

- full Bazel service build and all 16 backend test targets
- full pnpm frontend build, WebV2 typecheck, and lint