### PR TITLE
Switch platform logs to the scoring engine

### DIFF
--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -387,11 +387,11 @@ endpoint. All form changes must use `react-hook-form` and components from the
   - [x] Add the same fields independently to `contest_logs`.
   - [x] Allow rule fields to be null when the score is zero because no rule matched.
 
-- [ ] Switch platform log scoring to the engine behind the feature flag.
-  - [ ] Use the active platform rule set for create and update.
-  - [ ] Preserve legacy UUID-unit compatibility.
-  - [ ] Preserve existing amount-plus-duration behavior.
-  - [ ] Confirm historical logs and aggregates remain unchanged.
+- [x] Switch platform log scoring to the engine behind the feature flag.
+  - [x] Use the active platform rule set for create and update.
+  - [x] Preserve legacy UUID-unit compatibility.
+  - [x] Preserve existing amount-plus-duration behavior.
+  - [x] Confirm historical logs and aggregates remain unchanged.
 
 - [ ] Implement independent contest scoring.
   - [ ] Resolve each selected contest's rules separately.

--- a/services/immersion-api/deployments/api.yaml
+++ b/services/immersion-api/deployments/api.yaml
@@ -54,6 +54,8 @@ spec:
             value: "redis://valkey-immersion.default:6379"
           - name: SERVICE_NAME
             value: "immersion-api"
+          - name: API_SCORING_ENGINE_ENABLED
+            value: "false"
         volumeMounts:
         - name: k8s-token
           mountPath: /var/run/secrets/tokens

