### PR TITLE
Require complete sqlc regeneration

### DIFF
--- a/.github/workflows/verify-sqlc.yaml
+++ b/.github/workflows/verify-sqlc.yaml
@@ -1,0 +1,36 @@
+name: verify-sqlc
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  verify:
+    name: Verify generated sqlc code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Regenerate sqlc code
+        run: |
+          (cd services/immersion-api/storage/postgres && go generate)
+          (cd services/content-api/storage/postgres && go generate)
+
+      - name: Verify generated code is current
+        run: |
+          if [[ -n "$(git status --porcelain)" ]]; then
+            echo "::error::sqlc generated code is out of date. Run go generate for every affected Postgres package and commit the complete output."
+            git status --short
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/verify-sqlc.yaml
+++ b/.github/workflows/verify-sqlc.yaml
@@ -16,29 +16,12 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Regenerate sqlc code
-        run: |
-          generate_sqlc() {
-            package_dir="$1"
-            sqlc_version="$(sed -nE 's|^//go:generate go install github.com/kyleconroy/sqlc/cmd/sqlc@v([^[:space:]]+)$|\1|p' "${package_dir}/generate.go")"
-            if [[ -z "${sqlc_version}" ]]; then
-              echo "::error::Could not determine the pinned sqlc version for ${package_dir}."
-              return 1
-            fi
-
-            docker run --rm \
-              --user "$(id -u):$(id -g)" \
-              --volume "${PWD}:/src" \
-              --workdir "/src/${package_dir}" \
-              "sqlc/sqlc:${sqlc_version}" generate
-          }
-
-          generate_sqlc services/immersion-api/storage/postgres
-          generate_sqlc services/content-api/storage/postgres
+        run: ./scripts/generate-sqlc.sh
 
       - name: Verify generated code is current
         run: |
           if [[ -n "$(git status --porcelain)" ]]; then
-            echo "::error::sqlc generated code is out of date. Run go generate for every affected Postgres package and commit the complete output."
+            echo "::error::sqlc generated code is out of date. Run ./scripts/generate-sqlc.sh and commit the complete output."
             git status --short
             git diff
             exit 1

--- a/.github/workflows/verify-sqlc.yaml
+++ b/.github/workflows/verify-sqlc.yaml
@@ -15,16 +15,25 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
 
-      - name: Set up Go
-        uses: actions/setup-go@v7
-        with:
-          go-version-file: go.mod
-          cache: true
-
       - name: Regenerate sqlc code
         run: |
-          (cd services/immersion-api/storage/postgres && go generate)
-          (cd services/content-api/storage/postgres && go generate)
+          generate_sqlc() {
+            package_dir="$1"
+            sqlc_version="$(sed -nE 's|^//go:generate go install github.com/kyleconroy/sqlc/cmd/sqlc@v([^[:space:]]+)$|\1|p' "${package_dir}/generate.go")"
+            if [[ -z "${sqlc_version}" ]]; then
+              echo "::error::Could not determine the pinned sqlc version for ${package_dir}."
+              return 1
+            fi
+
+            docker run --rm \
+              --user "$(id -u):$(id -g)" \
+              --volume "${PWD}:/src" \
+              --workdir "/src/${package_dir}" \
+              "sqlc/sqlc:${sqlc_version}" generate
+          }
+
+          generate_sqlc services/immersion-api/storage/postgres
+          generate_sqlc services/content-api/storage/postgres
 
       - name: Verify generated code is current
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Run the generator for every affected service from the repository root:
 
 Each `go generate` command installs the sqlc version pinned in that service's `generate.go` and then runs `sqlc generate`.
 
-CI runs both generators on every pull request and fails if they change the working tree. Before pushing, commit the complete generated output so this check stays clean.
+CI runs sqlc for both packages on every pull request using the versions pinned in their `generate.go` files, and fails if code generation changes the working tree. Before pushing, commit the complete generated output so this check stays clean.
 
 **Accept narrow interfaces** — define interfaces where they are used, with only the methods that consumer needs. Don't create wide/shared interfaces that bundle many methods together. Concrete implementations can be large, but each consumer should accept the smallest dependency possible. This follows Go's interface segregation principle and makes testing easier.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,22 @@ Migration PRs must remain compatible with the application version currently depl
 
 **SQL style: always use lowercase keywords** (select, create table, not SELECT, CREATE TABLE)
 
