### PR TITLE
Add score provenance schema migration

### DIFF
--- a/services/immersion-api/storage/postgres/migrations/0022_score_provenance.down.sql
+++ b/services/immersion-api/storage/postgres/migrations/0022_score_provenance.down.sql
@@ -1,0 +1,19 @@
+begin;
+
+alter table contest_logs
+  drop constraint contest_logs_score_provenance_valid,
+  drop constraint contest_logs_score_source_valid,
+  drop column score_source,
+  drop column score_rates,
+  drop column score_rule_ids,
+  drop column score_rule_set_id;
+
+alter table logs
+  drop constraint logs_score_provenance_valid,
+  drop constraint logs_score_source_valid,
+  drop column score_source,
+  drop column score_rates,
+  drop column score_rule_ids,
+  drop column score_rule_set_id;
+
+commit;

--- a/services/immersion-api/storage/postgres/migrations/0022_score_provenance.up.sql
+++ b/services/immersion-api/storage/postgres/migrations/0022_score_provenance.up.sql
@@ -1,0 +1,61 @@
+begin;
+
+alter table logs
+  add column score_rule_set_id uuid references scoring_rule_sets(id),
+  add column score_rule_ids uuid[],
+  add column score_rates real[],
+  add column score_source text;
+
+alter table logs
+  add constraint logs_score_source_valid
+  check (
+    score_source is null
+    or score_source in ('amount', 'duration_minutes')
+  ),
+  add constraint logs_score_provenance_valid
+  check (
+    (
+      score_rule_set_id is null
+      and score_rule_ids is null
+      and score_rates is null
+    )
+    or (
+      score_rule_set_id is not null
+      and score_rule_ids is not null
+      and score_rates is not null
+      and cardinality(score_rule_ids) > 0
+      and cardinality(score_rule_ids) = cardinality(score_rates)
+      and score_source is not null
+    )
+  );
+
+alter table contest_logs
+  add column score_rule_set_id uuid references scoring_rule_sets(id),
+  add column score_rule_ids uuid[],
+  add column score_rates real[],
+  add column score_source text;
+
+alter table contest_logs
+  add constraint contest_logs_score_source_valid
+  check (
+    score_source is null
+    or score_source in ('amount', 'duration_minutes')
+  ),
+  add constraint contest_logs_score_provenance_valid
+  check (
+    (
+      score_rule_set_id is null
+      and score_rule_ids is null
+      and score_rates is null
+    )
+    or (
+      score_rule_set_id is not null
+      and score_rule_ids is not null
+      and score_rates is not null
+      and cardinality(score_rule_ids) > 0
+      and cardinality(score_rule_ids) = cardinality(score_rates)
+      and score_source is not null
+    )
+  );
+
+commit;


### PR DESCRIPTION
Stacked after #742.

## Summary

Adds only migration `0022_score_provenance`, which adds immutable score provenance columns and constraints to platform and contest log snapshots.

This is intentionally isolated from generated storage code and runtime behavior so it can merge to `main` and deploy independently before #743.

## Deployment order

1. Merge and deploy the preceding stack slices.
2. Merge this migration PR after GitHub retargets it to `main`.
3. Deploy and verify the migration independently.
4. Continue with the dependent provenance code in #743.

## Validation

- `git diff --check`
- `bazel build //services/immersion-api/storage/postgres/migrations:tar`