--- a/services/immersion-api/domain/logcreate.go
+++ b/services/immersion-api/domain/logcreate.go
@@ -44,10 +44,11 @@ func (r *LogCreateRequest) Year() int16                       { return r.year }
 func (r *LogCreateRequest) Tracking() LogTracking             { return r.tracking }
 
 type LogCreate struct {
-	repo       LogCreateRepository
-	clock      commondomain.Clock
-	validate   *validator.Validate
-	userUpsert *UserUpsert
+	repo             LogCreateRepository
+	clock            commondomain.Clock
+	validate         *validator.Validate
+	userUpsert       *UserUpsert
+	useScoringEngine bool
 }
 
 func NewLogCreate(
@@ -55,11 +56,21 @@ func NewLogCreate(
 	clock commondomain.Clock,
 	userUpsert *UserUpsert,
 ) *LogCreate {
+	return NewLogCreateWithScoringEngine(repo, clock, userUpsert, false)
+}
+
+func NewLogCreateWithScoringEngine(
+	repo LogCreateRepository,
+	clock commondomain.Clock,
+	userUpsert *UserUpsert,
+	enabled bool,
+) *LogCreate {
 	return &LogCreate{
-		repo:       repo,
-		clock:      clock,
-		validate:   validator.New(),
-		userUpsert: userUpsert,
+		repo:             repo,
+		clock:            clock,
+		validate:         validator.New(),
+		userUpsert:       userUpsert,
+		useScoringEngine: enabled,
 	}
 }
 
@@ -155,14 +166,23 @@ func (s *LogCreate) Execute(ctx context.Context, req *LogCreateRequest) (*Log, e
 	if err != nil {
 		return nil, err
 	}
-	RecordPlatformScoringShadow(ctx, s.repo, ScoringInput{
+	scoringInput := ScoringInput{
 		ActivityID:      req.ActivityID,
 		UnitKey:         req.tracking.UnitKey,
 		LanguageCode:    req.LanguageCode,
 		Tags:            req.Tags,
 		Amount:          req.Amount,
 		DurationSeconds: req.DurationSeconds,
-	}, req.tracking.ComputedScore)
+	}
+	if s.useScoringEngine {
+		result, scoringErr := EvaluateActivePlatformScore(ctx, s.repo, scoringInput)
+		if scoringErr != nil {
+			return nil, fmt.Errorf("could not score log: %w", scoringErr)
+		}
+		ApplyScoringResult(&req.tracking, result)
+	} else {
+		RecordPlatformScoringShadow(ctx, s.repo, scoringInput, req.tracking.ComputedScore)
+	}
 
 	req.year = int16(s.clock.Now().Year())
 

--- a/services/immersion-api/domain/logcreate_test.go
+++ b/services/immersion-api/domain/logcreate_test.go
@@ -123,6 +123,12 @@ func newLogCreateService(repo *mockLogCreateRepository, clock commondomain.Clock
 	return domain.NewLogCreate(repo, clock, userUpsert)
 }
 
+func newLogCreateServiceWithScoringEngine(repo *mockLogCreateRepository, clock commondomain.Clock) *domain.LogCreate {
+	userRepo := &mockUserUpsertRepositoryForLog{}
+	userUpsert := domain.NewUserUpsert(userRepo)
+	return domain.NewLogCreateWithScoringEngine(repo, clock, userUpsert, true)
+}
+
 func TestLogCreate_Execute(t *testing.T) {
 	userID := uuid.New()
 	logID := uuid.New()
@@ -512,6 +518,93 @@ func TestLogCreate_Execute(t *testing.T) {
 		assert.Equal(t, 1, repo.scoringRuleCalls)
 		assert.True(t, repo.createCalled)
 		assert.Equal(t, float32(100), repo.createCalledWith.Tracking().ComputedScore)
+	})
+
+	t.Run("writes the engine score and provenance when enabled", func(t *testing.T) {
+		ruleSetID := uuid.New()
+		ruleID := uuid.New()
+		repo := &mockLogCreateRepository{
+			scoringRuleSet: &domain.ScoringRuleSet{
+				ID: ruleSetID,
+				Rules: []domain.ScoringRule{{
+					ID:          ruleID,
+					Priority:    1,
+					ActivityID:  1,
+					UnitKey:     domain.UnitKeyReadingPage,
+					ScoreSource: domain.ScoreSourceAmount,
+					Rate:        2,
+				}},
+			},
+			createdLogID: &logID,
+			log:          createdLog,
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := newLogCreateServiceWithScoringEngine(repo, clock)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			UnitID:       &unitID,
+			ActivityID:   1,
+			LanguageCode: "jpn",
+			Amount:       &amount100,
+		})
+
+		require.NoError(t, err)
+		tracking := repo.createCalledWith.Tracking()
+		assert.Equal(t, float32(200), tracking.ComputedScore)
+		require.NotNil(t, tracking.ScoreProvenance)
+		assert.Equal(t, &ruleSetID, tracking.ScoreProvenance.RuleSetID)
+		assert.Equal(t, []uuid.UUID{ruleID}, tracking.ScoreProvenance.RuleIDs)
+		assert.Equal(t, []float32{2}, tracking.ScoreProvenance.Rates)
+		assert.Equal(t, domain.ScoreSourceAmount, tracking.ScoreProvenance.Source)
+	})
+
+	t.Run("writes zero for an unmatched input when enabled", func(t *testing.T) {
+		repo := &mockLogCreateRepository{
+			scoringRuleSet: &domain.ScoringRuleSet{
+				ID: uuid.New(),
+				Rules: []domain.ScoringRule{{
+					ID:          uuid.New(),
+					Priority:    1,
+					ActivityID:  3,
+					ScoreSource: domain.ScoreSourceAmount,
+					Rate:        1,
+				}},
+			},
+			createdLogID: &logID,
+			log:          createdLog,
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := newLogCreateServiceWithScoringEngine(repo, clock)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			UnitID:       &unitID,
+			ActivityID:   1,
+			LanguageCode: "jpn",
+			Amount:       &amount100,
+		})
+
+		require.NoError(t, err)
+		tracking := repo.createCalledWith.Tracking()
+		assert.Zero(t, tracking.ComputedScore)
+		require.NotNil(t, tracking.ScoreProvenance)
+		assert.Nil(t, tracking.ScoreProvenance.RuleSetID)
+		assert.Equal(t, domain.ScoreSourceAmount, tracking.ScoreProvenance.Source)
+	})
+
+	t.Run("rejects the write when authoritative scoring fails", func(t *testing.T) {
+		repo := &mockLogCreateRepository{scoringRuleErr: errors.New("scoring unavailable")}
+		clock := commondomain.NewMockClock(now)
+		svc := newLogCreateServiceWithScoringEngine(repo, clock)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			UnitID:       &unitID,
+			ActivityID:   1,
+			LanguageCode: "jpn",
+			Amount:       &amount100,
+		})
+
+		assert.Error(t, err)
+		assert.False(t, repo.createCalled)
 	})
 
 	t.Run("successfully creates amount log with duration metadata", func(t *testing.T) {

--- a/services/immersion-api/domain/logtracking.go
+++ b/services/immersion-api/domain/logtracking.go
@@ -41,6 +41,23 @@ type ScoreProvenance struct {
 	Source    ScoreSource
 }
 
+func ApplyScoringResult(tracking *LogTracking, result ScoringResult) {
+	tracking.ComputedScore = result.Score
+	tracking.ScoreProvenance = &ScoreProvenance{
+		Source: result.ScoreSource,
+	}
+	if !result.Matched {
+		return
+	}
+	tracking.ScoreProvenance.RuleSetID = result.AppliedRuleSetID
+	tracking.ScoreProvenance.RuleIDs = make([]uuid.UUID, len(result.AppliedRules))
+	tracking.ScoreProvenance.Rates = make([]float32, len(result.AppliedRules))
+	for i, appliedRule := range result.AppliedRules {
+		tracking.ScoreProvenance.RuleIDs[i] = appliedRule.RuleID
+		tracking.ScoreProvenance.Rates[i] = appliedRule.Rate
+	}
+}
+
 type LogTrackingInput struct {
 	ActivityID      int32
 	UnitID          *uuid.UUID

--- a/services/immersion-api/domain/logtracking_test.go
+++ b/services/immersion-api/domain/logtracking_test.go
@@ -157,3 +157,44 @@ func TestComputeInterimLogScore(t *testing.T) {
 		}
 	})
 }