+### sqlc code generation
+
+**Always run sqlc code generation after changing a SQL query.** The checked-in generated Go files must exactly match the query sources.
+
+**Never manually edit sqlc-generated files, and never delete, revert, or selectively omit changes produced by sqlc code generation.** Commit the complete generated diff, even when code generation reveals previously stale output. If generated changes are unexpected, investigate the query inputs and pinned sqlc version, then rerun code generation; do not discard the generated changes.
+
+Run the generator for every affected service from the repository root:
+
+```sh
+(cd services/immersion-api/storage/postgres && go generate)
+(cd services/content-api/storage/postgres && go generate)
+(cd services/profile-api/storage/postgres && go generate)
+```
+
+Each `go generate` command installs the sqlc version pinned in that service's `generate.go` and then runs `sqlc generate`.
+
 **Accept narrow interfaces** — define interfaces where they are used, with only the methods that consumer needs. Don't create wide/shared interfaces that bundle many methods together. Concrete implementations can be large, but each consumer should accept the smallest dependency possible. This follows Go's interface segregation principle and makes testing easier.
 
 **Use "Repository" for persistent source-of-truth data, "Store" for everything else** — `Repository` interfaces access the primary database (Postgres) where authoritative data lives. `Store` interfaces access auxiliary storage (e.g. Valkey/Redis) for caches, derived data, pub/sub, coordination state, or any non-authoritative data. Implementations live under `storage/postgres/` and `storage/valkey/` respectively.
@@ -74,9 +90,8 @@ gofmt -w services/
 # CI fails if these are stale (it runs `bazel run //:gazelle -- -mode=diff`)
 bazel run //:gazelle
 
-# 6. Regenerate sqlc code (after modifying SQL queries)
-cd services/immersion-api/storage/postgres && go generate
-cd services/content-api/storage/postgres && go generate
+# 6. Regenerate sqlc code after modifying SQL queries
+# Run the commands in the "sqlc code generation" section above for every affected service.
 
 # 7. Regenerate OpenAPI code (after modifying OpenAPI specs)
 cd services/immersion-api/http/rest/openapi && go generate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,10 +57,11 @@ Run the generator for every affected service from the repository root:
 ```sh
 (cd services/immersion-api/storage/postgres && go generate)
 (cd services/content-api/storage/postgres && go generate)
-(cd services/profile-api/storage/postgres && go generate)
 ```
 
 Each `go generate` command installs the sqlc version pinned in that service's `generate.go` and then runs `sqlc generate`.
+
+CI runs both generators on every pull request and fails if they change the working tree. Before pushing, commit the complete generated output so this check stays clean.
 
 **Accept narrow interfaces** — define interfaces where they are used, with only the methods that consumer needs. Don't create wide/shared interfaces that bundle many methods together. Concrete implementations can be large, but each consumer should accept the smallest dependency possible. This follows Go's interface segregation principle and makes testing easier.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,16 +52,13 @@ Migration PRs must remain compatible with the application version currently depl
 
 **Never manually edit sqlc-generated files, and never delete, revert, or selectively omit changes produced by sqlc code generation.** Commit the complete generated diff, even when code generation reveals previously stale output. If generated changes are unexpected, investigate the query inputs and pinned sqlc version, then rerun code generation; do not discard the generated changes.
 
-Run the generator for every affected service from the repository root:
+Run the repository generator from the repository root. It downloads and runs the sqlc versions pinned in each active package's `generate.go`, so it does not require `go` to be installed or available on `PATH`:
 
 ```sh
-(cd services/immersion-api/storage/postgres && go generate)
-(cd services/content-api/storage/postgres && go generate)
+./scripts/generate-sqlc.sh
 ```
 
-Each `go generate` command installs the sqlc version pinned in that service's `generate.go` and then runs `sqlc generate`.
-
-CI runs sqlc for both packages on every pull request using the versions pinned in their `generate.go` files, and fails if code generation changes the working tree. Before pushing, commit the complete generated output so this check stays clean.
+CI runs the same script on every pull request and fails if code generation changes the working tree. Before pushing, commit the complete generated output so this check stays clean.
 
 **Accept narrow interfaces** — define interfaces where they are used, with only the methods that consumer needs. Don't create wide/shared interfaces that bundle many methods together. Concrete implementations can be large, but each consumer should accept the smallest dependency possible. This follows Go's interface segregation principle and makes testing easier.
 
