### PR TITLE
Snapshot independent contest scores

### DIFF
--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -393,13 +393,13 @@ endpoint. All form changes must use `react-hook-form` and components from the
   - [x] Preserve existing amount-plus-duration behavior.
   - [x] Confirm historical logs and aggregates remain unchanged.
 
-- [ ] Implement independent contest scoring.
-  - [ ] Resolve each selected contest's rules separately.
-  - [ ] Snapshot each contest score in `contest_logs`.
-  - [ ] Re-resolve ongoing contest scores when a log is edited.
-  - [ ] Resolve rules when an existing log is attached to a contest.
-  - [ ] Never change completed-contest snapshots implicitly.
-  - [ ] Confirm uncovered replacing rule sets award zero.
+- [x] Implement independent contest scoring.
+  - [x] Resolve each selected contest's rules separately.
+  - [x] Snapshot each contest score in `contest_logs`.
+  - [x] Re-resolve ongoing contest scores when a log is edited.
+  - [x] Resolve rules when an existing log is attached to a contest.
+  - [x] Never change completed-contest snapshots implicitly.
+  - [x] Confirm uncovered replacing rule sets award zero.
 
 - [ ] Add a score-preview API.
   - [ ] Accept the same activity, unit, language, tags, amount, duration, and contest

--- a/services/immersion-api/domain/BUILD.bazel
+++ b/services/immersion-api/domain/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "contestlist.go",
         "contestmoderationdetachlog.go",
         "contestpermissioncheck.go",
+        "contestscoring.go",
         "contestsummaryfetch.go",
         "errors.go",
         "interfaces.go",

--- a/services/immersion-api/domain/contestscoring.go
+++ b/services/immersion-api/domain/contestscoring.go
@@ -1,0 +1,75 @@
+package domain
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+)
+
+type contestScoringRuleSetFinder interface {
+	FindActivePlatformScoringRuleSet(context.Context) (*ScoringRuleSet, error)
+	FindContestScoringRuleSets(context.Context, uuid.UUID) (*ScoringRuleSet, *ScoringRuleSet, error)
+}
+
+type ContestLogTracking struct {
+	RegistrationID uuid.UUID
+	ContestID      uuid.UUID
+	Tracking       LogTracking
+}
+
+func scoringInputFromTracking(
+	activityID int32,
+	languageCode string,
+	tags []string,
+	tracking LogTracking,
+) ScoringInput {
+	input := ScoringInput{
+		ActivityID:   activityID,
+		UnitKey:      tracking.UnitKey,
+		LanguageCode: languageCode,
+		Tags:         tags,
+	}
+	if tracking.Kind == LogTrackingAmountUnit || tracking.Kind == LogTrackingBoth {
+		input.Amount = &tracking.Amount
+	}
+	if tracking.Kind == LogTrackingDuration || tracking.Kind == LogTrackingBoth {
+		input.DurationSeconds = &tracking.DurationSeconds
+	}
+	return input
+}
+
+func resolveContestLogTracking(
+	ctx context.Context,
+	finder contestScoringRuleSetFinder,
+	contestID uuid.UUID,
+	registrationID uuid.UUID,
+	platformTracking LogTracking,
+	input ScoringInput,
+) (ContestLogTracking, error) {
+	contestRuleSet, fallbackRuleSet, err := finder.FindContestScoringRuleSets(ctx, contestID)
+	if err != nil {
+		return ContestLogTracking{}, err
+	}
+
+	tracking := platformTracking
+	if contestRuleSet == nil {
+		result, evaluateErr := EvaluateActivePlatformScore(ctx, finder, input)
+		if evaluateErr != nil {
+			return ContestLogTracking{}, fmt.Errorf("could not evaluate platform scoring rules: %w", evaluateErr)
+		}
+		ApplyScoringResult(&tracking, result)
+	} else {
+		result, evaluateErr := EvaluateContestScore(input, *contestRuleSet, fallbackRuleSet)
+		if evaluateErr != nil {
+			return ContestLogTracking{}, fmt.Errorf("could not evaluate contest scoring rules: %w", evaluateErr)
+		}
+		ApplyScoringResult(&tracking, result)
+	}
+
+	return ContestLogTracking{
+		RegistrationID: registrationID,
+		ContestID:      contestID,
+		Tracking:       tracking,
+	}, nil
+}