+
+func TestApplyScoringResult(t *testing.T) {
+	ruleSetID := uuid.New()
+	baseRuleID := uuid.New()
+	modifierRuleID := uuid.New()
+	tracking := domain.LogTracking{ComputedScore: 99}
+
+	domain.ApplyScoringResult(&tracking, domain.ScoringResult{
+		Score:            15,
+		ScoreSource:      domain.ScoreSourceAmount,
+		Matched:          true,
+		AppliedRuleSetID: &ruleSetID,
+		AppliedRules: []domain.AppliedScoringRule{
+			{RuleID: baseRuleID, Rate: 1},
+			{RuleID: modifierRuleID, Rate: 1.5},
+		},
+	})
+
+	assert.Equal(t, float32(15), tracking.ComputedScore)
+	require.NotNil(t, tracking.ScoreProvenance)
+	assert.Equal(t, &ruleSetID, tracking.ScoreProvenance.RuleSetID)
+	assert.Equal(t, []uuid.UUID{baseRuleID, modifierRuleID}, tracking.ScoreProvenance.RuleIDs)
+	assert.Equal(t, []float32{1, 1.5}, tracking.ScoreProvenance.Rates)
+	assert.Equal(t, domain.ScoreSourceAmount, tracking.ScoreProvenance.Source)
+}
+
+func TestApplyUnmatchedScoringResult(t *testing.T) {
+	tracking := domain.LogTracking{ComputedScore: 99}
+
+	domain.ApplyScoringResult(&tracking, domain.ScoringResult{
+		Score:       0,
+		ScoreSource: domain.ScoreSourceDurationMinutes,
+	})
+
+	assert.Zero(t, tracking.ComputedScore)
+	require.NotNil(t, tracking.ScoreProvenance)
+	assert.Nil(t, tracking.ScoreProvenance.RuleSetID)
+	assert.Empty(t, tracking.ScoreProvenance.RuleIDs)
+	assert.Empty(t, tracking.ScoreProvenance.Rates)
+	assert.Equal(t, domain.ScoreSourceDurationMinutes, tracking.ScoreProvenance.Source)
+}

