### PR TITLE
Use score previews in log forms

### DIFF
--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -408,12 +408,12 @@ endpoint. All form changes must use `react-hook-form` and components from the
   - [x] Return applied-rule information where appropriate.
   - [x] Return zero for uncovered inputs.
 
-- [ ] Move frontend estimates to score preview.
-  - [ ] Use `react-hook-form` values for preview requests.
-  - [ ] Remove dependence on `unit.modifier`.
-  - [ ] Preserve the legacy form's visible workflow.
-  - [ ] Display platform and contest-specific estimates clearly.
-  - [ ] Keep the feature behind the existing flag until verified.
+- [x] Move frontend estimates to score preview.
+  - [x] Use `react-hook-form` values for preview requests.
+  - [x] Remove dependence on `unit.modifier`.
+  - [x] Preserve the legacy form's visible workflow.
+  - [x] Display platform and contest-specific estimates clearly.
+  - [x] Keep the feature behind the existing flag until verified.
 
 - [ ] Add rule-set management APIs.
   - [ ] Create draft rule-set versions.

--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -7,20 +7,20 @@ import {
   Log,
   LogConfigurationOptions,
   useUpdateLog,
+  useScorePreview,
 } from '@app/immersion/api'
 import { useRouter } from 'next/router'
 import { routes } from '@app/common/routes'
 import {
-  estimateScore,
   filterUnits,
   NewLogFormV2Schema,
   NewLogV2APISchema,
 } from '@app/immersion/NewLogFormV2/domain'
-import { formatScore } from '@app/common/format'
-import { useDebouncedCallback } from 'use-debounce'
+import { useDebounce, useDebouncedCallback } from 'use-debounce'
 import { useSessionOrRedirect } from '@app/common/session'
 import { AmountWithUnit, Option } from 'ui/components/Form'
 import { toast } from 'react-toastify'