@@ -92,7 +89,7 @@ gofmt -w services/
 bazel run //:gazelle
 
 # 6. Regenerate sqlc code after modifying SQL queries
-# Run the commands in the "sqlc code generation" section above for every affected service.
+./scripts/generate-sqlc.sh
 
 # 7. Regenerate OpenAPI code (after modifying OpenAPI specs)
 cd services/immersion-api/http/rest/openapi && go generate

--- a/scripts/generate-sqlc.sh
+++ b/scripts/generate-sqlc.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SQLC_PACKAGES=(
+  "services/immersion-api/storage/postgres"
+  "services/content-api/storage/postgres"
+)
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+require_cmd curl
+require_cmd tar
+
+case "$(uname -s)" in
+  Linux) SQLC_OS="linux" ;;
+  Darwin) SQLC_OS="darwin" ;;
+  *)
+    echo "unsupported operating system for sqlc code generation: $(uname -s)" >&2
+    exit 1
+    ;;
+esac
+
+case "$(uname -m)" in
+  x86_64 | amd64) SQLC_ARCH="amd64" ;;
+  arm64 | aarch64) SQLC_ARCH="arm64" ;;
+  *)
+    echo "unsupported architecture for sqlc code generation: $(uname -m)" >&2
+    exit 1
+    ;;
+esac
+
+SQLC_CODEGEN_TMP="$(mktemp -d)"
+trap 'rm -rf -- "$SQLC_CODEGEN_TMP"' EXIT
+
+sqlc_binary() {
+  local version="$1"
+  local binary="$SQLC_CODEGEN_TMP/bin/sqlc-${version}"
+  if [ ! -x "$binary" ]; then
+    local archive="$SQLC_CODEGEN_TMP/sqlc-${version}.tar.gz"
+    local extract_dir="$SQLC_CODEGEN_TMP/extract-${version}"
+    mkdir -p "$(dirname "$binary")" "$extract_dir"
+    curl --fail --silent --show-error --location \
+      "https://github.com/sqlc-dev/sqlc/releases/download/v${version}/sqlc_${version}_${SQLC_OS}_${SQLC_ARCH}.tar.gz" \
+      --output "$archive"
+    tar -xzf "$archive" -C "$extract_dir"
+    mv "$extract_dir/sqlc" "$binary"
+  fi
+  printf '%s\n' "$binary"
+}
+
+for package_dir in "${SQLC_PACKAGES[@]}"; do
+  sqlc_version="$(sed -nE 's|^//go:generate go install github.com/kyleconroy/sqlc/cmd/sqlc@v([^[:space:]]+)$|\1|p' "$ROOT/${package_dir}/generate.go")"
+  if [ -z "$sqlc_version" ]; then
+    echo "could not determine the pinned sqlc version for ${package_dir}" >&2
+    exit 1
+  fi
+
+  sqlc_bin="$(sqlc_binary "$sqlc_version")"
+  echo "generating ${package_dir} with sqlc v${sqlc_version}"
+  (cd "$ROOT/${package_dir}" && "$sqlc_bin" generate)
+done


### PR DESCRIPTION
## Summary

- add a mandatory sqlc regeneration workflow to `CLAUDE.md`
- add a self-contained `scripts/generate-sqlc.sh` command that works without `go` on `PATH`
- forbid manually editing generated files or deleting, reverting, or selectively omitting generated changes
- run that exact repository command in pull-request CI and fail if the working tree changes

## Why

The logging v1 production failure was caused by checked-in generated SQL that did not match its source query. Documentation plus an automated clean-tree check prevents source/generated drift from reaching production again.

The T3 environment does not expose Go on `PATH`, so documenting raw `go generate` commands was not actionable. The repository script reads each active package's pinned sqlc version, downloads the matching official prebuilt release, and runs code generation without requiring a Go installation.

## CI behavior

On every pull request, `verify-sqlc`:

1. runs `./scripts/generate-sqlc.sh`, the same command developers and agents use locally
2. fails with the generated diff when tracked or untracked output changes

## Validation

- `./scripts/generate-sqlc.sh` passes in the T3 workspace without Go on `PATH`
- generation leaves the committed working tree clean
- `bash -n scripts/generate-sqlc.sh`
- `git diff --check`
- GitHub Actions `Verify generated sqlc code` passes
