### PR TITLE
Add contest scoring rule editor

### DIFF
--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -423,13 +423,13 @@ endpoint. All form changes must use `react-hook-form` and components from the
   - [x] Configure contest mode and pinned fallback.
   - [x] Prevent implicit mutation of published rule sets.
 
-- [ ] Add contest scoring configuration UI.
-  - [ ] Use components from the `ui` package.
-  - [ ] Use `react-hook-form` for form state and validation.
-  - [ ] Support ordered rules and match conditions.
-  - [ ] Show uncovered inputs as scoring zero.
-  - [ ] Show whether the contest overrides or replaces platform rules.
-  - [ ] Prevent unsafe rule changes after the contest starts.
+- [x] Add contest scoring configuration UI.
+  - [x] Use components from the `ui` package.
+  - [x] Use `react-hook-form` for form state and validation.
+  - [x] Support ordered rules and match conditions.
+  - [x] Show uncovered inputs as scoring zero.
+  - [x] Show whether the contest overrides or replaces platform rules.
+  - [x] Prevent unsafe rule changes after the contest starts.
 
 - [ ] Complete production verification.
   - [ ] Shadow mismatches are understood or zero.

--- a/frontend/apps/webv2/app/common/routes.ts
+++ b/frontend/apps/webv2/app/common/routes.ts
@@ -25,6 +25,7 @@ export const routes = {
   contestUpdates: (id: string, page?: Page) =>
     `/contests/${id}/updates/${page ?? '1'}`,
   contestJoin: (id: string) => `/contests/${id}/registration`,
+  contestScoring: (id: string) => `/contests/${id}/scoring`,
   contestUserProfile: (contest_id: string, user_id: string, page?: Page) =>
     `/contests/${contest_id}/profile/${user_id}/${page ?? '1'}`,
 

--- a/frontend/apps/webv2/app/immersion/ContestScoringRules.tsx
+++ b/frontend/apps/webv2/app/immersion/ContestScoringRules.tsx
@@ -1,0 +1,386 @@
+import { zodResolver } from '@hookform/resolvers/zod'
+import {
+  LogConfigurationOptions,
+  ScoringRuleSet,
+  ScoringRuleSetDraftPayload,
+  useActivateScoringRuleSet,
+  useCreateContestScoringRuleSet,
+  usePublishScoringRuleSet,
+} from '@app/immersion/api'
+import { FormProvider, useFieldArray, useForm } from 'react-hook-form'
+import { z } from 'zod'
+import { Checkbox, Flash, Input, Select } from 'ui'
+import { Option } from 'ui/components/Form'
+import { toast } from 'react-toastify'
+
+const RuleFormSchema = z.object({
+  stackable: z.boolean(),
+  activity_id: z.number(),
+  unit_key: z.string(),
+  language_code: z.string(),
+  tag: z.string().max(50),
+  score_source: z.enum(['amount', 'duration_minutes']),
+  rate: z.number().min(0),
+})
+
+const ContestScoringFormSchema = z
+  .object({
+    mode: z.enum(['override', 'replace']),
+    fallback_rule_set_id: z.string(),
+    rules: z.array(RuleFormSchema),
+  })
+  .superRefine((value, ctx) => {
+    if (value.mode === 'override' && !value.fallback_rule_set_id) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['fallback_rule_set_id'],
+        message: 'Choose the pinned platform version',
+      })
+    }
+  })
+
+type ContestScoringForm = z.infer<typeof ContestScoringFormSchema>
+
+interface Props {
+  contestId: string
+  options: LogConfigurationOptions
+  platformRuleSets: ScoringRuleSet[]
+  contestRuleSets: ScoringRuleSet[]
+  locked: boolean
+}
+
+const emptyRule = (): ContestScoringForm['rules'][number] => ({
+  stackable: false,
+  activity_id: 1,
+  unit_key: '',
+  language_code: '',
+  tag: '',
+  score_source: 'amount',
+  rate: 1,
+})
+
+export const ContestScoringRules = ({
+  contestId,
+  options,
+  platformRuleSets,
+  contestRuleSets,
+  locked,
+}: Props) => {
+  const publishedPlatformRuleSets = platformRuleSets.filter(
+    ruleSet => ruleSet.status === 'published',
+  )
+  const activePlatformRuleSet =
+    publishedPlatformRuleSets.find(ruleSet => ruleSet.active) ??
+    publishedPlatformRuleSets[0]
+  const methods = useForm<ContestScoringForm>({
+    resolver: zodResolver(ContestScoringFormSchema),
+    defaultValues: {
+      mode: 'override',
+      fallback_rule_set_id: activePlatformRuleSet?.id ?? '',
+      rules: [emptyRule()],
+    },
+  })
+  const rules = useFieldArray({ control: methods.control, name: 'rules' })
+  const mode = methods.watch('mode')
+  const ruleValues = methods.watch('rules')
+  const createRuleSet = useCreateContestScoringRuleSet(contestId)
+  const publishRuleSet = usePublishScoringRuleSet(contestId)
+  const activateRuleSet = useActivateScoringRuleSet(contestId)
+
+  const activityOptions: Option[] = options.activities.map(activity => ({
+    value: activity.id.toString(),
+    label: activity.name,
+  }))
+  const unitOptionsForActivity = (activityId: number): Option[] => [
+    { value: '', label: 'Any unit' },
+    ...options.units
+      .filter(unit => unit.log_activity_id === activityId)
+      .filter(
+        (unit, index, units) =>
+          units.findIndex(candidate => candidate.unit_key === unit.unit_key) ===
+          index,
+      )
+      .map(unit => ({
+        value: unit.unit_key,
+        label: `${unit.name} (${unit.unit_key})`,
+      })),
+  ]
+  const languageOptions: Option[] = [
+    { value: '', label: 'Any language' },
+    ...options.languages.map(language => ({
+      value: language.code,
+      label: language.name,
+    })),
+  ]
+  const fallbackOptions: Option[] = publishedPlatformRuleSets.map(ruleSet => ({
+    value: ruleSet.id,
+    label: `Platform v${ruleSet.version}${ruleSet.active ? ' (active)' : ''}`,
+  }))
+
+  const onSubmit = async (form: ContestScoringForm) => {
+    const payload: ScoringRuleSetDraftPayload = {
+      mode: form.mode,
+      ...(form.mode === 'override'
+        ? { fallback_rule_set_id: form.fallback_rule_set_id }
+        : {}),
+      rules: form.rules.map((rule, index) => ({
+        priority: index * 10,
+        stackable: rule.stackable,
+        activity_id: rule.activity_id,
+        ...(rule.unit_key ? { unit_key: rule.unit_key } : {}),
+        ...(rule.language_code
+          ? { language_code: rule.language_code }
+          : {}),
+        ...(rule.tag.trim() ? { tag: rule.tag.trim() } : {}),
+        score_source: rule.score_source,
+        rate: rule.rate,
+      })),
+    }
+    try {
+      await createRuleSet.mutateAsync(payload)
+      toast.success('Scoring rule-set draft created')
+    } catch {
+      toast.error('Could not create scoring rule-set draft')
+    }
+  }
+
+  return (
+    <div className="v-stack spaced">
+      <Flash visible={locked} style="warning">
+        Scoring is locked because this contest has started. Published snapshots
+        and active rules remain visible below.
+      </Flash>
+
+      {!locked ? (
+        <FormProvider {...methods}>
+          <form
+            className="card v-stack spaced"
+            onSubmit={methods.handleSubmit(onSubmit)}
+          >
+            <div>
+              <h2 className="subtitle">New rule-set version</h2>
+              <p className="text-slate-600">
+                Uncovered inputs score zero. Override mode falls back to the
+                pinned platform version; replace mode does not.
+              </p>
+            </div>
+            <Select
+              name="mode"
+              label="Contest behavior"
+              values={[
+                { value: 'override', label: 'Override platform rules' },
+                { value: 'replace', label: 'Replace platform rules' },
+              ]}
+            />
+            {mode === 'override' ? (
+              <Select
+                name="fallback_rule_set_id"
+                label="Pinned platform version"
+                values={fallbackOptions}
+              />
+            ) : null}
+
+            <div className="v-stack spaced">
+              <div className="h-stack justify-between items-center">
+                <h3 className="font-semibold">Ordered rules</h3>
+                <button
+                  type="button"
+                  className="btn secondary"
+                  onClick={() => rules.append(emptyRule())}
+                >
+                  Add rule
+                </button>
+              </div>
+              {rules.fields.length === 0 ? (
+                <p className="text-slate-600">
+                  This replacing rule set will score every input as zero.
+                </p>
+              ) : null}
+              {rules.fields.map((field, index) => (
+                <div key={field.id} className="card bg-slate-500/5">
+                  <div className="h-stack justify-between items-center mb-3">
+                    <strong>Rule {index + 1}</strong>
+                    <div className="h-stack spaced">
+                      <button
+                        type="button"
+                        className="btn ghost"
+                        disabled={index === 0}
+                        onClick={() => rules.move(index, index - 1)}
+                      >
+                        Up
+                      </button>
+                      <button
+                        type="button"
+                        className="btn ghost"
+                        disabled={index === rules.fields.length - 1}
+                        onClick={() => rules.move(index, index + 1)}
+                      >
+                        Down
+                      </button>
+                      <button
+                        type="button"
+                        className="btn danger"
+                        onClick={() => rules.remove(index)}
+                      >
+                        Remove
+                      </button>
+                    </div>
+                  </div>
+                  <div className="grid md:grid-cols-2 gap-3">
+                    <Select
+                      name={`rules.${index}.activity_id`}
+                      label="Activity"
+                      values={activityOptions}
+                      options={{ valueAsNumber: true }}
+                    />
+                    <Select
+                      name={`rules.${index}.score_source`}
+                      label="Score source"
+                      values={[
+                        { value: 'amount', label: 'Amount' },
+                        {
+                          value: 'duration_minutes',
+                          label: 'Duration (minutes)',
+                        },
+                      ]}
+                    />
+                    <Select
+                      name={`rules.${index}.unit_key`}
+                      label="Unit matcher"
+                      values={unitOptionsForActivity(
+                        ruleValues[index]?.activity_id ?? 1,
+                      )}
+                    />
+                    <Select
+                      name={`rules.${index}.language_code`}
+                      label="Language matcher"
+                      values={languageOptions}
+                    />
+                    <Input
+                      name={`rules.${index}.tag`}
+                      label="Tag matcher"
+                      placeholder="Any tag"
+                    />
+                    <Input
+                      name={`rules.${index}.rate`}
+                      label="Rate"
+                      type="number"
+                      min={0}
+                      step="any"
+                      options={{ valueAsNumber: true }}
+                    />
+                  </div>
+                  <Checkbox
+                    name={`rules.${index}.stackable`}
+                    label="Stackable modifier"
+                    hint="Modifiers multiply the selected base rule and never score alone."
+                  />
+                </div>
+              ))}
+            </div>
+            <div className="h-stack justify-end">
+              <button
+                type="submit"
+                className="btn primary"
+                disabled={createRuleSet.isLoading}
+              >
+                Create draft
+              </button>
+            </div>
+          </form>
+        </FormProvider>
+      ) : null}
+
+      <section className="v-stack spaced">
+        <h2 className="subtitle">Rule-set versions</h2>
+        {contestRuleSets.length === 0 ? (
+          <p>No contest-specific rule sets yet.</p>
+        ) : null}
+        {contestRuleSets.map(ruleSet => (
+          <div key={ruleSet.id} className="card">
+            <div className="h-stack justify-between items-start">
+              <div>
+                <h3 className="font-semibold">
+                  Version {ruleSet.version}
+                  {ruleSet.active ? ' · Active' : ''}
+                </h3>
+                <p>
+                  {ruleSet.mode === 'override'
+                    ? 'Overrides platform rules with a pinned fallback'
+                    : 'Replaces platform rules; uncovered inputs score zero'}
+                  {' · '}
+                  {ruleSet.status}
+                </p>
+              </div>
+              {!locked ? (
+                <div className="h-stack spaced">
+                  {ruleSet.status === 'draft' ? (
+                    <button
+                      type="button"
+                      className="btn secondary"
+                      disabled={publishRuleSet.isLoading}
+                      onClick={async () => {
+                        if (
+                          !window.confirm(
+                            'Publish this version? Published rules are immutable.',
+                          )
+                        ) {
+                          return
+                        }
+                        try {
+                          await publishRuleSet.mutateAsync(ruleSet.id)
+                          toast.success('Rule-set version published')
+                        } catch {
+                          toast.error('Could not publish rule-set version')
+                        }
+                      }}
+                    >
+                      Publish
+                    </button>
+                  ) : null}
+                  {ruleSet.status === 'published' && !ruleSet.active ? (
+                    <button
+                      type="button"
+                      className="btn primary"
+                      disabled={activateRuleSet.isLoading}
+                      onClick={async () => {
+                        if (
+                          !window.confirm(
+                            'Activate this version for new contest submissions?',
+                          )
+                        ) {
+                          return
+                        }
+                        try {
+                          await activateRuleSet.mutateAsync(ruleSet.id)
+                          toast.success('Rule-set version activated')
+                        } catch {
+                          toast.error('Could not activate rule-set version')
+                        }
+                      }}
+                    >
+                      Activate
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+            </div>
+            <ol className="mt-3 list-decimal pl-5">
+              {ruleSet.rules.map(rule => (
+                <li key={rule.id ?? rule.priority}>
+                  {rule.stackable ? 'Modifier' : 'Base'} · activity{' '}
+                  {rule.activity_id} · {rule.score_source} × {rule.rate}
+                  {rule.unit_key ? ` · unit ${rule.unit_key}` : ''}
+                  {rule.language_code
+                    ? ` · language ${rule.language_code}`
+                    : ''}
+                  {rule.tag ? ` · tag ${rule.tag}` : ''}
+                </li>
+              ))}
+            </ol>
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/frontend/apps/webv2/app/immersion/api.ts
+++ b/frontend/apps/webv2/app/immersion/api.ts
@@ -781,6 +781,152 @@ export const useScorePreview = (
     },
   )
 
+const ScoringRule = z.object({
+  id: z.string().optional(),
+  priority: z.number(),
+  stackable: z.boolean(),
+  activity_id: z.number(),
+  unit_key: z.string().optional(),
+  language_code: z.string().optional(),
+  tag: z.string().optional(),
+  score_source: z.enum(['amount', 'duration_minutes']),
+  rate: z.number(),
+})
+
+export type ScoringRule = z.infer<typeof ScoringRule>
+
+const ScoringRuleSet = z.object({
+  id: z.string(),
+  scope: z.enum(['platform', 'contest']),
+  contest_id: z.string().optional(),
+  version: z.number(),
+  status: z.enum(['draft', 'published']),
+  active: z.boolean(),
+  mode: z.enum(['override', 'replace']).optional(),
+  fallback_rule_set_id: z.string().optional(),
+  rules: z.array(ScoringRule),
+  created_at: z.string(),
+  published_at: z.string().optional(),
+})
+
+export type ScoringRuleSet = z.infer<typeof ScoringRuleSet>
+
+const ScoringRuleSets = z.object({
+  rule_sets: z.array(ScoringRuleSet),
+})
+
+export type ScoringRuleSetDraftPayload = {
+  mode: 'override' | 'replace'
+  fallback_rule_set_id?: string
+  rules: Omit<ScoringRule, 'id'>[]
+}
+
+export const usePlatformScoringRuleSets = (options?: { enabled?: boolean }) =>
+  useQuery(
+    ['scoring', 'rule-sets', 'platform'],
+    async (): Promise<ScoringRuleSet[]> => {
+      const response = await fetch(`${root}/scoring/rule-sets`)
+      if (response.status !== 200) {
+        throw new Error(response.status.toString())
+      }
+      return ScoringRuleSets.parse(await response.json()).rule_sets
+    },
+    options,
+  )
+
+export const useContestScoringRuleSets = (
+  contestId: string,
+  options?: { enabled?: boolean },
+) =>
+  useQuery(
+    ['scoring', 'rule-sets', 'contest', contestId],
+    async (): Promise<ScoringRuleSet[]> => {
+      const response = await fetch(
+        `${root}/contests/${contestId}/scoring/rule-sets`,
+      )
+      if (response.status !== 200) {
+        throw new Error(response.status.toString())
+      }
+      return ScoringRuleSets.parse(await response.json()).rule_sets
+    },
+    { ...options, enabled: !!contestId && options?.enabled !== false },
+  )
+
+export const useCreateContestScoringRuleSet = (contestId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (payload: ScoringRuleSetDraftPayload) => {
+      const response = await fetch(
+        `${root}/contests/${contestId}/scoring/rule-sets`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(payload),
+        },
+      )
+      if (response.status !== 200) {
+        throw new Error(response.status.toString())
+      }
+      return ScoringRuleSet.parse(await response.json())
+    },
+    onSuccess() {
+      queryClient.invalidateQueries([
+        'scoring',
+        'rule-sets',
+        'contest',
+        contestId,
+      ])
+    },
+  })
+}
+
+export const usePublishScoringRuleSet = (contestId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (ruleSetId: string) => {
+      const response = await fetch(
+        `${root}/scoring/rule-sets/${ruleSetId}/publish`,
+        { method: 'POST' },
+      )
+      if (response.status !== 200) {
+        throw new Error(response.status.toString())
+      }
+      return ScoringRuleSet.parse(await response.json())
+    },
+    onSuccess() {
+      queryClient.invalidateQueries([
+        'scoring',
+        'rule-sets',
+        'contest',
+        contestId,
+      ])
+    },
+  })
+}
+
+export const useActivateScoringRuleSet = (contestId: string) => {
+  const queryClient = useQueryClient()
+  return useMutation({
+    mutationFn: async (ruleSetId: string) => {
+      const response = await fetch(
+        `${root}/scoring/rule-sets/${ruleSetId}/activate`,
+        { method: 'POST' },
+      )
+      if (response.status !== 204) {
+        throw new Error(response.status.toString())
+      }
+    },
+    onSuccess() {
+      queryClient.invalidateQueries([
+        'scoring',
+        'rule-sets',
+        'contest',
+        contestId,
+      ])
+    },
+  })
+}
+
 const TagSuggestion = z.object({
   tag: z.string(),
   count: z.number(),

--- a/frontend/apps/webv2/pages/contests/[id]/leaderboard/[[...page]].tsx
+++ b/frontend/apps/webv2/pages/contests/[id]/leaderboard/[[...page]].tsx
@@ -1,11 +1,15 @@
 import { useCurrentDateTime } from '@app/common/hooks'
-import { useSession } from '@app/common/session'
+import { useSession, useUserRole } from '@app/common/session'
 import { useContest, useContestRegistration } from '@app/immersion/api'
 import { useRouter } from 'next/router'
 import { Breadcrumb, ButtonGroup, Loading, Tabbar } from 'ui'
 import { DateTime, Interval } from 'luxon'
 import { HomeIcon } from '@heroicons/react/20/solid'
-import { PencilSquareIcon, PlusIcon } from '@heroicons/react/24/solid'
+import {
+  AdjustmentsHorizontalIcon,
+  PencilSquareIcon,
+  PlusIcon,
+} from '@heroicons/react/24/solid'
 import { routes } from '@app/common/routes'
 import { ContestLeaderboard } from '@app/immersion/ContestLeaderboard'
 import Head from 'next/head'
@@ -18,6 +22,7 @@ const Page = () => {
 
   const contest = useContest(id)
   const [session] = useSession()
+  const role = useUserRole()
 
   const registration = useContestRegistration(id, { enabled: !!session })
 
@@ -94,6 +99,13 @@ const Page = () => {
                 IconComponent: PencilSquareIcon,
                 style: 'primary',
                 visible: isOngoing && registration.data !== undefined,
+              },
+              {
+                href: routes.contestScoring(id),
+                label: 'Scoring rules',
+                IconComponent: AdjustmentsHorizontalIcon,
+                style: 'secondary',
+                visible: role === 'admin',
               },
             ]}
             orientation="right"

--- a/frontend/apps/webv2/pages/contests/[id]/scoring.tsx
+++ b/frontend/apps/webv2/pages/contests/[id]/scoring.tsx
@@ -1,0 +1,105 @@
+import { routes } from '@app/common/routes'
+import {
+  useSessionOrRedirect,
+  useSession,
+  useUserRole,
+} from '@app/common/session'
+import {
+  useContest,
+  useContestScoringRuleSets,
+  useLogConfigurationOptions,
+  usePlatformScoringRuleSets,
+} from '@app/immersion/api'
+import { ContestScoringRules } from '@app/immersion/ContestScoringRules'
+import { HomeIcon } from '@heroicons/react/20/solid'
+import { DateTime } from 'luxon'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import { Breadcrumb, Loading } from 'ui'
+
+const Page = () => {
+  const router = useRouter()
+  const id = router.query['id']?.toString() ?? ''
+  const [session] = useSession()
+  const role = useUserRole()
+  useSessionOrRedirect()
+
+  const isAdmin = role === 'admin'
+  const contest = useContest(id, { enabled: !!id && isAdmin })
+  const options = useLogConfigurationOptions({ enabled: !!id && isAdmin })
+  const contestRuleSets = useContestScoringRuleSets(id, { enabled: isAdmin })
+  const platformRuleSets = usePlatformScoringRuleSets({ enabled: isAdmin })
+
+  if (!session || role === undefined) {
+    return <Loading />
+  }
+  if (!isAdmin) {
+    return (
+      <span className="flash error">This feature is not yet available.</span>
+    )
+  }
+  if (
+    contest.isLoading ||
+    contest.isIdle ||
+    options.isLoading ||
+    options.isIdle
+  ) {
+    return <Loading />
+  }
+  if (
+    contest.isError ||
+    options.isError ||
+    contestRuleSets.isError ||
+    platformRuleSets.isError ||
+    !contest.data ||
+    !options.data
+  ) {
+    return (
+      <span className="flash error">
+        Could not load scoring rules, please try again later.
+      </span>
+    )
+  }
+  if (
+    contestRuleSets.isLoading ||
+    contestRuleSets.isIdle ||
+    platformRuleSets.isLoading ||
+    platformRuleSets.isIdle
+  ) {
+    return <Loading />
+  }
+
+  const locked =
+    DateTime.now() >= DateTime.fromISO(contest.data.contest_start).startOf('day')
+
+  return (
+    <>
+      <Head>
+        <title>Contest scoring - Tadoku</title>
+      </Head>
+      <div className="pb-4">
+        <Breadcrumb
+          links={[
+            { label: 'Home', href: routes.home(), IconComponent: HomeIcon },
+            {
+              label: contest.data.title,
+              href: routes.contestLeaderboard(id),
+            },
+            { label: 'Scoring', href: routes.contestScoring(id) },
+          ]}
+        />
+      </div>
+      <h1 className="title">Contest scoring</h1>
+      <p className="subtitle mb-4">{contest.data.title}</p>
+      <ContestScoringRules
+        contestId={id}
+        options={options.data}
+        platformRuleSets={platformRuleSets.data}
+        contestRuleSets={contestRuleSets.data}
+        locked={locked}
+      />
+    </>
+  )
+}
+
+export default Page

--- a/frontend/apps/webv2/pages/contests/[id]/updates/[[...page]].tsx
+++ b/frontend/apps/webv2/pages/contests/[id]/updates/[[...page]].tsx
@@ -1,7 +1,11 @@
 import { useRouter } from 'next/router'
 import { Breadcrumb, ButtonGroup, Loading, Pagination, Tabbar } from 'ui'
 import { HomeIcon } from '@heroicons/react/20/solid'
-import { PencilSquareIcon, PlusIcon } from '@heroicons/react/24/solid'
+import {
+  AdjustmentsHorizontalIcon,
+  PencilSquareIcon,
+  PlusIcon,
+} from '@heroicons/react/24/solid'
 import { routes } from '@app/common/routes'
 import {
   useContest,
@@ -14,7 +18,7 @@ import { useEffect, useState } from 'react'
 import LogsList from '@app/immersion/LogsList'
 import { useCurrentDateTime } from '@app/common/hooks'
 import { DateTime, Interval } from 'luxon'
-import { useSession } from '@app/common/session'
+import { useSession, useUserRole } from '@app/common/session'
 
 const Page = () => {
   const router = useRouter()
@@ -45,6 +49,7 @@ const Page = () => {
   const logs = useContestLogs(filters)
 
   const [session] = useSession()
+  const role = useUserRole()
   const registration = useContestRegistration(id, { enabled: !!session })
 
   if (contest.isLoading || contest.isIdle) {
@@ -124,6 +129,13 @@ const Page = () => {
                 IconComponent: PencilSquareIcon,
                 style: 'primary',
                 visible: isOngoing && registration.data !== undefined,
+              },
+              {
+                href: routes.contestScoring(id),
+                label: 'Scoring rules',
+                IconComponent: AdjustmentsHorizontalIcon,
+                style: 'secondary',
+                visible: role === 'admin',
               },
             ]}
             orientation="right"


### PR DESCRIPTION
Stacked on #748.

## What changed

Add an owner-only contest scoring page for editing ordered rules, choosing override or replace behavior, selecting fallback behavior, and publishing or activating versions. The editor locks after the contest starts.

## Why

Contest owners need a guided interface for the validated rule-management API.

## Validation

- full pnpm frontend build
- WebV2 typecheck and lint
- full Bazel service build and all 16 backend test targets