### PR TITLE
Document final scoring semantics

### DIFF
--- a/docs/docs/adr/005-scoring-rules.md
+++ b/docs/docs/adr/005-scoring-rules.md
@@ -49,6 +49,24 @@ The scoring engine will resolve a rule set, select the first matching
 non-stackable base rule in priority order, and then multiply the rates of every
 matching stackable modifier.
 
+Every populated matcher must match. Rules may match the code-owned activity,
+stable unit key, language code, and one normalized tag. Each rule explicitly
+selects either the submitted `amount` or `duration_minutes` as its score
+source. When a log contains both amount and duration, amount is authoritative
+for scoring and duration remains tracking metadata.
+
+If no base rule matches, the score is zero and the submission remains valid.
+Modifiers never score without a matching base rule.
+
+Rule sets are versioned. Drafts may be assembled and validated, but publication
+makes a version immutable. Activating a new platform or contest version affects
+only future score resolutions; it never recalculates stored scores.
+
+An overriding contest rule set evaluates its rules first and falls back to a
+specific published platform version pinned when the contest version is
+created. A replacing contest rule set has no fallback, so uncovered inputs
+score zero for that contest.
+
 Scores should be snapshotted with the log submission that uses them. If contest scoring can differ from platform scoring, the contest score should be stored with the contest log entry rather than only on the base log.
 
 ## Consequences
@@ -58,5 +76,9 @@ Using code-owned activities and units keeps the core vocabulary stable and preve
 Using database-backed scoring rules lets us tune platform defaults without redeploying application code, and lets platform defaults and contest-specific rules share one implementation path.
 
 Snapshotting scores prevents historical leaderboards from changing silently when rules are edited. Recalculation, if needed, should be an explicit operation.
+
+Versioning and publication add an explicit management workflow, but make
+provenance durable: a score can retain the exact rule-set version, ordered rule
+IDs, applied rates, and score source that produced it.
 
 Default tags are not part of scoring metadata by default. Tags remain free text. If a tag affects scoring, it does so because a scoring rule matches it.

--- a/docs/wip/scoring-rules/README.md
+++ b/docs/wip/scoring-rules/README.md
@@ -327,13 +327,13 @@ endpoint. All form changes must use `react-hook-form` and components from the
 
 ## Trunk-based rollout plan
 
-- [ ] Document the rule evaluation semantics in ADR 005.
-  - [ ] Rules use explicit priority ordering.
-  - [ ] Matchers use activity, stable unit key, language, and one normalized tag.
-  - [ ] Rules declare `score_source: amount | duration_minutes`.
-  - [ ] Amount-plus-duration logs use `amount`.
-  - [ ] Unmatched rules produce zero.
-  - [ ] Published rule sets are immutable and versioned.
+- [x] Document the rule evaluation semantics in ADR 005.
+  - [x] Rules use explicit priority ordering.
+  - [x] Matchers use activity, stable unit key, language, and one normalized tag.
+  - [x] Rules declare `score_source: amount | duration_minutes`.
+  - [x] Amount-plus-duration logs use `amount`.
+  - [x] Unmatched rules produce zero.
+  - [x] Published rule sets are immutable and versioned.
 
 - [x] Introduce stable, code-owned unit keys.
   - [x] Add keys such as `reading_page`, `reading_character`, and
@@ -453,33 +453,33 @@ A rollout item is complete only when its implementation subitems are checked,
 its relevant tests pass, generated files are current, and the change remains
 independently deployable.
 
-- [ ] Format changed backend Go files.
+- [x] Format changed backend Go files.
 
   ```sh
   gofmt -w services/
   ```
 
-- [ ] Regenerate sqlc after changing Postgres queries.
+- [x] Regenerate sqlc after changing Postgres queries.
 
   ```sh
   cd services/immersion-api/storage/postgres
   go generate
   ```
 
-- [ ] Regenerate OpenAPI code after changing the API specification.
+- [x] Regenerate OpenAPI code after changing the API specification.
 
   ```sh
   cd services/immersion-api/http/rest/openapi
   go generate
   ```
 
-- [ ] Regenerate Bazel metadata after adding files or changing Go dependencies.
+- [x] Regenerate Bazel metadata after adding files or changing Go dependencies.
 
   ```sh
   bazel run //:gazelle
   ```
 
-- [ ] Run focused domain, repository, and REST tests for the rollout slice.
+- [x] Run focused domain, repository, and REST tests for the rollout slice.
 
   ```sh
   bazel test //services/immersion-api/domain:domain_test
@@ -487,14 +487,14 @@ independently deployable.
   bazel test //services/immersion-api/http/rest:rest_test
   ```
 
-- [ ] Build and test all backend services before merging a completed slice.
+- [x] Build and test all backend services before merging a completed slice.
 
   ```sh
   bazel build //services/...
   bazel test //services/...
   ```
 
-- [ ] Typecheck and lint WebV2 after frontend or generated API changes.
+- [x] Typecheck and lint WebV2 after frontend or generated API changes.
 
   ```sh
   cd frontend
@@ -502,14 +502,14 @@ independently deployable.
   pnpm --filter webv2 lint
   ```
 
-- [ ] Build the frontend before merging a user-visible rollout slice.
+- [x] Build the frontend before merging a user-visible rollout slice.
 
   ```sh
   cd frontend
   pnpm build
   ```
 
-- [ ] Confirm generated files and build metadata have no unexplained diff.
+- [x] Confirm generated files and build metadata have no unexplained diff.
 
   ```sh
   git diff --check


### PR DESCRIPTION
## What changed

Document the final scoring semantics in ADR 005 and update the rollout checklist to reflect the completed implementation and validation work.

## Why

The matching, score-source, versioning, fallback, and provenance behavior should be durable documentation before the scoring engine is enabled.

## Validation

- full Bazel service build
- all 16 backend test targets
- diff and stale-reference checks