--- a/services/immersion-api/domain/logupdate.go
+++ b/services/immersion-api/domain/logupdate.go
@@ -38,19 +38,29 @@ func (r *LogUpdateRequest) UserID() uuid.UUID     { return r.userID }
 func (r *LogUpdateRequest) Tracking() LogTracking { return r.tracking }
 
 type LogUpdate struct {
-	repo     LogUpdateRepository
-	clock    commondomain.Clock
-	validate *validator.Validate
+	repo             LogUpdateRepository
+	clock            commondomain.Clock
+	validate         *validator.Validate
+	useScoringEngine bool
 }
 
 func NewLogUpdate(
 	repo LogUpdateRepository,
 	clock commondomain.Clock,
 ) *LogUpdate {
+	return NewLogUpdateWithScoringEngine(repo, clock, false)
+}
+
+func NewLogUpdateWithScoringEngine(
+	repo LogUpdateRepository,
+	clock commondomain.Clock,
+	enabled bool,
+) *LogUpdate {
 	return &LogUpdate{
-		repo:     repo,
-		clock:    clock,
-		validate: validator.New(),
+		repo:             repo,
+		clock:            clock,
+		validate:         validator.New(),
+		useScoringEngine: enabled,
 	}
 }
 
@@ -101,14 +111,23 @@ func (s *LogUpdate) Execute(ctx context.Context, req *LogUpdateRequest) (*Log, e
 	if err != nil {
 		return nil, err
 	}
-	RecordPlatformScoringShadow(ctx, s.repo, ScoringInput{
+	scoringInput := ScoringInput{
 		ActivityID:      int32(log.ActivityID),
 		UnitKey:         req.tracking.UnitKey,
 		LanguageCode:    log.LanguageCode,
 		Tags:            req.Tags,
 		Amount:          req.Amount,
 		DurationSeconds: req.DurationSeconds,
-	}, req.tracking.ComputedScore)
+	}
+	if s.useScoringEngine {
+		result, scoringErr := EvaluateActivePlatformScore(ctx, s.repo, scoringInput)
+		if scoringErr != nil {
+			return nil, fmt.Errorf("could not score log: %w", scoringErr)
+		}
+		ApplyScoringResult(&req.tracking, result)
+	} else {
+		RecordPlatformScoringShadow(ctx, s.repo, scoringInput, req.tracking.ComputedScore)
+	}
 
 	req.now = s.clock.Now()
 	req.userID = log.UserID

--- a/services/immersion-api/domain/logupdate_test.go
+++ b/services/immersion-api/domain/logupdate_test.go
@@ -365,6 +365,42 @@ func TestLogUpdate_Execute(t *testing.T) {
 		assert.Equal(t, float32(10), repo.updateCalledWith.Tracking().ComputedScore)
 	})
 
