### PR TITLE
Fix contest log submission SQL

### DIFF
--- a/services/immersion-api/storage/postgres/logs.sql.go
+++ b/services/immersion-api/storage/postgres/logs.sql.go
@@ -60,7 +60,7 @@ insert into contest_logs (
   $7,
   $8,
   $9,
-  $10
+  $10,
   $11
 )
 `

--- a/services/immersion-api/storage/postgres/logs.sql.go
+++ b/services/immersion-api/storage/postgres/logs.sql.go
@@ -545,7 +545,7 @@ with eligible_logs as (
     languages.name as language_name,
     logs.log_activity_id as activity_id,
     logs.unit_id,
-    coalesce(logs.unit_key, '') as unit_key,
+    coalesce(contest_logs.unit_key, '') as unit_key,
     coalesce(log_units.name, '') as unit_name,
     logs.description,
     contest_logs.amount,

--- a/services/immersion-api/storage/postgres/models.go
+++ b/services/immersion-api/storage/postgres/models.go
@@ -39,6 +39,7 @@ type ContestLog struct {
 	Score           sql.NullFloat64
 	DurationSeconds sql.NullInt32
 	ComputedScore   sql.NullFloat64
+	UnitKey         sql.NullString
 	ScoreRuleSetID  uuid.NullUUID
 	ScoreRuleIds    []uuid.UUID
 	ScoreRates      []float32


### PR DESCRIPTION
## Summary

- regenerate the immersion Postgres bindings from the checked-in sqlc source
- fix the malformed generated `CreateContestLogRelation` SQL
- synchronize the generated contest `unit_key` query and model fields

## Root cause

The checked-in sqlc output was stale and malformed: the source query correctly separated `score_rates` and `score_source`, but the generated query omitted the comma between `$10` and `$11`. PostgreSQL rejected contest-attached logging v1 submissions with `SQLSTATE 42601`, and the surrounding transaction rolled back. Logs without contest registrations were unaffected.

## Impact

Restores logging v1 submissions when the log is attached to a contest, including the reported iOS and desktop flows. The generated Go bindings now match the current SQL queries and schema.

## Validation

- regenerated with `go generate` (`sqlc v1.16.0`)
- `bazel test //services/immersion-api/...`
- `git diff --check`