+import { ScorePreviewEstimate } from '@app/immersion/components/ScorePreviewEstimate'
 
 interface Props {
   options: LogConfigurationOptions
@@ -58,18 +58,30 @@ export const EditLogForm = ({ options, log }: Props) => {
 
   useSessionOrRedirect()
 
-  const unitId = methods.watch('amountUnit')
-  const amount = methods.watch('amountValue')
+  const formValues = methods.watch()
 
   const units = filterUnits(options.units, log.activity.id, log.language.code)
   const unitsAsOptions: Option[] = units.map(it => ({
     value: it.id,
     label: it.name,
   }))
-  const currentSelectedUnit = units.find(it => it.id === unitId)
-  const estimatedScore = usesAmountUnit
-    ? estimateScore(amount, currentSelectedUnit)
+  const parsedPreviewValues = NewLogV2APISchema.safeParse(formValues)
+  const [previewPayloadJSON] = useDebounce(
+    parsedPreviewValues.success
+      ? JSON.stringify({
+          ...parsedPreviewValues.data,
+          activity_id: log.activity.id,
+          language_code: log.language.code,
+        })
+      : undefined,
+    300,
+  )
+  const previewPayload = previewPayloadJSON
+    ? JSON.parse(previewPayloadJSON)
     : undefined
+  const scorePreview = useScorePreview(previewPayload, {
+    enabled: options.scoring_engine_enabled,
+  })
 
   const router = useRouter()
   const updateLogMutation = useUpdateLog(updatedLog => {
@@ -165,10 +177,10 @@ export const EditLogForm = ({ options, log }: Props) => {
               </div>
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-              Estimated score:{' '}
-              <strong>
-                {usesAmountUnit ? formatScore(estimatedScore) : '-'}
-              </strong>
+              <ScorePreviewEstimate
+                enabled={options.scoring_engine_enabled}
+                preview={scorePreview.data}
+              />
             </div>
           </div>
           <div className="h-stack spaced justify-end">

--- a/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
@@ -12,11 +12,11 @@ import {
   fetchTagSuggestions,
   LogConfigurationOptions,
   useCreateLog,
+  useScorePreview,
 } from '@app/immersion/api'
 import { useRouter } from 'next/router'
 import { routes } from '@app/common/routes'
 import {
-  estimateScore,
   filterActivities,
   filterUnits,
   formatContestLabel,
@@ -24,11 +24,11 @@ import {
   NewLogFormSchema,
   trackingModesForRegistrations,
 } from '@app/immersion/NewLogForm/domain'
-import { formatScore } from '@app/common/format'
-import { useDebouncedCallback } from 'use-debounce'
+import { useDebounce, useDebouncedCallback } from 'use-debounce'
 import { useSessionOrRedirect } from '@app/common/session'
 import { useEffect } from 'react'
 import { AmountWithUnit, Option, Select } from 'ui/components/Form'
+import { ScorePreviewEstimate } from '@app/immersion/components/ScorePreviewEstimate'
 
 interface Props {
   registrations: ContestRegistrationsView
@@ -66,8 +66,7 @@ export const LogForm = ({
   const trackingMode = methods.watch('tracking_mode') ?? 'personal'
   const activityId = methods.watch('activityId')
   const languageCode = methods.watch('languageCode')
-  const unitId = methods.watch('amountUnit')
-  const amount = methods.watch('amountValue')
+  const formValues = methods.watch()
 
   const languages =
     trackingMode === 'personal'
@@ -98,7 +97,6 @@ export const LogForm = ({
     value: it.id,
     label: it.name,
   }))
-  const currentSelectedUnit = units.find(it => it.id === unitId)
   const activities = filterActivities(
     options.activities,
     registrations,
@@ -108,7 +106,19 @@ export const LogForm = ({
     value: it.id.toString(),
     label: it.name,
   }))
-  const estimatedScore = estimateScore(amount, currentSelectedUnit)
+  const previewPayloadResult = NewLogAPISchema.safeParse(formValues)
+  const [previewPayloadJSON] = useDebounce(
+    previewPayloadResult.success
+      ? JSON.stringify(previewPayloadResult.data)
+      : undefined,
+    300,
+  )
+  const previewPayload = previewPayloadJSON
+    ? JSON.parse(previewPayloadJSON)
+    : undefined
+  const scorePreview = useScorePreview(previewPayload, {
+    enabled: options.scoring_engine_enabled,
+  })
 
   const router = useRouter()
   const createLogMutation = useCreateLog(id => {
@@ -220,7 +230,11 @@ export const LogForm = ({
               </div>
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-              Estimated score: <strong>{formatScore(estimatedScore)}</strong>
+              <ScorePreviewEstimate
+                enabled={options.scoring_engine_enabled}
+                preview={scorePreview.data}
+                registrations={registrations}
+              />
             </div>
           </div>
           <div className="h-stack spaced justify-end">

--- a/frontend/apps/webv2/app/immersion/NewLogForm/domain.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogForm/domain.tsx
@@ -165,17 +165,6 @@ export const trackingModesForRegistrations = (registrationCount: number) => {
   ] satisfies RadioProps['options']
 }
 
-export const estimateScore = (
-  amount: number | undefined,
-  unit: Unit | undefined,
-) => {
-  if (!amount || !unit) {
-    return undefined
-  }
-
-  return amount * unit.modifier
-}
-
 export function contestsForLog({
   registrations,
   manualContests,

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -7,20 +7,20 @@ import {
   LogConfigurationOptions,
   useCreateLogV2,
   useOngoingContestRegistrations,
+  useScorePreview,
 } from '@app/immersion/api'
 import { useRouter } from 'next/router'
 import { routes } from '@app/common/routes'
 import {
-  estimateScore,
   filterUnits,
   NewLogFormV2Schema,
   NewLogV2APISchema,
 } from '@app/immersion/NewLogFormV2/domain'
-import { formatScore } from '@app/common/format'
-import { useDebouncedCallback } from 'use-debounce'
+import { useDebounce, useDebouncedCallback } from 'use-debounce'
 import { useSessionOrRedirect } from '@app/common/session'
 import { useEffect } from 'react'
 import { AmountWithUnit, Option, OptionGroup, Select } from 'ui/components/Form'
+import { ScorePreviewEstimate } from '@app/immersion/components/ScorePreviewEstimate'
 
 interface Props {
   options: LogConfigurationOptions
@@ -82,8 +82,7 @@ export const LogFormV2 = ({
 
   const activityId = methods.watch('activityId')
   const languageCode = methods.watch('languageCode')
-  const unitId = methods.watch('amountUnit')
-  const amount = methods.watch('amountValue')
+  const formValues = methods.watch()
 
   const languagesAsOptions: Option[] = options.languages.map(it => ({
     value: it.code,
@@ -110,14 +109,23 @@ export const LogFormV2 = ({
     value: it.id,
     label: it.name,
   }))
-  const currentSelectedUnit = units.find(it => it.id === unitId)
   const activitiesAsOptions: Option[] = options.activities.map(it => ({
     value: it.id.toString(),
     label: it.name,
   }))
-  const estimatedScore = usesAmountUnit
-    ? estimateScore(amount, currentSelectedUnit)
+  const previewPayloadResult = NewLogV2APISchema.safeParse(formValues)
+  const [previewPayloadJSON] = useDebounce(
+    previewPayloadResult.success
+      ? JSON.stringify(previewPayloadResult.data)
+      : undefined,
+    300,
+  )
+  const previewPayload = previewPayloadJSON
+    ? JSON.parse(previewPayloadJSON)
     : undefined
+  const scorePreview = useScorePreview(previewPayload, {
+    enabled: options.scoring_engine_enabled,
+  })
 
   // Eagerly prefetch ongoing registrations (non-blocking)
   const registrations = useOngoingContestRegistrations()
@@ -266,10 +274,10 @@ export const LogFormV2 = ({
               </div>
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
-              Estimated score:{' '}
-              <strong>
-                {usesAmountUnit ? formatScore(estimatedScore) : '-'}
-              </strong>
+              <ScorePreviewEstimate
+                enabled={options.scoring_engine_enabled}
+                preview={scorePreview.data}
+              />
             </div>
           </div>
           <div className="h-stack spaced justify-end">

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/domain.tsx
@@ -1,8 +1,8 @@
 import { z } from 'zod'
 import { Activity, Unit } from '@app/immersion/api'
-import { filterUnits, estimateScore } from '@app/immersion/NewLogForm/domain'
+import { filterUnits } from '@app/immersion/NewLogForm/domain'
 
-export { filterUnits, estimateScore }
+export { filterUnits }
 
 const optionalPositiveNumber = z.preprocess(
   value =>

--- a/frontend/apps/webv2/app/immersion/api.ts
+++ b/frontend/apps/webv2/app/immersion/api.ts
@@ -699,6 +699,7 @@ const LogConfigurationOptions = z.object({
   activities: z.array(Activity),
   units: z.array(Unit),
   user_language_codes: z.array(z.string()).default([]),
+  scoring_engine_enabled: z.boolean(),
 })
 
 export type LogConfigurationOptions = z.infer<typeof LogConfigurationOptions>
@@ -716,6 +717,68 @@ export const useLogConfigurationOptions = (options?: { enabled?: boolean }) =>
       return LogConfigurationOptions.parse(await response.json())
     },
     options,
+  )
+
+export type ScorePreviewPayload = {
+  registration_ids?: string[]
+  language_code: string
+  activity_id: number
+  amount?: number
+  unit_id?: string
+  unit_key?: string
+  duration_seconds?: number
+  tags: string[]
+}
+
+const AppliedScoringRule = z.object({
+  rule_id: z.string(),
+  rate: z.number(),
+})
+
+const ScoreEstimate = z.object({
+  score: z.number(),
+  source: z.enum(['amount', 'duration_minutes']),
+  rule_set_id: z.string().optional(),
+  rules: z.array(AppliedScoringRule),
+})
+
+const ScorePreview = z.object({
+  platform: ScoreEstimate,
+  contests: z.array(
+    z.object({
+      registration_id: z.string(),
+      contest_id: z.string(),
+      estimate: ScoreEstimate,
+    }),
+  ),
+})
+
+export type ScorePreview = z.infer<typeof ScorePreview>
+
+export const useScorePreview = (
+  payload: ScorePreviewPayload | undefined,
+  options?: { enabled?: boolean },
+) =>
+  useQuery(
+    ['log', 'score-preview', payload],
+    async (): Promise<ScorePreview> => {
+      const response = await fetch(`${root}/logs/score-preview`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+      if (response.status !== 200) {
+        throw new Error(response.status.toString())
+      }
+      return ScorePreview.parse(await response.json())
+    },
+    {
+      ...options,
+      enabled: payload !== undefined && options?.enabled !== false,
+      keepPreviousData: true,
+    },
   )
 
 const TagSuggestion = z.object({

--- a/frontend/apps/webv2/app/immersion/components/ScorePreviewEstimate.tsx
+++ b/frontend/apps/webv2/app/immersion/components/ScorePreviewEstimate.tsx
@@ -1,0 +1,42 @@
+import { formatScore } from '@app/common/format'
+import {
+  ContestRegistrationView,
+  ScorePreview,
+} from '@app/immersion/api'
+
+interface Props {
+  enabled: boolean
+  preview?: ScorePreview
+  registrations?: ContestRegistrationView[]
+}
+
+export const ScorePreviewEstimate = ({
+  enabled,
+  preview,
+  registrations = [],
+}: Props) => {
+  const registrationsById = new Map(
+    registrations.map(registration => [registration.id, registration]),
+  )
+
+  return (
+    <>
+      <div>
+        Estimated score:{' '}
+        <strong>
+          {enabled && preview
+            ? formatScore(preview.platform.score)
+            : '-'}
+        </strong>
+      </div>
+      {enabled &&
+        preview?.contests.map(contest => (
+          <div key={contest.registration_id} className="text-sm">
+            {registrationsById.get(contest.registration_id)?.contest?.title ??
+              'Contest'}
+            : <strong>{formatScore(contest.estimate.score)}</strong>
+          </div>
+        ))}
+    </>
+  )
+}

--- a/services/immersion-api/domain/logconfigurationoptions.go
+++ b/services/immersion-api/domain/logconfigurationoptions.go
@@ -12,18 +12,30 @@ type LogConfigurationOptionsRepository interface {
 }
 
 type LogConfigurationOptionsResponse struct {
-	Languages         []Language
-	Activities        []Activity
-	Units             []Unit
-	UserLanguageCodes []string
+	Languages            []Language
+	Activities           []Activity
+	Units                []Unit
+	UserLanguageCodes    []string
+	ScoringEngineEnabled bool
 }
 
 type LogConfigurationOptions struct {
-	repo LogConfigurationOptionsRepository
+	repo                 LogConfigurationOptionsRepository
+	scoringEngineEnabled bool
 }
 
 func NewLogConfigurationOptions(repo LogConfigurationOptionsRepository) *LogConfigurationOptions {
-	return &LogConfigurationOptions{repo: repo}
+	return NewLogConfigurationOptionsWithScoringEngine(repo, false)
+}
+
+func NewLogConfigurationOptionsWithScoringEngine(
+	repo LogConfigurationOptionsRepository,
+	enabled bool,
+) *LogConfigurationOptions {
+	return &LogConfigurationOptions{
+		repo:                 repo,
+		scoringEngineEnabled: enabled,
+	}
 }
 
 func (s *LogConfigurationOptions) Execute(ctx context.Context) (*LogConfigurationOptionsResponse, error) {
@@ -41,5 +53,6 @@ func (s *LogConfigurationOptions) Execute(ctx context.Context) (*LogConfiguratio
 		return nil, err
 	}
 	res.Activities = Activities()
+	res.ScoringEngineEnabled = s.scoringEngineEnabled
 	return res, nil
 }

--- a/services/immersion-api/domain/logconfigurationoptions_test.go
+++ b/services/immersion-api/domain/logconfigurationoptions_test.go
@@ -41,7 +41,7 @@ func TestLogConfigurationOptions_Execute(t *testing.T) {
 			},
 		}
 
-		svc := domain.NewLogConfigurationOptions(repo)
+		svc := domain.NewLogConfigurationOptionsWithScoringEngine(repo, true)
 		ctx := ctxWithUser()
 		resp, err := svc.Execute(ctx)
 
@@ -55,6 +55,7 @@ func TestLogConfigurationOptions_Execute(t *testing.T) {
 		assert.Equal(t, domain.ActivityInputTypeTimePrimary, resp.Activities[1].InputType)
 		assert.Equal(t, "Pages", resp.Units[0].Name)
 		assert.Equal(t, []string{"ja"}, resp.UserLanguageCodes)
+		assert.True(t, resp.ScoringEngineEnabled)
 	})
 
 	t.Run("returns unauthorized for guest user", func(t *testing.T) {

--- a/services/immersion-api/http/rest/openapi/api.gen.go
+++ b/services/immersion-api/http/rest/openapi/api.gen.go
@@ -249,10 +249,11 @@ type Log struct {
 
 // LogConfigurationOptions defines model for LogConfigurationOptions.
 type LogConfigurationOptions struct {
-	Activities        []Activity `json:"activities"`
-	Languages         []Language `json:"languages"`
-	Units             []Unit     `json:"units"`
-	UserLanguageCodes *[]string  `json:"user_language_codes,omitempty"`
+	Activities           []Activity `json:"activities"`
+	Languages            []Language `json:"languages"`
+	ScoringEngineEnabled bool       `json:"scoring_engine_enabled"`
+	Units                []Unit     `json:"units"`
+	UserLanguageCodes    *[]string  `json:"user_language_codes,omitempty"`
 }
 
 // Logs defines model for Logs.

--- a/services/immersion-api/http/rest/openapi/api.yaml
+++ b/services/immersion-api/http/rest/openapi/api.yaml
@@ -1098,11 +1098,15 @@ components:
         - $ref: "#/components/schemas/Activities"
         - $ref: "#/components/schemas/Units"
         - type: object
+          required:
+            - scoring_engine_enabled
           properties:
             user_language_codes:
               type: array
               items:
                 type: string
+            scoring_engine_enabled:
+              type: boolean
     Unit:
       type: object
       required:

--- a/services/immersion-api/http/rest/server_loggetconfigurations.go
+++ b/services/immersion-api/http/rest/server_loggetconfigurations.go
@@ -24,10 +24,11 @@ func (s *Server) LogGetConfigurations(ctx echo.Context) error {
 	}
 
 	res := openapi.LogConfigurationOptions{
-		Activities:        make([]openapi.Activity, len(opts.Activities)),
-		Languages:         make([]openapi.Language, len(opts.Languages)),
-		Units:             make([]openapi.Unit, len(opts.Units)),
-		UserLanguageCodes: &userLangCodes,
+		Activities:           make([]openapi.Activity, len(opts.Activities)),
+		Languages:            make([]openapi.Language, len(opts.Languages)),
+		Units:                make([]openapi.Unit, len(opts.Units)),
+		UserLanguageCodes:    &userLangCodes,
+		ScoringEngineEnabled: opts.ScoringEngineEnabled,
 	}
 
 	for i, it := range opts.Activities {

--- a/services/immersion-api/main.go
+++ b/services/immersion-api/main.go
@@ -121,7 +121,7 @@ func main() {
 
 	// Service-per-function services
 	contestConfigurationOptions := immersiondomain.NewContestConfigurationOptions(postgresRepository)
-	logConfigurationOptions := immersiondomain.NewLogConfigurationOptions(postgresRepository)
+	logConfigurationOptions := immersiondomain.NewLogConfigurationOptionsWithScoringEngine(postgresRepository, cfg.ScoringEngineEnabled)
 	contestFindLatestOfficial := immersiondomain.NewContestFindLatestOfficial(postgresRepository)
 	contestSummaryFetch := immersiondomain.NewContestSummaryFetch(postgresRepository)
 	profileYearlyActivitySplit := immersiondomain.NewProfileYearlyActivitySplit(postgresRepository)


### PR DESCRIPTION
Stacked on #746.

## What changed

Use debounced server score previews in the new, edit, and V2 log forms when the scoring-engine feature flag is enabled. Forms continue using react-hook-form and the shared UI components.

## Why

Displayed estimates should match the authoritative server rule evaluation rather than legacy client-side modifiers.

## Validation

- full Bazel service build and all 16 backend test targets
- full pnpm frontend build
- WebV2 typecheck and lint