+	t.Run("writes the engine score and provenance when enabled", func(t *testing.T) {
+		ruleSetID := uuid.New()
+		ruleID := uuid.New()
+		updatedLog := &domain.Log{ID: logID, UserID: userID, ActivityID: 1, Amount: 10}
+		repo := &mockLogUpdateRepository{
+			log:        makeLog(userID),
+			updatedLog: updatedLog,
+			scoringRuleSet: &domain.ScoringRuleSet{
+				ID: ruleSetID,
+				Rules: []domain.ScoringRule{{
+					ID:          ruleID,
+					Priority:    1,
+					ActivityID:  1,
+					UnitKey:     domain.UnitKeyReadingPage,
+					ScoreSource: domain.ScoreSourceAmount,
+					Rate:        2,
+				}},
+			},
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := domain.NewLogUpdateWithScoringEngine(repo, clock, true)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogUpdateRequest{
+			LogID:  logID,
+			UnitID: &unitID,
+			Amount: &amount10,
+		})
+
+		require.NoError(t, err)
+		tracking := repo.updateCalledWith.Tracking()
+		assert.Equal(t, float32(20), tracking.ComputedScore)
+		require.NotNil(t, tracking.ScoreProvenance)
+		assert.Equal(t, &ruleSetID, tracking.ScoreProvenance.RuleSetID)
+		assert.Equal(t, []uuid.UUID{ruleID}, tracking.ScoreProvenance.RuleIDs)
+	})
+
 	t.Run("allows amount update with duration metadata", func(t *testing.T) {
 		updatedLog := &domain.Log{ID: logID, UserID: userID, ActivityID: 1, Amount: 10, DurationSeconds: &duration900}
 		repo := &mockLogUpdateRepository{

--- a/services/immersion-api/domain/scoringshadow.go
+++ b/services/immersion-api/domain/scoringshadow.go
@@ -23,14 +23,7 @@ func EvaluatePlatformScoringShadow(
 	input ScoringInput,
 	interimScore float32,
 ) (ScoringShadowComparison, error) {
-	ruleSet, err := finder.FindActivePlatformScoringRuleSet(ctx)
-	if err != nil {
-		return ScoringShadowComparison{}, err
-	}
-	if ruleSet == nil {
-		return ScoringShadowComparison{}, fmt.Errorf("active platform scoring rule set is nil: %w", ErrScoringRuleSetNotFound)
-	}
-	ruleResult, err := EvaluateScoringRuleSet(input, *ruleSet)
+	ruleResult, err := EvaluateActivePlatformScore(ctx, finder, input)
 	if err != nil {
 		return ScoringShadowComparison{}, err
 	}
@@ -39,6 +32,21 @@ func EvaluatePlatformScoringShadow(
 		RuleResult:   ruleResult,
 		Mismatch:     !scoringScoresEqual(interimScore, ruleResult.Score),
 	}, nil
+}
+
+func EvaluateActivePlatformScore(
+	ctx context.Context,
+	finder activePlatformScoringRuleSetFinder,
+	input ScoringInput,
+) (ScoringResult, error) {
+	ruleSet, err := finder.FindActivePlatformScoringRuleSet(ctx)
+	if err != nil {
+		return ScoringResult{}, err
+	}
+	if ruleSet == nil {
+		return ScoringResult{}, fmt.Errorf("active platform scoring rule set is nil: %w", ErrScoringRuleSetNotFound)
+	}
+	return EvaluateScoringRuleSet(input, *ruleSet)
 }
 
 func RecordPlatformScoringShadow(

--- a/services/immersion-api/main.go
+++ b/services/immersion-api/main.go
@@ -43,6 +43,7 @@ type Config struct {
 	ServiceName            string  `envconfig:"service_name" default:"immersion-api"`
 	SentryDSN              string  `envconfig:"sentry_dns"`
 	SentryTracesSampleRate float64 `validate:"required_with=SentryDSN" envconfig:"sentry_traces_sample_rate"`
+	ScoringEngineEnabled   bool    `envconfig:"scoring_engine_enabled" default:"false"`
 }
 
 func main() {
@@ -145,8 +146,8 @@ func main() {
 	contestModerationDetachLog := immersiondomain.NewContestModerationDetachLog(postgresRepository)
 	userUpsert := immersiondomain.NewUserUpsert(postgresRepository)
 	registrationUpsert := immersiondomain.NewRegistrationUpsert(postgresRepository, userUpsert)
-	logCreate := immersiondomain.NewLogCreate(postgresRepository, clock, userUpsert)
-	logUpdate := immersiondomain.NewLogUpdate(postgresRepository, clock)
+	logCreate := immersiondomain.NewLogCreateWithScoringEngine(postgresRepository, clock, userUpsert, cfg.ScoringEngineEnabled)
+	logUpdate := immersiondomain.NewLogUpdateWithScoringEngine(postgresRepository, clock, cfg.ScoringEngineEnabled)
 	contestCreate := immersiondomain.NewContestCreate(postgresRepository, clock, userUpsert)
 	languageList := immersiondomain.NewLanguageList(postgresRepository)
 	languageCreate := immersiondomain.NewLanguageCreate(postgresRepository)


### PR DESCRIPTION
Stacked on #743.

## What changed

Make the active platform rule set authoritative for log create and update when API_SCORING_ENGINE_ENABLED is true. The flag defaults to false and the interim scorer remains the fallback while disabled.

## Why

This introduces the production cutover as an explicit, reversible deployment decision after shadow parity is verified.

## Validation

- full Bazel service build and all 16 backend test targets
- full pnpm frontend build, WebV2 typecheck, and lint