--- a/services/immersion-api/domain/logcontestupdate.go
+++ b/services/immersion-api/domain/logcontestupdate.go
@@ -12,6 +12,8 @@ import (
 type LogContestUpdateRepository interface {
 	FetchOngoingContestRegistrations(context.Context, *RegistrationListOngoingRequest) (*ContestRegistrations, error)
 	FindLogByID(context.Context, *LogFindRequest) (*Log, error)
+	FindActivePlatformScoringRuleSet(context.Context) (*ScoringRuleSet, error)
+	FindContestScoringRuleSets(context.Context, uuid.UUID) (*ScoringRuleSet, *ScoringRuleSet, error)
 	UpdateLogContests(ctx context.Context, req *LogContestUpdateDBRequest) error
 }
 
@@ -30,20 +32,31 @@ type LogContestUpdateDBRequest struct {
 type LogContestAttach struct {
 	RegistrationID uuid.UUID
 	ContestID      uuid.UUID
+	Tracking       LogTracking
 }
 
 type LogContestUpdate struct {
-	repo  LogContestUpdateRepository
-	clock commondomain.Clock
+	repo             LogContestUpdateRepository
+	clock            commondomain.Clock
+	useScoringEngine bool
 }
 
 func NewLogContestUpdate(
 	repo LogContestUpdateRepository,
 	clock commondomain.Clock,
 ) *LogContestUpdate {
+	return NewLogContestUpdateWithScoringEngine(repo, clock, false)
+}
+
+func NewLogContestUpdateWithScoringEngine(
+	repo LogContestUpdateRepository,
+	clock commondomain.Clock,
+	enabled bool,
+) *LogContestUpdate {
 	return &LogContestUpdate{
-		repo:  repo,
-		clock: clock,
+		repo:             repo,
+		clock:            clock,
+		useScoringEngine: enabled,
 	}
 }
 
@@ -152,6 +165,7 @@ func (s *LogContestUpdate) Execute(ctx context.Context, req *LogContestUpdateReq
 			toAttach = append(toAttach, LogContestAttach{
 				RegistrationID: regID,
 				ContestID:      reg.ContestID,
+				Tracking:       log.Tracking,
 			})
 		}
 	}
@@ -168,6 +182,24 @@ func (s *LogContestUpdate) Execute(ctx context.Context, req *LogContestUpdateReq
 
 	if len(toAttach) > 0 && log.Tracking.Kind == "" {
 		return nil, fmt.Errorf("log tracking data is required for contest attachment: %w", ErrInvalidLog)
+	}
+
+	if s.useScoringEngine {
+		input := scoringInputFromTracking(int32(log.ActivityID), log.LanguageCode, log.Tags, log.Tracking)
+		for i := range toAttach {
+			contestTracking, scoringErr := resolveContestLogTracking(
+				ctx,
+				s.repo,
+				toAttach[i].ContestID,
+				toAttach[i].RegistrationID,
+				log.Tracking,
+				input,
+			)
+			if scoringErr != nil {
+				return nil, fmt.Errorf("could not score contest %s: %w", toAttach[i].ContestID, scoringErr)
+			}
+			toAttach[i].Tracking = contestTracking.Tracking
+		}
 	}
 
 	if err := s.repo.UpdateLogContests(ctx, &LogContestUpdateDBRequest{

--- a/services/immersion-api/domain/logcontestupdate_test.go
+++ b/services/immersion-api/domain/logcontestupdate_test.go
@@ -14,15 +14,33 @@ import (
 )
 
 type mockLogContestUpdateRepository struct {
-	registrations    *domain.ContestRegistrations
-	fetchRegErr      error
-	log              *domain.Log
-	updatedLog       *domain.Log
-	findErr          error
-	updateErr        error
-	updateCalled     bool
-	updateCalledWith *domain.LogContestUpdateDBRequest
-	findCallCount    int
+	registrations     *domain.ContestRegistrations
+	fetchRegErr       error
+	log               *domain.Log
+	updatedLog        *domain.Log
+	findErr           error
+	updateErr         error
+	updateCalled      bool
+	updateCalledWith  *domain.LogContestUpdateDBRequest
+	findCallCount     int
+	contestRuleSets   map[uuid.UUID]*domain.ScoringRuleSet
+	contestFallbacks  map[uuid.UUID]*domain.ScoringRuleSet
+	contestScoringErr error
+	scoringRuleSet    *domain.ScoringRuleSet
+}
+
+func (m *mockLogContestUpdateRepository) FindActivePlatformScoringRuleSet(context.Context) (*domain.ScoringRuleSet, error) {
+	if m.scoringRuleSet != nil {
+		return m.scoringRuleSet, nil
+	}
+	return defaultScoringShadowRuleSet(), nil
+}
+
+func (m *mockLogContestUpdateRepository) FindContestScoringRuleSets(_ context.Context, contestID uuid.UUID) (*domain.ScoringRuleSet, *domain.ScoringRuleSet, error) {
+	if m.contestScoringErr != nil {
+		return nil, nil, m.contestScoringErr
+	}
+	return m.contestRuleSets[contestID], m.contestFallbacks[contestID], nil
 }
 
 func (m *mockLogContestUpdateRepository) FetchOngoingContestRegistrations(ctx context.Context, req *domain.RegistrationListOngoingRequest) (*domain.ContestRegistrations, error) {
@@ -279,6 +297,44 @@ func TestLogContestUpdate_Execute(t *testing.T) {
 		assert.Equal(t, contestID, repo.updateCalledWith.Attach[0].ContestID)
 		assert.Empty(t, repo.updateCalledWith.Detach)
 		assert.Equal(t, logID, result.ID)
+	})
+
+	t.Run("scores a newly attached contest independently when enabled", func(t *testing.T) {
+		contestRuleSetID := uuid.New()
+		contestRuleID := uuid.New()
+		repo := &mockLogContestUpdateRepository{
+			log:           baseLog,
+			updatedLog:    baseLog,
+			registrations: ongoingRegistrations,
+			contestRuleSets: map[uuid.UUID]*domain.ScoringRuleSet{
+				contestID: {
+					ID:   contestRuleSetID,
+					Mode: domain.ScoringRuleSetModeReplace,
+					Rules: []domain.ScoringRule{{
+						ID:          contestRuleID,
+						Priority:    1,
+						ActivityID:  1,
+						ScoreSource: domain.ScoreSourceAmount,
+						Rate:        0.25,
+					}},
+				},
+			},
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := domain.NewLogContestUpdateWithScoringEngine(repo, clock, true)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogContestUpdateRequest{
+			LogID:           logID,
+			RegistrationIDs: []uuid.UUID{registrationID},
+		})
+
+		require.NoError(t, err)
+		require.Len(t, repo.updateCalledWith.Attach, 1)
+		tracking := repo.updateCalledWith.Attach[0].Tracking
+		assert.Equal(t, float32(25), tracking.ComputedScore)
+		require.NotNil(t, tracking.ScoreProvenance)
+		assert.Equal(t, &contestRuleSetID, tracking.ScoreProvenance.RuleSetID)
+		assert.Equal(t, []uuid.UUID{contestRuleID}, tracking.ScoreProvenance.RuleIDs)
 	})
 
 	t.Run("snapshots duration-only score data when attaching a registration", func(t *testing.T) {

--- a/services/immersion-api/domain/logcreate.go
+++ b/services/immersion-api/domain/logcreate.go
@@ -14,6 +14,7 @@ type LogCreateRepository interface {
 	FindUnitForTracking(context.Context, *UnitFindForTrackingRequest) (*Unit, error)
 	FindUnitForTrackingByKey(context.Context, *UnitFindForTrackingByKeyRequest) (*Unit, error)
 	FindActivePlatformScoringRuleSet(context.Context) (*ScoringRuleSet, error)
+	FindContestScoringRuleSets(context.Context, uuid.UUID) (*ScoringRuleSet, *ScoringRuleSet, error)
 	CreateLog(context.Context, *LogCreateRequest) (*uuid.UUID, error)
 	FindLogByID(context.Context, *LogFindRequest) (*Log, error)
 }
@@ -36,12 +37,16 @@ type LogCreateRequest struct {
 	eligibleOfficialLeaderboard bool
 	year                        int16
 	tracking                    LogTracking
+	contestTrackings            []ContestLogTracking
 }
 
 func (r *LogCreateRequest) UserID() uuid.UUID                 { return r.userID }
 func (r *LogCreateRequest) EligibleOfficialLeaderboard() bool { return r.eligibleOfficialLeaderboard }
 func (r *LogCreateRequest) Year() int16                       { return r.year }
 func (r *LogCreateRequest) Tracking() LogTracking             { return r.tracking }
+func (r *LogCreateRequest) ContestTrackings() []ContestLogTracking {
+	return r.contestTrackings
+}
 
 type LogCreate struct {
 	repo             LogCreateRepository
@@ -102,6 +107,7 @@ func (s *LogCreate) Execute(ctx context.Context, req *LogCreateRequest) (*Log, e
 		return nil, fmt.Errorf("unable to validate tags: %w", err)
 	}
 
+	validContestRegistrations := map[uuid.UUID]ContestRegistration{}
 	if len(req.RegistrationIDs) > 0 {
 		registrations, fetchErr := s.repo.FetchOngoingContestRegistrations(ctx, &RegistrationListOngoingRequest{
 			UserID: req.userID,
@@ -111,14 +117,13 @@ func (s *LogCreate) Execute(ctx context.Context, req *LogCreateRequest) (*Log, e
 			return nil, fmt.Errorf("unable to fetch registrations: %w", fetchErr)
 		}
 
-		validContestIDs := map[uuid.UUID]ContestRegistration{}
 		for _, r := range registrations.Registrations {
-			validContestIDs[r.ID] = r
+			validContestRegistrations[r.ID] = r
 		}
 
 		// validate registrations
 		for _, id := range req.RegistrationIDs {
-			registration, ok := validContestIDs[id]
+			registration, ok := validContestRegistrations[id]
 			if !ok {
 				return nil, fmt.Errorf("registration is not found as ongoing for the current user: %w", ErrInvalidLog)
 			}
@@ -180,6 +185,21 @@ func (s *LogCreate) Execute(ctx context.Context, req *LogCreateRequest) (*Log, e
 			return nil, fmt.Errorf("could not score log: %w", scoringErr)
 		}
 		ApplyScoringResult(&req.tracking, result)
+		for _, registrationID := range req.RegistrationIDs {
+			registration := validContestRegistrations[registrationID]
+			contestTracking, contestErr := resolveContestLogTracking(
+				ctx,
+				s.repo,
+				registration.ContestID,
+				registrationID,
+				req.tracking,
+				scoringInput,
+			)
+			if contestErr != nil {
+				return nil, fmt.Errorf("could not score contest %s: %w", registration.ContestID, contestErr)
+			}
+			req.contestTrackings = append(req.contestTrackings, contestTracking)
+		}
 	} else {
 		RecordPlatformScoringShadow(ctx, s.repo, scoringInput, req.tracking.ComputedScore)
 	}

--- a/services/immersion-api/domain/logcreate_test.go
+++ b/services/immersion-api/domain/logcreate_test.go
@@ -14,19 +14,29 @@ import (
 )
 
 type mockLogCreateRepository struct {
-	registrations    *domain.ContestRegistrations
-	fetchRegErr      error
-	unit             *domain.Unit
-	findUnitErr      error
-	scoringRuleSet   *domain.ScoringRuleSet
-	scoringRuleErr   error
-	scoringRuleCalls int
-	createdLogID     *uuid.UUID
-	createErr        error
-	log              *domain.Log
-	findErr          error
-	createCalled     bool
-	createCalledWith *domain.LogCreateRequest
+	registrations     *domain.ContestRegistrations
+	fetchRegErr       error
+	unit              *domain.Unit
+	findUnitErr       error
+	scoringRuleSet    *domain.ScoringRuleSet
+	scoringRuleErr    error
+	scoringRuleCalls  int
+	contestRuleSets   map[uuid.UUID]*domain.ScoringRuleSet
+	contestFallbacks  map[uuid.UUID]*domain.ScoringRuleSet
+	contestScoringErr error
+	createdLogID      *uuid.UUID
+	createErr         error
+	log               *domain.Log
+	findErr           error
+	createCalled      bool
+	createCalledWith  *domain.LogCreateRequest
+}
+
+func (m *mockLogCreateRepository) FindContestScoringRuleSets(_ context.Context, contestID uuid.UUID) (*domain.ScoringRuleSet, *domain.ScoringRuleSet, error) {
+	if m.contestScoringErr != nil {
+		return nil, nil, m.contestScoringErr
+	}
+	return m.contestRuleSets[contestID], m.contestFallbacks[contestID], nil
 }
 
 func (m *mockLogCreateRepository) FetchOngoingContestRegistrations(ctx context.Context, req *domain.RegistrationListOngoingRequest) (*domain.ContestRegistrations, error) {
@@ -589,6 +599,63 @@ func TestLogCreate_Execute(t *testing.T) {
 		require.NotNil(t, tracking.ScoreProvenance)
 		assert.Nil(t, tracking.ScoreProvenance.RuleSetID)
 		assert.Equal(t, domain.ScoreSourceAmount, tracking.ScoreProvenance.Source)
+	})
+
+	t.Run("snapshots an independent contest score when enabled", func(t *testing.T) {
+		platformRuleSetID := uuid.New()
+		contestRuleSetID := uuid.New()
+		contestRuleID := uuid.New()
+		repo := &mockLogCreateRepository{
+			registrations: validRegistrations,
+			scoringRuleSet: &domain.ScoringRuleSet{
+				ID: platformRuleSetID,
+				Rules: []domain.ScoringRule{{
+					ID:          uuid.New(),
+					Priority:    1,
+					ActivityID:  1,
+					UnitKey:     domain.UnitKeyReadingPage,
+					ScoreSource: domain.ScoreSourceAmount,
+					Rate:        2,
+				}},
+			},
+			contestRuleSets: map[uuid.UUID]*domain.ScoringRuleSet{
+				contestID: {
+					ID:   contestRuleSetID,
+					Mode: domain.ScoringRuleSetModeReplace,
+					Rules: []domain.ScoringRule{{
+						ID:          contestRuleID,
+						Priority:    1,
+						ActivityID:  1,
+						UnitKey:     domain.UnitKeyReadingPage,
+						ScoreSource: domain.ScoreSourceAmount,
+						Rate:        0.5,
+					}},
+				},
+			},
+			createdLogID: &logID,
+			log:          createdLog,
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := newLogCreateServiceWithScoringEngine(repo, clock)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			RegistrationIDs: []uuid.UUID{registrationID},
+			UnitID:          &unitID,
+			ActivityID:      1,
+			LanguageCode:    "jpn",
+			Amount:          &amount100,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, float32(200), repo.createCalledWith.Tracking().ComputedScore)
+		contestTrackings := repo.createCalledWith.ContestTrackings()
+		require.Len(t, contestTrackings, 1)
+		assert.Equal(t, registrationID, contestTrackings[0].RegistrationID)
+		assert.Equal(t, contestID, contestTrackings[0].ContestID)
+		assert.Equal(t, float32(50), contestTrackings[0].Tracking.ComputedScore)
+		require.NotNil(t, contestTrackings[0].Tracking.ScoreProvenance)
+		assert.Equal(t, &contestRuleSetID, contestTrackings[0].Tracking.ScoreProvenance.RuleSetID)
+		assert.Equal(t, []uuid.UUID{contestRuleID}, contestTrackings[0].Tracking.ScoreProvenance.RuleIDs)
 	})
 
 	t.Run("rejects the write when authoritative scoring fails", func(t *testing.T) {

--- a/services/immersion-api/domain/logupdate.go
+++ b/services/immersion-api/domain/logupdate.go
@@ -15,6 +15,7 @@ type LogUpdateRepository interface {
 	FindUnitForTracking(context.Context, *UnitFindForTrackingRequest) (*Unit, error)
 	FindUnitForTrackingByKey(context.Context, *UnitFindForTrackingByKeyRequest) (*Unit, error)
 	FindActivePlatformScoringRuleSet(context.Context) (*ScoringRuleSet, error)
+	FindContestScoringRuleSets(context.Context, uuid.UUID) (*ScoringRuleSet, *ScoringRuleSet, error)
 	UpdateLog(context.Context, *LogUpdateRequest) error
 }
 
@@ -28,14 +29,18 @@ type LogUpdateRequest struct {
 	Description     *string
 
 	// Set by domain layer (unexported: only domain can write, others read via getters)
-	now      time.Time
-	userID   uuid.UUID
-	tracking LogTracking
+	now              time.Time
+	userID           uuid.UUID
+	tracking         LogTracking
+	contestTrackings []ContestLogTracking
 }
 
 func (r *LogUpdateRequest) Now() time.Time        { return r.now }
 func (r *LogUpdateRequest) UserID() uuid.UUID     { return r.userID }
 func (r *LogUpdateRequest) Tracking() LogTracking { return r.tracking }
+func (r *LogUpdateRequest) ContestTrackings() []ContestLogTracking {
+	return r.contestTrackings
+}
 
 type LogUpdate struct {
 	repo             LogUpdateRepository
@@ -125,11 +130,29 @@ func (s *LogUpdate) Execute(ctx context.Context, req *LogUpdateRequest) (*Log, e
 			return nil, fmt.Errorf("could not score log: %w", scoringErr)
 		}
 		ApplyScoringResult(&req.tracking, result)
+		req.now = s.clock.Now()
+		for _, registration := range log.Registrations {
+			if registration.ContestEnd.Before(req.now) {
+				continue
+			}
+			contestTracking, contestErr := resolveContestLogTracking(
+				ctx,
+				s.repo,
+				registration.ContestID,
+				registration.RegistrationID,
+				req.tracking,
+				scoringInput,
+			)
+			if contestErr != nil {
+				return nil, fmt.Errorf("could not score contest %s: %w", registration.ContestID, contestErr)
+			}
+			req.contestTrackings = append(req.contestTrackings, contestTracking)
+		}
 	} else {
 		RecordPlatformScoringShadow(ctx, s.repo, scoringInput, req.tracking.ComputedScore)
+		req.now = s.clock.Now()
 	}
 
-	req.now = s.clock.Now()
 	req.userID = log.UserID
 
 	if err := s.repo.UpdateLog(ctx, req); err != nil {

--- a/services/immersion-api/domain/logupdate_test.go
+++ b/services/immersion-api/domain/logupdate_test.go
@@ -14,18 +14,28 @@ import (
 )
 
 type mockLogUpdateRepository struct {
-	log              *domain.Log
-	updatedLog       *domain.Log
-	unit             *domain.Unit
-	findUnitErr      error
-	scoringRuleSet   *domain.ScoringRuleSet
-	scoringRuleErr   error
-	scoringRuleCalls int
-	findErr          error
-	updateErr        error
-	updateCalled     bool
-	updateCalledWith *domain.LogUpdateRequest
-	findCallCount    int
+	log               *domain.Log
+	updatedLog        *domain.Log
+	unit              *domain.Unit
+	findUnitErr       error
+	scoringRuleSet    *domain.ScoringRuleSet
+	scoringRuleErr    error
+	scoringRuleCalls  int
+	contestRuleSets   map[uuid.UUID]*domain.ScoringRuleSet
+	contestFallbacks  map[uuid.UUID]*domain.ScoringRuleSet
+	contestScoringErr error
+	findErr           error
+	updateErr         error
+	updateCalled      bool
+	updateCalledWith  *domain.LogUpdateRequest
+	findCallCount     int
+}
+
+func (m *mockLogUpdateRepository) FindContestScoringRuleSets(_ context.Context, contestID uuid.UUID) (*domain.ScoringRuleSet, *domain.ScoringRuleSet, error) {
+	if m.contestScoringErr != nil {
+		return nil, nil, m.contestScoringErr
+	}
+	return m.contestRuleSets[contestID], m.contestFallbacks[contestID], nil
 }
 
 func (m *mockLogUpdateRepository) FindLogByID(_ context.Context, req *domain.LogFindRequest) (*domain.Log, error) {
@@ -399,6 +409,54 @@ func TestLogUpdate_Execute(t *testing.T) {
 		require.NotNil(t, tracking.ScoreProvenance)
 		assert.Equal(t, &ruleSetID, tracking.ScoreProvenance.RuleSetID)
 		assert.Equal(t, []uuid.UUID{ruleID}, tracking.ScoreProvenance.RuleIDs)
+	})
+
+	t.Run("recomputes ongoing contest scores independently when enabled", func(t *testing.T) {
+		contestID := uuid.New()
+		registrationID := uuid.New()
+		contestRuleSetID := uuid.New()
+		contestRuleID := uuid.New()
+		log := makeLog(userID)
+		log.LanguageCode = "jpn"
+		log.Registrations = []domain.ContestRegistrationReference{{
+			RegistrationID: registrationID,
+			ContestID:      contestID,
+			ContestEnd:     now.Add(time.Hour),
+		}}
+		repo := &mockLogUpdateRepository{
+			log:        log,
+			updatedLog: &domain.Log{ID: logID, UserID: userID, ActivityID: 1},
+			contestRuleSets: map[uuid.UUID]*domain.ScoringRuleSet{
+				contestID: {
+					ID:   contestRuleSetID,
+					Mode: domain.ScoringRuleSetModeReplace,
+					Rules: []domain.ScoringRule{{
+						ID:          contestRuleID,
+						Priority:    1,
+						ActivityID:  1,
+						UnitKey:     domain.UnitKeyReadingPage,
+						ScoreSource: domain.ScoreSourceAmount,
+						Rate:        3,
+					}},
+				},
+			},
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := domain.NewLogUpdateWithScoringEngine(repo, clock, true)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogUpdateRequest{
+			LogID:  logID,
+			UnitID: &unitID,
+			Amount: &amount10,
+		})
+
+		require.NoError(t, err)
+		contestTrackings := repo.updateCalledWith.ContestTrackings()
+		require.Len(t, contestTrackings, 1)
+		assert.Equal(t, contestID, contestTrackings[0].ContestID)
+		assert.Equal(t, float32(30), contestTrackings[0].Tracking.ComputedScore)
+		require.NotNil(t, contestTrackings[0].Tracking.ScoreProvenance)
+		assert.Equal(t, &contestRuleSetID, contestTrackings[0].Tracking.ScoreProvenance.RuleSetID)
 	})
 
 	t.Run("allows amount update with duration metadata", func(t *testing.T) {

--- a/services/immersion-api/main.go
+++ b/services/immersion-api/main.go
@@ -153,7 +153,7 @@ func main() {
 	languageCreate := immersiondomain.NewLanguageCreate(postgresRepository)
 	languageUpdate := immersiondomain.NewLanguageUpdate(postgresRepository)
 	tagSuggestions := immersiondomain.NewTagSuggestions(postgresRepository)
-	logContestUpdate := immersiondomain.NewLogContestUpdate(postgresRepository, clock)
+	logContestUpdate := immersiondomain.NewLogContestUpdateWithScoringEngine(postgresRepository, clock, cfg.ScoringEngineEnabled)
 
 	server := rest.NewServer(
 		contestConfigurationOptions,

--- a/services/immersion-api/storage/postgres/logs.sql.go
+++ b/services/immersion-api/storage/postgres/logs.sql.go
@@ -868,6 +868,59 @@ func (q *Queries) UpdateLogEligibleOfficialLeaderboard(ctx context.Context, logI
 	return err
 }
 
+const updateOngoingContestLog = `-- name: UpdateOngoingContestLog :exec
+update contest_logs
+set
+  unit_key = $1,
+  amount = $2,
+  modifier = $3,
+  duration_seconds = $4,
+  computed_score = $5,
+  score_rule_set_id = $6,
+  score_rule_ids = $7,
+  score_rates = $8,
+  score_source = $9
+from contests
+where
+  contest_logs.log_id = $10
+  and contest_logs.contest_id = $11
+  and contest_logs.contest_id = contests.id
+  and contests.contest_end >= $12
+`
+
+type UpdateOngoingContestLogParams struct {
+	UnitKey         sql.NullString
+	Amount          sql.NullFloat64
+	Modifier        sql.NullFloat64
+	DurationSeconds sql.NullInt32
+	ComputedScore   sql.NullFloat64
+	ScoreRuleSetID  uuid.NullUUID
+	ScoreRuleIds    []uuid.UUID
+	ScoreRates      []float32
+	ScoreSource     sql.NullString
+	LogID           uuid.UUID
+	ContestID       uuid.UUID
+	Now             time.Time
+}
+
+func (q *Queries) UpdateOngoingContestLog(ctx context.Context, arg UpdateOngoingContestLogParams) error {
+	_, err := q.db.ExecContext(ctx, updateOngoingContestLog,
+		arg.UnitKey,
+		arg.Amount,
+		arg.Modifier,
+		arg.DurationSeconds,
+		arg.ComputedScore,
+		arg.ScoreRuleSetID,
+		pq.Array(arg.ScoreRuleIds),
+		pq.Array(arg.ScoreRates),
+		arg.ScoreSource,
+		arg.LogID,
+		arg.ContestID,
+		arg.Now,
+	)
+	return err
+}
+
 const updateOngoingContestLogs = `-- name: UpdateOngoingContestLogs :exec
 update contest_logs
 set

--- a/services/immersion-api/storage/postgres/queries/logs.sql
+++ b/services/immersion-api/storage/postgres/queries/logs.sql
@@ -329,6 +329,25 @@ where
   and contest_logs.contest_id = contests.id
   and contests.contest_end >= sqlc.arg('now');
 
+-- name: UpdateOngoingContestLog :exec
+update contest_logs
+set
+  unit_key = sqlc.arg('unit_key'),
+  amount = sqlc.arg('amount'),
+  modifier = sqlc.arg('modifier'),
+  duration_seconds = sqlc.arg('duration_seconds'),
+  computed_score = sqlc.arg('computed_score'),
+  score_rule_set_id = sqlc.arg('score_rule_set_id'),
+  score_rule_ids = sqlc.arg('score_rule_ids'),
+  score_rates = sqlc.arg('score_rates'),
+  score_source = sqlc.arg('score_source')
+from contests
+where
+  contest_logs.log_id = sqlc.arg('log_id')
+  and contest_logs.contest_id = sqlc.arg('contest_id')
+  and contest_logs.contest_id = contests.id
+  and contests.contest_end >= sqlc.arg('now');
+
 -- name: FetchOngoingContestIDsForLog :many
 select contest_logs.contest_id
 from contest_logs

--- a/services/immersion-api/storage/postgres/queries/scoring.sql
+++ b/services/immersion-api/storage/postgres/queries/scoring.sql
@@ -10,6 +10,12 @@ select *
 from scoring_rule_sets
 where id = sqlc.arg('id');
 
+-- name: FindContestScoringRuleSetID :one
+select scoring_rule_set_id
+from contests
+where id = sqlc.arg('contest_id')
+  and deleted_at is null;
+
 -- name: ListScoringRulesForRuleSet :many
 select *
 from scoring_rules

--- a/services/immersion-api/storage/postgres/repository/repo_createlog.go
+++ b/services/immersion-api/storage/postgres/repository/repo_createlog.go
@@ -44,25 +44,37 @@ func (r *Repository) CreateLog(ctx context.Context, req *domain.LogCreateRequest
 	// Track unique contest IDs for outbox events
 	contestIDSet := map[uuid.UUID]struct{}{}
 
-	for _, registrationID := range req.RegistrationIDs {
+	contestTrackings := req.ContestTrackings()
+	if len(contestTrackings) == 0 {
+		contestTrackings = make([]domain.ContestLogTracking, len(req.RegistrationIDs))
+		for i, registrationID := range req.RegistrationIDs {
+			contestTrackings[i] = domain.ContestLogTracking{
+				RegistrationID: registrationID,
+				Tracking:       tracking,
+			}
+		}
+	}
+
+	for _, contestTracking := range contestTrackings {
+		contestTracking := contestTracking
 		if err = qtx.CreateContestLogRelation(ctx, postgres.CreateContestLogRelationParams{
-			RegistrationID:  registrationID,
+			RegistrationID:  contestTracking.RegistrationID,
 			LogID:           id,
-			UnitKey:         trackingUnitKey(tracking),
-			Amount:          trackingAmount(tracking),
-			Modifier:        trackingModifier(tracking),
-			DurationSeconds: trackingDurationSeconds(tracking),
-			ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
-			ScoreRuleSetID:  scoreRuleSetID(nil),
-			ScoreRuleIds:    scoreRuleIDs(nil),
-			ScoreRates:      scoreRates(nil),
-			ScoreSource:     scoreSource(nil),
+			UnitKey:         trackingUnitKey(contestTracking.Tracking),
+			Amount:          trackingAmount(contestTracking.Tracking),
+			Modifier:        trackingModifier(contestTracking.Tracking),
+			DurationSeconds: trackingDurationSeconds(contestTracking.Tracking),
+			ComputedScore:   postgres.NewNullFloat64FromFloat32(contestTracking.Tracking.ComputedScore),
+			ScoreRuleSetID:  scoreRuleSetID(contestTracking.Tracking.ScoreProvenance),
+			ScoreRuleIds:    scoreRuleIDs(contestTracking.Tracking.ScoreProvenance),
+			ScoreRates:      scoreRates(contestTracking.Tracking.ScoreProvenance),
+			ScoreSource:     scoreSource(contestTracking.Tracking.ScoreProvenance),
 		}); err != nil {
 			_ = tx.Rollback()
 			return nil, fmt.Errorf("could not create log: %w", err)
 		}
 
-		contestID, err := qtx.FetchContestIDForRegistration(ctx, registrationID)
+		contestID, err := qtx.FetchContestIDForRegistration(ctx, contestTracking.RegistrationID)
 		if err != nil {
 			_ = tx.Rollback()
 			return nil, fmt.Errorf("could not resolve contest for registration: %w", err)

--- a/services/immersion-api/storage/postgres/repository/repo_findscoringruleset.go
+++ b/services/immersion-api/storage/postgres/repository/repo_findscoringruleset.go
@@ -69,6 +69,38 @@ func (r *Repository) FindScoringRuleSetByID(ctx context.Context, id uuid.UUID) (
 	return result, nil
 }
 
+func (r *Repository) FindContestScoringRuleSets(
+	ctx context.Context,
+	contestID uuid.UUID,
+) (*domain.ScoringRuleSet, *domain.ScoringRuleSet, error) {
+	ruleSetID, err := r.q.FindContestScoringRuleSetID(ctx, contestID)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return nil, nil, domain.ErrNotFound
+		}
+
+		return nil, nil, fmt.Errorf("could not fetch contest scoring rule set: %w", err)
+	}
+	if !ruleSetID.Valid {
+		return nil, nil, nil
+	}
+
+	ruleSet, err := r.FindScoringRuleSetByID(ctx, ruleSetID.UUID)
+	if err != nil {
+		return nil, nil, err
+	}
+	if ruleSet.FallbackRuleSetID == nil {
+		return ruleSet, nil, nil
+	}
+
+	fallback, err := r.FindScoringRuleSetByID(ctx, *ruleSet.FallbackRuleSetID)
+	if err != nil {
+		return nil, nil, fmt.Errorf("could not fetch contest fallback scoring rule set: %w", err)
+	}
+
+	return ruleSet, fallback, nil
+}
+
 func loadScoringRuleSet(
 	ctx context.Context,
 	queries *postgres.Queries,

--- a/services/immersion-api/storage/postgres/repository/repo_updatelog.go
+++ b/services/immersion-api/storage/postgres/repository/repo_updatelog.go
@@ -44,22 +44,45 @@ func (r *Repository) UpdateLog(ctx context.Context, req *domain.LogUpdateRequest
 		return fmt.Errorf("could not update log: %w", err)
 	}
 
-	// Update contest_logs for ongoing contests only
-	if err := qtx.UpdateOngoingContestLogs(ctx, postgres.UpdateOngoingContestLogsParams{
-		LogID:           req.LogID,
-		UnitKey:         trackingUnitKey(tracking),
-		Amount:          trackingAmount(tracking),
-		Modifier:        trackingModifier(tracking),
-		DurationSeconds: trackingDurationSeconds(tracking),
-		ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
-		ScoreRuleSetID:  scoreRuleSetID(nil),
-		ScoreRuleIds:    scoreRuleIDs(nil),
-		ScoreRates:      scoreRates(nil),
-		ScoreSource:     scoreSource(nil),
-		Now:             req.Now(),
-	}); err != nil {
-		_ = tx.Rollback()
-		return fmt.Errorf("could not update contest logs: %w", err)
+	contestTrackings := req.ContestTrackings()
+	if len(contestTrackings) == 0 {
+		if err := qtx.UpdateOngoingContestLogs(ctx, postgres.UpdateOngoingContestLogsParams{
+			LogID:           req.LogID,
+			UnitKey:         trackingUnitKey(tracking),
+			Amount:          trackingAmount(tracking),
+			Modifier:        trackingModifier(tracking),
+			DurationSeconds: trackingDurationSeconds(tracking),
+			ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
+			ScoreRuleSetID:  scoreRuleSetID(nil),
+			ScoreRuleIds:    scoreRuleIDs(nil),
+			ScoreRates:      scoreRates(nil),
+			ScoreSource:     scoreSource(nil),
+			Now:             req.Now(),
+		}); err != nil {
+			_ = tx.Rollback()
+			return fmt.Errorf("could not update contest logs: %w", err)
+		}
+	} else {
+		for _, contestTracking := range contestTrackings {
+			contestTracking := contestTracking
+			if err := qtx.UpdateOngoingContestLog(ctx, postgres.UpdateOngoingContestLogParams{
+				LogID:           req.LogID,
+				ContestID:       contestTracking.ContestID,
+				UnitKey:         trackingUnitKey(contestTracking.Tracking),
+				Amount:          trackingAmount(contestTracking.Tracking),
+				Modifier:        trackingModifier(contestTracking.Tracking),
+				DurationSeconds: trackingDurationSeconds(contestTracking.Tracking),
+				ComputedScore:   postgres.NewNullFloat64FromFloat32(contestTracking.Tracking.ComputedScore),
+				ScoreRuleSetID:  scoreRuleSetID(contestTracking.Tracking.ScoreProvenance),
+				ScoreRuleIds:    scoreRuleIDs(contestTracking.Tracking.ScoreProvenance),
+				ScoreRates:      scoreRates(contestTracking.Tracking.ScoreProvenance),
+				ScoreSource:     scoreSource(contestTracking.Tracking.ScoreProvenance),
+				Now:             req.Now(),
+			}); err != nil {
+				_ = tx.Rollback()
+				return fmt.Errorf("could not update contest log %s: %w", contestTracking.ContestID, err)
+			}
+		}
 	}
 
 	// Sync tags: delete all, re-insert new ones

--- a/services/immersion-api/storage/postgres/repository/repo_updatelogcontests.go
+++ b/services/immersion-api/storage/postgres/repository/repo_updatelogcontests.go
@@ -33,9 +33,8 @@ func (r *Repository) UpdateLogContests(ctx context.Context, req *domain.LogConte
 		}
 	}
 
-	tracking := req.Tracking
-
 	for _, attach := range req.Attach {
+		tracking := attach.Tracking
 		if err := qtx.CreateContestLogRelation(ctx, postgres.CreateContestLogRelationParams{
 			RegistrationID:  attach.RegistrationID,
 			LogID:           req.LogID,
@@ -44,6 +43,10 @@ func (r *Repository) UpdateLogContests(ctx context.Context, req *domain.LogConte
 			Modifier:        trackingModifier(tracking),
 			DurationSeconds: trackingDurationSeconds(tracking),
 			ComputedScore:   postgres.NewNullFloat64FromFloat32(tracking.ComputedScore),
+			ScoreRuleSetID:  scoreRuleSetID(tracking.ScoreProvenance),
+			ScoreRuleIds:    scoreRuleIDs(tracking.ScoreProvenance),
+			ScoreRates:      scoreRates(tracking.ScoreProvenance),
+			ScoreSource:     scoreSource(tracking.ScoreProvenance),
 		}); err != nil {
 			_ = tx.Rollback()
 			return fmt.Errorf("could not attach contest %s: %w", attach.ContestID, err)

--- a/services/immersion-api/storage/postgres/scoring.sql.go
+++ b/services/immersion-api/storage/postgres/scoring.sql.go
@@ -36,6 +36,20 @@ func (q *Queries) FindActivePlatformScoringRuleSet(ctx context.Context) (Scoring
 	return i, err
 }
 
+const findContestScoringRuleSetID = `-- name: FindContestScoringRuleSetID :one
+select scoring_rule_set_id
+from contests
+where id = $1
+  and deleted_at is null
+`
+
+func (q *Queries) FindContestScoringRuleSetID(ctx context.Context, contestID uuid.UUID) (uuid.NullUUID, error) {
+	row := q.db.QueryRowContext(ctx, findContestScoringRuleSetID, contestID)
+	var scoring_rule_set_id uuid.NullUUID
+	err := row.Scan(&scoring_rule_set_id)
+	return scoring_rule_set_id, err
+}
+
 const findScoringRuleSetByID = `-- name: FindScoringRuleSetByID :one
 select id, scope, contest_id, version, status, mode, fallback_rule_set_id, created_at, published_at
 from scoring_rule_sets


### PR DESCRIPTION
Stacked on #744.

## What changed

Evaluate contest-specific rule sets independently from the platform score and persist separate contest score/provenance snapshots. Override mode can use a pinned platform fallback; replace mode awards zero when unmatched.

## Why

Contest scoring must remain stable and auditable without changing completed contest snapshots when a base log is edited.

## Validation

- full Bazel service build and all 16 backend test targets
- full pnpm frontend build, WebV2 typecheck, and lint