### PR TITLE
Archive Tadoku Paper design planning

### DIFF
--- a/docs/wip/tadoku-paper/README.md
+++ b/docs/wip/tadoku-paper/README.md
@@ -1,0 +1,32 @@
+# Tadoku Paper design-system planning
+
+This directory archives the complete Tadoku Paper design-system planning iteration. It includes the original audit, every visual study shown during discussion, and the permanent decision log.
+
+The studies intentionally include rejected directions. They document why the final visual and architectural decisions were made and should remain available alongside the eventual implementation plan.
+
+## Documents
+
+- [Decision log](decision-log.md)
+- [Original design-system refinement audit](artifacts/design-system-refinement-audit.html)
+
+## Visual studies
+
+| Study | Focus | Presenter copy |
+| --- | --- | --- |
+| [Direction preview](artifacts/design-system-bookplate-preview.html) | Bookplate versus flat archival direction | [Open](https://presentr.lab/html/tadoku-bookplate-direction-preview) |
+| [Refinement v2](artifacts/design-system-bookplate-refinement-v2.html) | Border grammar, accent options, elevation, and wordmark lockups | [Open](https://presentr.lab/html/tadoku-bookplate-refinement-v2) |
+| [Dark preview v3](artifacts/design-system-bookplate-dark-preview-v3.html) | Light/dark ink-violet mapping and corrected wordmark | [Open](https://presentr.lab/html/tadoku-bookplate-dark-preview-v3) |
+| [Border and logo v4](artifacts/design-system-bookplate-border-logo-v4.html) | Straight accent rails, 2px interactive edges, and initial logo concepts | [Open](https://presentr.lab/html/tadoku-bookplate-border-logo-v4) |
+| [Controls and logo v5](artifacts/design-system-bookplate-controls-logo-v5.html) | Quieter field edges, primary hover, and abstract marks | [Open](https://presentr.lab/html/tadoku-bookplate-controls-logo-v5) |
+| [Brand territories v6](artifacts/design-system-bookplate-brand-v6.html) | Immersion, listening, language, contest, and media concepts | [Open](https://presentr.lab/html/tadoku-bookplate-brand-v6) |
+| [Meter study v7](artifacts/design-system-bookplate-meter-v7.html) | Hard-offset elevation and monochrome meter-mark family | [Open](https://presentr.lab/html/tadoku-bookplate-meter-v7) |
+| [Cut Meter variations v8](artifacts/design-system-cut-meter-variations-v8.html) | Six negative-space treatments and remaining decision queue | [Open](https://presentr.lab/html/tadoku-cut-meter-variations-v8) |
+| [Soft Cut Meter v9](artifacts/design-system-cut-meter-soft-v9.html) | Genuinely rounded cut constructions | [Open](https://presentr.lab/html/tadoku-cut-meter-soft-v9) |
+| [Typography and icons v10](artifacts/design-system-type-icon-baseline-v10.html) | Typography hierarchy, icon grammar, API direction, and regression baseline | [Open](https://presentr.lab/html/tadoku-type-icon-baseline-v10) |
+| [Button grammar v11](artifacts/tadoku-paper-button-grammar-v11.html) | Button variants, class/component parity, and `paper-ui` architecture | [Open](https://presentr.lab/html/tadoku-paper-button-grammar-v11) |
+
+The original audit also remains published at [Presenter](https://presentr.lab/html/tadoku-design-system-refinement-audit).
+
+## Status
+
+The discussion phase is complete enough to produce the implementation plan. The plan should be added to this directory without replacing the audit, studies, or decision log.

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-border-logo-v4.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-border-logo-v4.html
@@ -1,0 +1,337 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku Bookplate — Border and Logo Study</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --accent: #5747b8;
+      --accent-soft: #e8e4fa;
+      --accent-bottom: #35277f;
+    }
+
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --accent: #9a8bea;
+      --accent-soft: #332d52;
+      --accent-bottom: #b8acf8;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--canvas);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+
+    button, input, select { font: inherit; }
+    button { color: inherit; }
+    .page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 800; letter-spacing: .14em; text-transform: uppercase; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1 { max-width: 820px; margin-bottom: 16px; font-family: Georgia, "Times New Roman", serif; font-size: clamp(36px, 6vw, 68px); line-height: .98; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-family: Georgia, "Times New Roman", serif; font-size: clamp(25px, 3vw, 36px); line-height: 1.1; }
+    h3 { margin-bottom: 6px; font-size: 16px; }
+    p { color: var(--muted); }
+    .lede { max-width: 740px; font-size: 18px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 42px; }
+    .theme-toggle { flex: none; }
+
+    .btn, .field {
+      min-height: 42px;
+      border: 1px solid var(--rule);
+      border-bottom: 2px solid var(--rule-strong);
+      border-radius: 0;
+      background: var(--surface);
+    }
+    .btn { display: inline-flex; align-items: center; justify-content: center; gap: 8px; padding: 9px 15px 8px; cursor: pointer; font-weight: 750; }
+    .btn:hover { background: var(--surface-soft); }
+    .btn:active { transform: translateY(1px); border-bottom-width: 1px; }
+    .btn.primary { border-color: var(--accent); border-bottom-color: var(--accent-bottom); background: var(--accent); color: #fff; }
+    [data-theme="dark"] .btn.primary { color: #17131f; }
+    .field { width: 100%; padding: 9px 11px 8px; color: var(--text); }
+    .field:focus, .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    .section { margin-top: 52px; }
+    .section-intro { max-width: 760px; margin-bottom: 20px; }
+    .rail-card {
+      position: relative;
+      border-top: 1px solid var(--rule);
+      border-right: 1px solid var(--rule);
+      border-bottom: 1px solid var(--rule);
+      border-left: 0;
+      background: var(--surface);
+    }
+    .rail-card::before {
+      content: "";
+      position: absolute;
+      z-index: 1;
+      top: -1px;
+      bottom: -1px;
+      left: 0;
+      width: 6px;
+      background: var(--accent);
+    }
+    .rail-content { padding: 26px 28px 26px 34px; }
+    .construction { display: grid; grid-template-columns: 1.05fr .95fr; }
+    .construction > * { min-width: 0; }
+    .construction-copy { padding-right: 32px; }
+    .construction-demo { border-left: 1px solid var(--rule); padding-left: 28px; }
+    .mini-bookplate { position: relative; min-height: 245px; padding: 26px 24px 24px 30px; border-top: 1px solid var(--rule); border-right: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: var(--canvas); }
+    .mini-bookplate::before { content: ""; position: absolute; top: -1px; bottom: -1px; left: 0; width: 6px; background: var(--accent); }
+    .mini-bookplate hr { margin: 20px 0; border: 0; border-top: 1px solid var(--rule); }
+    .mini-label { color: var(--accent); font-size: 11px; font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+    .mini-title { margin: 5px 0 6px; font: 700 26px/1.1 Georgia, serif; }
+    .form-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
+    .note { margin: 18px 0 0; padding-top: 14px; border-top: 1px solid var(--rule); font-size: 14px; }
+
+    .weight-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+    .weight-card { padding: 22px; border: 1px solid var(--rule); background: var(--surface); }
+    .control-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: end; margin-top: 18px; }
+    .field-wrap { flex: 1 1 210px; }
+    label { display: block; margin-bottom: 6px; font-size: 12px; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+    .static-example { border: 1px solid var(--rule); padding: 13px 15px; background: var(--canvas); }
+    .static-example p { margin: 0; }
+
+    .logos { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+    .logo-card { display: flex; flex-direction: column; min-height: 410px; border: 1px solid var(--rule); background: var(--surface); }
+    .logo-stage { display: grid; min-height: 185px; place-items: center; border-bottom: 1px solid var(--rule); background: var(--canvas); }
+    .logo-copy { display: flex; flex: 1; flex-direction: column; padding: 17px; }
+    .logo-copy p { margin-bottom: 16px; font-size: 14px; }
+    .logo-copy .fit { margin-top: auto; padding-top: 12px; border-top: 1px solid var(--rule); color: var(--text); font-size: 12px; }
+    .size-row { display: flex; align-items: center; gap: 14px; margin-top: 12px; }
+    .mark { display: block; color: var(--text); }
+    .mark.large { width: 92px; height: 92px; }
+    .mark.medium { width: 28px; height: 28px; }
+    .mark.small { width: 16px; height: 16px; }
+    .accent-stroke { stroke: var(--accent); }
+    .accent-fill { fill: var(--accent); }
+    .ink-stroke { stroke: currentColor; }
+    .ink-fill { fill: currentColor; }
+    .shortlist { border-top: 3px solid var(--accent); }
+    .badge { display: inline-block; align-self: flex-start; margin-bottom: 9px; padding: 3px 6px; background: var(--accent-soft); color: var(--accent); font-size: 10px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; }
+    .principles { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); }
+    .principle { padding: 22px; background: var(--surface); }
+    .principle strong { display: block; margin-bottom: 5px; }
+    .principle p { margin: 0; font-size: 14px; }
+
+    @media (max-width: 980px) {
+      .logos { grid-template-columns: repeat(2, 1fr); }
+      .construction { grid-template-columns: 1fr; }
+      .construction-copy { padding-right: 0; }
+      .construction-demo { margin-top: 24px; padding: 24px 0 0; border-top: 1px solid var(--rule); border-left: 0; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1180px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .weight-grid, .logos, .principles { grid-template-columns: 1fr; }
+      .rail-content { padding: 22px 18px 22px 26px; }
+      .form-row { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tadoku design discussion · P0.2 · Study 4</p>
+        <h1>Straight rails, firmer controls, and a mark of our own.</h1>
+        <p class="lede">This pass removes the triangular border join, tests a 2px lower edge only on interactive components, and explores five compact Tadoku logo ideas without borrowing the current K-shaped language.</p>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">01 · Border construction</p>
+        <h2>One uninterrupted accent rail</h2>
+        <p>The triangle was a mitered join: the browser was blending a thick left border into thin top and bottom borders. Here, the violet rail is an independent positioned strip that covers both endpoints, so its full six-pixel edge stays perfectly straight.</p>
+      </div>
+      <article class="rail-card">
+        <div class="rail-content construction">
+          <div class="construction-copy">
+            <h3>Less nesting, clearer hierarchy</h3>
+            <p>The rail belongs only to the outermost meaningful container. Inside it, content groups use whitespace and horizontal separators instead of more boxes. This preserves the bookplate character without producing frames inside frames.</p>
+            <div class="principles">
+              <div class="principle"><strong>Outer edge</strong><p>One violet rail; no neutral hairline beneath it.</p></div>
+              <div class="principle"><strong>Inside</strong><p>Spacing first, then horizontal rules where needed.</p></div>
+              <div class="principle"><strong>Static cards</strong><p>Neutral 1px rule; never a heavy lower edge.</p></div>
+            </div>
+            <p class="note"><strong>Implementation note:</strong> the rail extends one pixel above and below the container, hiding the corner joins rather than trying to coax four unequal borders into meeting cleanly.</p>
+          </div>
+          <div class="construction-demo">
+            <div class="mini-bookplate">
+              <span class="mini-label">Current challenge</span>
+              <div class="mini-title">August Reading</div>
+              <p>Track what you read, one page at a time.</p>
+              <hr>
+              <div class="form-row">
+                <input class="field" aria-label="Pages read" value="24 pages">
+                <button class="btn primary" type="button">Add entry</button>
+              </div>
+            </div>
+          </div>
+        </div>
+      </article>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Interaction weight</p>
+        <h2>A 2px lower edge, where it earns its keep</h2>
+        <p>The extra pixel makes controls feel deliberate and tactile. It is restricted to elements people can press or type into; content containers keep a quiet 1px outline.</p>
+      </div>
+      <div class="weight-grid">
+        <article class="weight-card">
+          <h3>Interactive · 1px sides + 2px lower edge</h3>
+          <p>Buttons, inputs, selects, tabs, and compact interactive tiles.</p>
+          <div class="control-row">
+            <div class="field-wrap"><label for="language">Language</label><select class="field" id="language"><option>Japanese</option></select></div>
+            <button class="btn" type="button">Cancel</button>
+            <button class="btn primary" type="button">Save entry</button>
+          </div>
+        </article>
+        <article class="weight-card">
+          <h3>Static · consistent 1px hairline</h3>
+          <p>Cards, summaries, documentation examples, and content sections.</p>
+          <div class="static-example"><strong>7-day total · 184 pages</strong><p>The container stays quiet so controls remain visibly actionable.</p></div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">03 · Logo territories</p>
+        <h2>Five marks that can belong to Tadoku</h2>
+        <p>These are deliberately schematic, code-native sketches for choosing a concept—not finished logos. Each is shown at favicon size to expose which ideas survive when small. The violet remains a structural accent, not decoration added afterward.</p>
+      </div>
+      <div class="logos">
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Open Book T mark">
+              <path class="ink-stroke" d="M7 15c10-2 18 1 25 7v31C25 47 17 44 7 46zM57 15c-10-2-18 1-25 7v31c7-6 15-9 25-7z" fill="none" stroke-width="3" stroke-linejoin="miter"/>
+              <path class="accent-stroke" d="M20 13h24M32 13v40" fill="none" stroke-width="5"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>1 · Open Book T</h3>
+            <p>An open book built around a violet T-shaped spine. Directly signals reading while giving the name an initial.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M7 15c10-2 18 1 25 7v31C25 47 17 44 7 46zM57 15c-10-2-18 1-25 7v31c7-6 15-9 25-7z" fill="none" stroke-width="4"/><path class="accent-stroke" d="M20 13h24M32 13v40" stroke-width="6"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M7 15c10-2 18 1 25 7v31C25 47 17 44 7 46zM57 15c-10-2-18 1-25 7v31c7-6 15-9 25-7z" fill="none" stroke-width="6"/><path class="accent-stroke" d="M20 13h24M32 13v40" stroke-width="8"/></svg>
+            </div>
+            <div class="fit"><strong>Fit:</strong> most literal, editorial, slightly formal.</div>
+          </div>
+        </article>
+
+        <article class="logo-card shortlist">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Bookmark T mark">
+              <path class="ink-stroke" d="M9 12h46M32 12v43" fill="none" stroke-width="6"/>
+              <path class="accent-fill" d="M24 8h16v50l-8-7-8 7z"/>
+              <path class="ink-stroke" d="M9 12h46" fill="none" stroke-width="6"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <span class="badge">Shortlist</span>
+            <h3>2 · Bookmark T</h3>
+            <p>A bold T interrupted by a bookmark ribbon. Simple enough to own, with a clear reading cue at small sizes.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M9 12h46M32 12v43" stroke-width="7"/><path class="accent-fill" d="M24 8h16v50l-8-7-8 7z"/><path class="ink-stroke" d="M9 12h46" stroke-width="7"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M8 12h48M32 12v44" stroke-width="9"/><path class="accent-fill" d="M23 7h18v52l-9-7-9 7z"/><path class="ink-stroke" d="M8 12h48" stroke-width="9"/></svg>
+            </div>
+            <div class="fit"><strong>Fit:</strong> strongest compact app icon; traditional but not nostalgic cosplay.</div>
+          </div>
+        </article>
+
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Library Shelf mark">
+              <path class="ink-stroke" d="M7 54h50M11 16h11v38H11zM25 10h12v44H25z" fill="none" stroke-width="4"/>
+              <path class="accent-stroke" d="M43 16l10-2 7 37-10 2z" fill="none" stroke-width="5"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>3 · Library Shelf</h3>
+            <p>A run of book spines with one violet volume leaning forward. It conveys collection, progress, and personal reading history.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M7 54h50M11 16h11v38H11zM25 10h12v44H25z" fill="none" stroke-width="5"/><path class="accent-stroke" d="M43 16l10-2 7 37-10 2z" fill="none" stroke-width="6"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M5 54h54M10 16h12v38H10zM25 10h13v44H25z" fill="none" stroke-width="7"/><path class="accent-stroke" d="M43 16l11-2 7 37-11 2z" fill="none" stroke-width="8"/></svg>
+            </div>
+            <div class="fit"><strong>Fit:</strong> warmest library cue; can become busy at 16px.</div>
+          </div>
+        </article>
+
+        <article class="logo-card shortlist">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Reading Loop mark">
+              <path class="ink-stroke" d="M8 32c7-15 18-18 24 0s17 15 24 0c-7-15-18-18-24 0S15 47 8 32z" fill="none" stroke-width="5" stroke-linecap="square"/>
+              <path class="accent-stroke" d="M31 32c6 18 17 15 24 2" fill="none" stroke-width="6"/>
+              <path class="accent-fill" d="M49 27l10 6-9 7z"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <span class="badge">Shortlist</span>
+            <h3>4 · Reading Loop</h3>
+            <p>A continuous page-turn path: read, record, continue. More abstract and ownable than a conventional book icon.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M8 32c7-15 18-18 24 0s17 15 24 0c-7-15-18-18-24 0S15 47 8 32z" fill="none" stroke-width="6"/><path class="accent-stroke" d="M31 32c6 18 17 15 24 2" fill="none" stroke-width="7"/><path class="accent-fill" d="M49 26l11 7-10 8z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M7 32c7-16 19-19 25 0s18 16 25 0c-7-16-19-19-25 0S14 48 7 32z" fill="none" stroke-width="8"/><path class="accent-stroke" d="M31 32c6 19 18 16 25 2" fill="none" stroke-width="9"/><path class="accent-fill" d="M48 25l13 8-12 9z"/></svg>
+            </div>
+            <div class="fit"><strong>Fit:</strong> most distinctive and active; needs refinement to avoid an infinity-app feel.</div>
+          </div>
+        </article>
+
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Catalog Card mark">
+              <path class="ink-stroke" d="M9 11h46v42H9zM20 23h26M20 32h20M20 41h25" fill="none" stroke-width="4"/>
+              <path class="accent-stroke" d="M9 10v44" fill="none" stroke-width="7"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>5 · Catalog Card</h3>
+            <p>A library catalog card whose violet rail mirrors the interface. It connects the product identity directly to the design system.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M9 11h46v42H9zM20 23h26M20 32h20M20 41h25" fill="none" stroke-width="5"/><path class="accent-stroke" d="M9 9v46" stroke-width="8"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M8 10h48v44H8zM20 24h27M20 34h24M20 44h26" fill="none" stroke-width="7"/><path class="accent-stroke" d="M8 8v48" stroke-width="10"/></svg>
+            </div>
+            <div class="fit"><strong>Fit:</strong> best system connection; risks reading as a generic document icon.</div>
+          </div>
+        </article>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-brand-v6.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-brand-v6.html
@@ -1,0 +1,334 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku Bookplate — Immersion Brand Study</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --input-lower: #aba398;
+      --accent: #5747b8;
+      --action: #5747b8;
+      --action-hover: #49399f;
+      --action-lower: #35277f;
+      --on-action: #fffefa;
+      --accent-soft: #e8e4fa;
+    }
+
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --input-lower: #696166;
+      --accent: #9a8bea;
+      --action: #6150bc;
+      --action-hover: #6d5cc7;
+      --action-lower: #40318c;
+      --on-action: #fffefa;
+      --accent-soft: #332d52;
+    }
+
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--canvas); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; }
+    button, input { font: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2 { font-family: Georgia, "Times New Roman", serif; }
+    h1 { max-width: 900px; margin-bottom: 16px; font-size: clamp(38px, 6vw, 68px); line-height: .98; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-size: clamp(26px, 3vw, 37px); line-height: 1.08; }
+    h3 { margin-bottom: 7px; font-size: 16px; }
+    p { color: var(--muted); }
+    .page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 52px; }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 850; letter-spacing: .14em; text-transform: uppercase; }
+    .lede, .section-intro { max-width: 790px; }
+    .lede { font-size: 18px; }
+    .section { margin-top: 54px; }
+    .section-intro { margin-bottom: 22px; }
+
+    .btn {
+      display: inline-flex;
+      min-height: 42px;
+      align-items: center;
+      justify-content: center;
+      padding: 9px 15px 8px;
+      border: 1px solid var(--rule);
+      border-bottom: 2px solid var(--rule-strong);
+      border-radius: 0;
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-weight: 750;
+      transition: background-color 140ms ease, border-color 140ms ease;
+    }
+    .btn:hover { background: var(--surface-soft); }
+    .btn.primary { border-color: var(--action); border-bottom-color: var(--action-lower); background: var(--action); color: var(--on-action); }
+    .btn.primary:hover { border-color: var(--action-hover); border-bottom-color: var(--action-lower); background: var(--action-hover); }
+    .btn:focus-visible, .field:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-toggle { flex: none; }
+    .field { width: 100%; min-height: 42px; padding: 9px 11px 8px; border: 1px solid var(--rule); border-bottom: 2px solid var(--input-lower); border-radius: 0; background: var(--surface); color: var(--text); }
+    .field:focus { border-color: var(--accent); border-bottom-color: var(--accent); }
+
+    .rail-card { position: relative; border-top: 1px solid var(--rule); border-right: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: var(--surface); }
+    .rail-card::before { content: ""; position: absolute; top: -1px; bottom: -1px; left: 0; width: 6px; background: var(--accent); }
+    .rail-content { padding: 27px 28px 27px 34px; }
+    .dark-decision { display: grid; grid-template-columns: 1fr 1fr; gap: 34px; }
+    .decision-copy { padding-right: 24px; }
+    .decision-list { margin: 18px 0 0; padding: 0; list-style: none; border: 1px solid var(--rule); }
+    .decision-list li { padding: 12px 14px; color: var(--muted); font-size: 14px; }
+    .decision-list li + li { border-top: 1px solid var(--rule); }
+    .decision-list strong { color: var(--text); }
+    .mini-form { padding-left: 32px; border-left: 1px solid var(--rule); }
+    label { display: block; margin: 0 0 6px; font-size: 12px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+    .form-row { display: grid; grid-template-columns: 1fr auto; gap: 10px; }
+    .form-note { margin: 10px 0 0; font-size: 13px; }
+
+    .strategy { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; margin-bottom: 20px; border: 1px solid var(--rule); background: var(--rule); }
+    .strategy-item { padding: 20px; background: var(--surface); }
+    .strategy-item strong { display: block; margin-bottom: 5px; }
+    .strategy-item p { margin: 0; font-size: 14px; }
+    .concepts { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+    .concept { display: flex; min-height: 455px; flex-direction: column; border: 1px solid var(--rule); background: var(--surface); }
+    .concept-stage { display: grid; min-height: 190px; place-items: center; border-bottom: 1px solid var(--rule); background: var(--canvas); }
+    .concept-copy { display: flex; flex: 1; flex-direction: column; padding: 17px; }
+    .concept-copy p { margin-bottom: 13px; font-size: 14px; }
+    .territory { display: inline-block; align-self: flex-start; margin-bottom: 9px; padding: 3px 6px; background: var(--accent-soft); color: var(--accent); font-size: 10px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; }
+    .lockup { display: flex; align-items: center; gap: 11px; margin-top: auto; padding: 12px 0; border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule); }
+    .wordmark { color: var(--text); font-size: 15px; font-weight: 900; letter-spacing: .13em; }
+    .size-row { display: flex; align-items: center; gap: 14px; padding-top: 12px; }
+    .size-label { margin-left: auto; color: var(--muted); font-size: 10px; text-transform: uppercase; }
+    .mark { display: block; color: var(--text); }
+    .mark.large { width: 98px; height: 98px; }
+    .mark.lock { width: 30px; height: 30px; }
+    .mark.medium { width: 28px; height: 28px; }
+    .mark.small { width: 16px; height: 16px; }
+    .ink-fill { fill: currentColor; }
+    .ink-stroke { fill: none; stroke: currentColor; }
+    .accent-fill { fill: var(--accent); }
+    .accent-stroke { fill: none; stroke: var(--accent); }
+
+    .recommendation { margin-top: 20px; padding: 22px 24px; border-left: 6px solid var(--accent); background: var(--surface); }
+    .recommendation p:last-child { margin-bottom: 0; }
+
+    @media (max-width: 1000px) {
+      .concepts { grid-template-columns: repeat(2, 1fr); }
+      .dark-decision { grid-template-columns: 1fr; }
+      .decision-copy { padding-right: 0; }
+      .mini-form { padding: 24px 0 0; border-top: 1px solid var(--rule); border-left: 0; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1180px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .concepts, .strategy { grid-template-columns: 1fr; }
+      .form-row { grid-template-columns: 1fr; }
+      .rail-content { padding: 22px 18px 22px 26px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tadoku design discussion · P0.2 · Study 6</p>
+        <h1>Language immersion, not a letter-shaped logo.</h1>
+        <p class="lede">A third logo reset based on what Tadoku actually does: build a habit of consuming foreign-language media through reading, listening, tracking, and friendly contests.</p>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">01 · Dark primary action</p>
+        <h2>Light text, with a darker action violet</h2>
+        <p>Light text does read more naturally on a filled primary button. In dark mode, the structural accent can stay bright while the button fill uses a deeper companion violet, preserving contrast instead of placing white text on pale lavender.</p>
+      </div>
+      <article class="rail-card">
+        <div class="rail-content dark-decision">
+          <div class="decision-copy">
+            <h3>Separate accent ink from action fill</h3>
+            <p>One violet does not have to perform every job. Bright ink violet remains excellent for rails, focus rings, and small marks in dark mode; a deeper violet makes a better button surface.</p>
+            <ul class="decision-list">
+              <li><strong>Dark structural accent:</strong> lifted violet for thin lines and small details.</li>
+              <li><strong>Dark action fill:</strong> deeper violet behind light text.</li>
+              <li><strong>Hover:</strong> a controlled lift in brightness, without changing the text color.</li>
+            </ul>
+          </div>
+          <form class="mini-form">
+            <label for="minutes">Listening minutes</label>
+            <div class="form-row">
+              <input class="field" id="minutes" value="35 minutes">
+              <button class="btn primary" type="button">Add listening</button>
+            </div>
+            <p class="form-note">Use the theme switch above, then hover the primary button.</p>
+          </form>
+        </div>
+      </article>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Brand territories</p>
+        <h2>Five concepts based on immersion and momentum</h2>
+        <p>These marks are evaluated beside a neutral Tadoku wordmark and at favicon size. None contains a hidden initial. They deliberately range from broad brand ideas to narrower contest and media ideas so we can decide what the identity should emphasize.</p>
+      </div>
+      <div class="strategy">
+        <div class="strategy-item"><strong>Core promise</strong><p>Understand more by steadily consuming native-language material.</p></div>
+        <div class="strategy-item"><strong>Supported modes</strong><p>Reading, listening, video, and other trackable media.</p></div>
+        <div class="strategy-item"><strong>Social energy</strong><p>Friendly contests create momentum, but winning is not the only point.</p></div>
+      </div>
+
+      <div class="concepts">
+        <article class="concept">
+          <div class="concept-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Immersion Field mark">
+              <path class="ink-stroke" d="M55 19V9H9v46h46V45M47 24v-7H17v30h30v-7M39 28v-3H25v14h14v-3" stroke-width="5" stroke-linecap="square"/>
+              <path class="accent-fill" d="M48 27h10v10H48z"/>
+            </svg>
+          </div>
+          <div class="concept-copy">
+            <span class="territory">Immersion</span>
+            <h3>1 · Immersion Field</h3>
+            <p>Nested fields represent going deeper into a language. Their openings form a route rather than a closed target; the violet block is the next piece of input.</p>
+            <div class="lockup">
+              <svg class="mark lock" viewBox="0 0 64 64"><path class="ink-stroke" d="M55 19V9H9v46h46V45M47 24v-7H17v30h30v-7M39 28v-3H25v14h14v-3" stroke-width="6"/><path class="accent-fill" d="M48 27h10v10H48z"/></svg>
+              <span class="wordmark">TADOKU</span>
+            </div>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M55 19V9H9v46h46V45M47 24v-7H17v30h30v-7M39 28v-3H25v14h14v-3" stroke-width="7"/><path class="accent-fill" d="M47 26h12v12H47z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M56 20V8H8v48h48V44M47 24v-8H16v32h31v-8M39 27v-3H24v16h15v-3" stroke-width="9"/><path class="accent-fill" d="M46 25h14v14H46z"/></svg>
+              <span class="size-label">28 / 16</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="concept">
+          <div class="concept-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Listening Signal mark">
+              <path class="ink-fill" d="M6 28h7v8H6zM17 20h7v24h-7zM28 10h8v44h-8zM40 17h7v30h-7zM51 25h7v14h-7z"/>
+              <path class="accent-fill" d="M28 10h8v16h-8zM28 38h8v16h-8z"/>
+            </svg>
+          </div>
+          <div class="concept-copy">
+            <span class="territory">Listening</span>
+            <h3>2 · Living Signal</h3>
+            <p>An uneven signal that can be read as sound, speech cadence, or activity. The violet interruptions suggest moments of recognition inside continuous input.</p>
+            <div class="lockup">
+              <svg class="mark lock" viewBox="0 0 64 64"><path class="ink-fill" d="M6 28h7v8H6zM17 20h7v24h-7zM28 10h8v44h-8zM40 17h7v30h-7zM51 25h7v14h-7z"/><path class="accent-fill" d="M28 10h8v16h-8zM28 38h8v16h-8z"/></svg>
+              <span class="wordmark">TADOKU</span>
+            </div>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M5 27h8v10H5zM17 19h8v26h-8zM28 8h8v48h-8zM40 16h8v32h-8zM52 24h8v16h-8z"/><path class="accent-fill" d="M28 8h8v17h-8zM28 39h8v17h-8z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M3 26h10v12H3zM16 17h10v30H16zM28 6h10v52H28zM41 14h10v36H41zM54 23h8v18h-8z"/><path class="accent-fill" d="M28 6h10v19H28zM28 39h10v19H28z"/></svg>
+              <span class="size-label">28 / 16</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="concept">
+          <div class="concept-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Language Weave mark">
+              <path class="ink-fill" d="M7 13h34l16 19-16 19H7l16-19z"/>
+              <path fill="var(--canvas)" d="M18 20h20l10 12-10 12H18l10-12z"/>
+              <path class="accent-fill" d="M23 13h18l16 19-16 19H23l16-19z" opacity=".92"/>
+              <path fill="var(--canvas)" d="M32 20h6l10 12-10 12h-6l10-12z"/>
+            </svg>
+          </div>
+          <div class="concept-copy">
+            <span class="territory">Language learning</span>
+            <h3>3 · Language Weave</h3>
+            <p>Two directional ribbons overlap and share a center. It treats language learning as patterns becoming connected, not as translation between letterforms.</p>
+            <div class="lockup">
+              <svg class="mark lock" viewBox="0 0 64 64"><path class="ink-fill" d="M7 13h34l16 19-16 19H7l16-19z"/><path fill="var(--surface)" d="M18 20h20l10 12-10 12H18l10-12z"/><path class="accent-fill" d="M23 13h18l16 19-16 19H23l16-19z"/><path fill="var(--surface)" d="M32 20h6l10 12-10 12h-6l10-12z"/></svg>
+              <span class="wordmark">TADOKU</span>
+            </div>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M7 13h34l16 19-16 19H7l16-19z"/><path fill="var(--canvas)" d="M18 20h20l10 12-10 12H18l10-12z"/><path class="accent-fill" d="M23 13h18l16 19-16 19H23l16-19z"/><path fill="var(--canvas)" d="M32 20h6l10 12-10 12h-6l10-12z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M4 11h38l18 21-18 21H4l18-21z"/><path fill="var(--canvas)" d="M17 20h21l10 12-10 12H17l10-12z"/><path class="accent-fill" d="M23 11h19l18 21-18 21H23l18-21z"/><path fill="var(--canvas)" d="M33 20h5l10 12-10 12h-5l10-12z"/></svg>
+              <span class="size-label">28 / 16</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="concept">
+          <div class="concept-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Friendly Pace mark">
+              <path class="ink-stroke" d="M9 17h24c14 0 22 6 22 15s-8 15-22 15H9M9 29h24c5 0 8 1 8 3s-3 3-8 3H9" stroke-width="6" stroke-linecap="square"/>
+              <path class="accent-fill" d="M48 24h10v16H48z"/>
+            </svg>
+          </div>
+          <div class="concept-copy">
+            <span class="territory">Friendly contest</span>
+            <h3>4 · Friendly Pace</h3>
+            <p>Two participants travel the same course at different rhythms. There is a checkpoint, but no winner’s podium—the competition is a structure for momentum.</p>
+            <div class="lockup">
+              <svg class="mark lock" viewBox="0 0 64 64"><path class="ink-stroke" d="M9 17h24c14 0 22 6 22 15s-8 15-22 15H9M9 29h24c5 0 8 1 8 3s-3 3-8 3H9" stroke-width="7"/><path class="accent-fill" d="M48 24h10v16H48z"/></svg>
+              <span class="wordmark">TADOKU</span>
+            </div>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M7 16h26c15 0 23 7 23 16s-8 16-23 16H7M7 28h26c6 0 9 2 9 4s-3 4-9 4H7" stroke-width="7"/><path class="accent-fill" d="M48 23h11v18H48z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M5 15h29c16 0 25 7 25 17s-9 17-25 17H5M5 27h29c7 0 10 2 10 5s-3 5-10 5H5" stroke-width="9"/><path class="accent-fill" d="M48 21h13v22H48z"/></svg>
+              <span class="size-label">28 / 16</span>
+            </div>
+          </div>
+        </article>
+
+        <article class="concept">
+          <div class="concept-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Media Feed mark">
+              <path class="ink-fill" d="M8 10h21v21H8zM35 10h21v21H35zM8 37h21v17H8zM35 37h21v17H35z"/>
+              <path fill="var(--canvas)" d="M14 16h9v9h-9zM40 16h11v3H40zM40 22h8v3h-8zM14 43h9v5h-9zM41 41l10 5-10 5z"/>
+              <path class="accent-fill" d="M8 37h21v17H8z"/>
+              <path fill="var(--canvas)" d="M13 46h3l2-5 3 10 2-5h2"/>
+            </svg>
+          </div>
+          <div class="concept-copy">
+            <span class="territory">Media consumption</span>
+            <h3>5 · Media Feed</h3>
+            <p>A compact field of different input formats—text, audio, video, and pages—with one active violet tile. It is broad, but intentionally more product-like.</p>
+            <div class="lockup">
+              <svg class="mark lock" viewBox="0 0 64 64"><path class="ink-fill" d="M8 10h21v21H8zM35 10h21v21H35zM8 37h21v17H8zM35 37h21v17H35z"/><path fill="var(--surface)" d="M14 16h9v9h-9zM40 16h11v3H40zM40 22h8v3h-8zM41 41l10 5-10 5z"/><path class="accent-fill" d="M8 37h21v17H8z"/></svg>
+              <span class="wordmark">TADOKU</span>
+            </div>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M8 10h21v21H8zM35 10h21v21H35zM8 37h21v17H8zM35 37h21v17H35z"/><path fill="var(--canvas)" d="M14 16h9v9h-9zM40 16h11v3H40zM40 22h8v3h-8zM41 41l10 5-10 5z"/><path class="accent-fill" d="M8 37h21v17H8z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M6 8h23v23H6zM35 8h23v23H35zM6 37h23v19H6zM35 37h23v19H35z"/><path fill="var(--canvas)" d="M13 15h10v10H13zM41 15h11v4H41zM41 22h8v4h-8zM41 41l12 6-12 6z"/><path class="accent-fill" d="M6 37h23v19H6z"/></svg>
+              <span class="size-label">28 / 16</span>
+            </div>
+          </div>
+        </article>
+      </div>
+
+      <div class="recommendation">
+        <p class="eyebrow">Brand judgment</p>
+        <h3>Keep the master mark broad; let contests have their own badge.</h3>
+        <p>Immersion Field and Language Weave are the broadest master-brand territories. Living Signal is viable if listening should become the strongest association. Friendly Pace and Media Feed are useful tests, but feel better suited to a contest badge or product feature than the permanent Tadoku mark.</p>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-controls-logo-v5.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-controls-logo-v5.html
@@ -1,0 +1,360 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku Bookplate — Control and Abstract Mark Study</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-hover: #a89f94;
+      --rule-strong: #393235;
+      --input-lower: #aba398;
+      --accent: #5747b8;
+      --accent-hover: #49399f;
+      --accent-lower: #35277f;
+      --accent-soft: #e8e4fa;
+    }
+
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-hover: #675f63;
+      --rule-strong: #81777c;
+      --input-lower: #696166;
+      --accent: #9a8bea;
+      --accent-hover: #ac9ff1;
+      --accent-lower: #7767c8;
+      --accent-soft: #332d52;
+    }
+
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      background: var(--canvas);
+      color: var(--text);
+      font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      line-height: 1.5;
+    }
+    button, input, select { font: inherit; }
+    button { color: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2 { font-family: Georgia, "Times New Roman", serif; }
+    h1 { max-width: 850px; margin-bottom: 16px; font-size: clamp(38px, 6vw, 68px); line-height: .98; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-size: clamp(26px, 3vw, 37px); line-height: 1.08; }
+    h3 { margin-bottom: 7px; font-size: 16px; }
+    p { color: var(--muted); }
+    .page { width: min(1160px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 850; letter-spacing: .14em; text-transform: uppercase; }
+    .lede, .section-intro { max-width: 760px; }
+    .lede { font-size: 18px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 52px; }
+    .section { margin-top: 52px; }
+    .section-intro { margin-bottom: 22px; }
+
+    .btn {
+      display: inline-flex;
+      min-height: 42px;
+      align-items: center;
+      justify-content: center;
+      padding: 9px 15px 8px;
+      border: 1px solid var(--rule);
+      border-bottom: 2px solid var(--rule-strong);
+      border-radius: 0;
+      background: var(--surface);
+      cursor: pointer;
+      font-weight: 750;
+      transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
+    }
+    .btn:hover { border-color: var(--rule-hover); background: var(--surface-soft); }
+    .btn:active { transform: translateY(1px); border-bottom-width: 1px; }
+    .btn.primary {
+      border-color: var(--accent);
+      border-bottom-color: var(--accent-lower);
+      background: var(--accent);
+      color: #fff;
+    }
+    .btn.primary:hover {
+      border-color: var(--accent-hover);
+      border-bottom-color: var(--accent-lower);
+      background: var(--accent-hover);
+    }
+    [data-theme="dark"] .btn.primary { color: #17131f; }
+    .btn:focus-visible, .field:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-toggle { flex: none; }
+
+    .field {
+      width: 100%;
+      min-height: 42px;
+      padding: 9px 11px 8px;
+      border: 1px solid var(--rule);
+      border-bottom: 2px solid var(--input-lower);
+      border-radius: 0;
+      background: var(--surface);
+      color: var(--text);
+      transition: border-color 140ms ease, background-color 140ms ease;
+    }
+    .field:hover { border-color: var(--rule-hover); border-bottom-color: var(--input-lower); }
+    .field:focus { border-color: var(--accent); border-bottom-color: var(--accent); }
+    label { display: block; margin-bottom: 6px; font-size: 12px; font-weight: 800; letter-spacing: .06em; text-transform: uppercase; }
+
+    .rail-card {
+      position: relative;
+      border-top: 1px solid var(--rule);
+      border-right: 1px solid var(--rule);
+      border-bottom: 1px solid var(--rule);
+      background: var(--surface);
+    }
+    .rail-card::before { content: ""; position: absolute; z-index: 1; top: -1px; bottom: -1px; left: 0; width: 6px; background: var(--accent); }
+    .rail-content { padding: 27px 28px 27px 34px; }
+
+    .control-layout { display: grid; grid-template-columns: .9fr 1.1fr; gap: 34px; }
+    .token-table { border: 1px solid var(--rule); }
+    .token-row { display: grid; grid-template-columns: 145px 1fr; gap: 16px; padding: 13px 15px; }
+    .token-row + .token-row { border-top: 1px solid var(--rule); }
+    .token-row strong { font-size: 13px; }
+    .token-row span { color: var(--muted); font-size: 13px; }
+    .form-demo { padding-left: 32px; border-left: 1px solid var(--rule); }
+    .form-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .form-grid .wide { grid-column: 1 / -1; }
+    .button-row { display: flex; flex-wrap: wrap; justify-content: flex-end; gap: 10px; padding-top: 4px; }
+    .hint { margin: 8px 0 0; font-size: 13px; }
+    .hover-demo { margin-top: 18px; padding-top: 18px; border-top: 1px solid var(--rule); }
+    .swatches { display: flex; flex-wrap: wrap; gap: 10px; }
+    .state-chip { min-width: 126px; padding: 10px 12px; border: 1px solid var(--accent); border-bottom: 2px solid var(--accent-lower); color: #fff; font-size: 12px; font-weight: 800; text-align: center; }
+    [data-theme="dark"] .state-chip { color: #17131f; }
+    .state-chip.default { background: var(--accent); }
+    .state-chip.hover { border-color: var(--accent-hover); background: var(--accent-hover); }
+
+    .logos { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+    .logo-card { display: flex; min-height: 400px; flex-direction: column; border: 1px solid var(--rule); background: var(--surface); }
+    .logo-stage { display: grid; min-height: 190px; place-items: center; border-bottom: 1px solid var(--rule); background: var(--canvas); }
+    .logo-copy { display: flex; flex: 1; flex-direction: column; padding: 17px; }
+    .logo-copy p { margin-bottom: 14px; font-size: 14px; }
+    .logo-copy .idea { margin-top: auto; padding-top: 12px; border-top: 1px solid var(--rule); color: var(--text); font-size: 12px; }
+    .mark { display: block; color: var(--text); }
+    .mark.large { width: 96px; height: 96px; }
+    .mark.medium { width: 28px; height: 28px; }
+    .mark.small { width: 16px; height: 16px; }
+    .size-row { display: flex; align-items: center; gap: 14px; margin-top: 11px; }
+    .ink-fill { fill: currentColor; }
+    .ink-stroke { fill: none; stroke: currentColor; }
+    .accent-fill { fill: var(--accent); }
+    .accent-stroke { fill: none; stroke: var(--accent); }
+
+    .guardrails { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); }
+    .guardrail { padding: 20px; background: var(--surface); }
+    .guardrail strong { display: block; margin-bottom: 5px; }
+    .guardrail p { margin: 0; font-size: 14px; }
+
+    @media (max-width: 980px) {
+      .logos { grid-template-columns: repeat(2, 1fr); }
+      .control-layout { grid-template-columns: 1fr; }
+      .form-demo { padding: 24px 0 0; border-top: 1px solid var(--rule); border-left: 0; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1160px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .logos, .guardrails, .form-grid { grid-template-columns: 1fr; }
+      .form-grid .wide { grid-column: auto; }
+      .rail-content { padding: 22px 18px 22px 26px; }
+      .token-row { grid-template-columns: 1fr; gap: 3px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tadoku design discussion · P0.2 · Study 5</p>
+        <h1>Quieter fields, responsive actions, abstract marks.</h1>
+        <p class="lede">This pass keeps the 2px interaction cue but lowers its contrast on pale fields. The primary action retains its authority and now has a visible hover state. The logo study starts over without letters.</p>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">01 · Control refinement</p>
+        <h2>The same thickness, less visual weight</h2>
+        <p>Inputs keep a two-pixel lower edge for tactility, but it now uses a mid-neutral rather than the near-black rule. Submit buttons retain their darker violet lower edge because the filled surface can support the contrast.</p>
+      </div>
+      <article class="rail-card">
+        <div class="rail-content control-layout">
+          <div>
+            <h3>Split the semantic tokens</h3>
+            <p>One lower-border token was doing two different jobs. This treatment separates pale fields from filled actions.</p>
+            <div class="token-table">
+              <div class="token-row"><strong>Field lower edge</strong><span>Soft mid-neutral · 2px</span></div>
+              <div class="token-row"><strong>Field focus</strong><span>Ink violet · 2px outline and edge</span></div>
+              <div class="token-row"><strong>Primary lower edge</strong><span>Deep ink violet · 2px</span></div>
+              <div class="token-row"><strong>Primary hover</strong><span>Lighter violet fill; stable lower edge</span></div>
+            </div>
+            <div class="hover-demo">
+              <h3>Primary states</h3>
+              <div class="swatches">
+                <div class="state-chip default">Default</div>
+                <div class="state-chip hover">Hover</div>
+              </div>
+            </div>
+          </div>
+          <form class="form-demo">
+            <div class="form-grid">
+              <div>
+                <label for="pages">Pages read</label>
+                <input class="field" id="pages" value="24">
+              </div>
+              <div>
+                <label for="language">Language</label>
+                <select class="field" id="language"><option>Japanese</option></select>
+              </div>
+              <div class="wide">
+                <label for="title">Book or article</label>
+                <input class="field" id="title" value="コンビニ人間">
+                <p class="hint">Hover and focus the fields; hover the submit button to compare the state changes.</p>
+              </div>
+              <div class="wide button-row">
+                <button class="btn" type="button">Cancel</button>
+                <button class="btn primary" type="button">Add reading</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      </article>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Abstract logo reset</p>
+        <h2>No initials. No letter puzzles.</h2>
+        <p>These are five fresh territories, not revisions of the previous marks. They avoid forcing a T or K and instead explore turning a page, opening a space, accumulating reading, forward motion, and the rhythm of a marked page.</p>
+      </div>
+      <div class="logos">
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Page Turn abstract mark">
+              <path class="ink-fill" d="M11 9h42v46H11z"/>
+              <path fill="var(--canvas)" d="M17 15h30v34H17z"/>
+              <path class="accent-fill" d="M31 15h16v16z"/>
+              <path class="accent-fill" d="M31 15v16H17z" opacity=".68"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>1 · Page Turn</h3>
+            <p>A single sheet caught mid-turn. The violet fold is the moment of movement, while the outer shape stays archival and square.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M11 9h42v46H11z"/><path fill="var(--canvas)" d="M17 15h30v34H17z"/><path class="accent-fill" d="M31 15h16v16zM31 15v16H17z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M9 7h46v50H9z"/><path fill="var(--canvas)" d="M17 15h30v34H17z"/><path class="accent-fill" d="M31 15h16v16zM31 15v16H17z"/></svg>
+            </div>
+            <div class="idea"><strong>Character:</strong> quiet, editorial, precise.</div>
+          </div>
+        </article>
+
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Open Passage abstract mark">
+              <path class="ink-fill" d="M7 12l22 7v36L7 47zM57 12l-22 7v36l22-8z"/>
+              <path class="accent-fill" d="M29 19h6v36h-6z"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>2 · Open Passage</h3>
+            <p>Two planes create a narrow violet passage between them. It suggests opening a book or entering another world without drawing either literally.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M7 12l22 7v36L7 47zM57 12l-22 7v36l22-8z"/><path class="accent-fill" d="M29 19h6v36h-6z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M5 10l24 8v38L5 48zM59 10l-24 8v38l24-8z"/><path class="accent-fill" d="M28 18h8v38h-8z"/></svg>
+            </div>
+            <div class="idea"><strong>Character:</strong> spatial, immersive, book-adjacent.</div>
+          </div>
+        </article>
+
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Accumulation abstract mark">
+              <path class="ink-fill" d="M8 42h35v8H8zM13 29h35v8H13zM18 16h35v8H18z"/>
+              <path class="accent-fill" d="M43 42h13v8H43zM48 29h8v8H48zM53 16h3v8h-3z"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>3 · Accumulation</h3>
+            <p>Three reading units gather into a stack. The stepped ends communicate steady progress rather than completion or competition.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M8 42h35v8H8zM13 29h35v8H13zM18 16h35v8H18z"/><path class="accent-fill" d="M43 42h13v8H43zM48 29h8v8H48zM53 16h3v8h-3z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M6 41h38v10H6zM12 27h38v10H12zM18 13h38v10H18z"/><path class="accent-fill" d="M44 41h14v10H44zM50 27h8v10H50zM54 13h4v10h-4z"/></svg>
+            </div>
+            <div class="idea"><strong>Character:</strong> patient, cumulative, system-friendly.</div>
+          </div>
+        </article>
+
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Reading Current abstract mark">
+              <path class="ink-stroke" d="M8 18h28c13 0 20 5 20 14s-7 14-20 14H14" stroke-width="7" stroke-linecap="square"/>
+              <path class="accent-fill" d="M8 39l14 7L8 53z"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>4 · Reading Current</h3>
+            <p>A line moves forward, doubles back, and continues. It represents the relaxed Tadoku loop: encounter, absorb, keep going.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-stroke" d="M8 18h28c13 0 20 5 20 14s-7 14-20 14H14" stroke-width="8"/><path class="accent-fill" d="M8 38l15 8-15 8z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-stroke" d="M6 17h31c14 0 21 6 21 15s-7 15-21 15H13" stroke-width="10"/><path class="accent-fill" d="M5 37l17 10-17 10z"/></svg>
+            </div>
+            <div class="idea"><strong>Character:</strong> active, continuous, less obviously literary.</div>
+          </div>
+        </article>
+
+        <article class="logo-card">
+          <div class="logo-stage">
+            <svg class="mark large" viewBox="0 0 64 64" role="img" aria-label="Marginal Rhythm abstract mark">
+              <path class="ink-fill" d="M12 10h8v44h-8zM27 10h25v7H27zM27 27h19v7H27zM27 44h25v7H27z"/>
+              <path class="accent-fill" d="M8 25h16v11H8z"/>
+            </svg>
+          </div>
+          <div class="logo-copy">
+            <h3>5 · Marginal Rhythm</h3>
+            <p>A marked margin beside lines of changing length. It references reading traces and the interface accent rail without becoming a document icon.</p>
+            <div class="size-row">
+              <svg class="mark medium" viewBox="0 0 64 64"><path class="ink-fill" d="M12 10h8v44h-8zM27 10h25v7H27zM27 27h19v7H27zM27 44h25v7H27z"/><path class="accent-fill" d="M8 25h16v11H8z"/></svg>
+              <svg class="mark small" viewBox="0 0 64 64"><path class="ink-fill" d="M10 8h10v48H10zM28 9h27v9H28zM28 27h21v9H28zM28 45h27v9H28z"/><path class="accent-fill" d="M6 24h18v14H6z"/></svg>
+            </div>
+            <div class="idea"><strong>Character:</strong> archival, rhythmic, closest to the UI language.</div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="guardrails">
+        <div class="guardrail"><strong>No hidden initials</strong><p>The final symbol should stand on form and meaning, not a letter-recognition trick.</p></div>
+        <div class="guardrail"><strong>One accent gesture</strong><p>Ink violet identifies the meaningful movement or interruption within each mark.</p></div>
+        <div class="guardrail"><strong>Survive at 16px</strong><p>Every territory must reduce to a compact two-color silhouette before refinement.</p></div>
+      </div>
+    </section>
+  </main>
+
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-dark-preview-v3.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-dark-preview-v3.html
@@ -1,0 +1,255 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tadoku UI — Bookplate Light and Dark Study</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      color-scheme: light;
+      --text: #211a1d;
+      --text-muted: #625b5f;
+      --paper: #fffefa;
+      --surface-raised: #ffffff;
+      --canvas: #f2efe8;
+      --canvas-deep: #e8e3d9;
+      --border-strong: #393235;
+      --border-default: #c7c0b5;
+      --border-subtle: #e2ddd4;
+      --accent: #5747b8;
+      --accent-hover: #46389d;
+      --accent-faint: rgba(87, 71, 184, .12);
+      --on-accent: #ffffff;
+      --success: #3f7048;
+      --danger: #a33333;
+      --hard-shadow: rgba(33, 26, 29, .15);
+      --font-serif: "Merriweather", Georgia, serif;
+      --font-sans: "Open Sans", ui-sans-serif, system-ui, sans-serif;
+    }
+
+    :root[data-theme="dark"] {
+      color-scheme: dark;
+      --text: #f2eee8;
+      --text-muted: #b8b0ac;
+      --paper: #222022;
+      --surface-raised: #2b282b;
+      --canvas: #171517;
+      --canvas-deep: #302b2e;
+      --border-strong: #81777c;
+      --border-default: #4e484b;
+      --border-subtle: #363235;
+      --accent: #9a8bea;
+      --accent-hover: #b1a5f0;
+      --accent-faint: rgba(154, 139, 234, .15);
+      --on-accent: #171517;
+      --success: #7fb488;
+      --danger: #e17d7d;
+      --hard-shadow: rgba(0, 0, 0, .42);
+    }
+
+    * { box-sizing: border-box; }
+    html { background: var(--canvas); }
+    body { margin: 0; color: var(--text); background: var(--canvas); font-family: var(--font-sans); line-height: 1.55; transition: color .18s ease, background .18s ease; }
+    button, input, select, textarea { font: inherit; }
+    button { color: inherit; }
+    :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    .page { width: min(1260px, calc(100% - 32px)); margin: 0 auto; padding: 48px 0 90px; }
+    .top { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 40px; align-items: end; }
+    .eyebrow { margin-bottom: 12px; color: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: .15em; text-transform: uppercase; }
+    h1 { max-width: 900px; margin: 0; font: 700 clamp(40px, 5.5vw, 70px)/1.08 var(--font-serif); letter-spacing: -.04em; }
+    .lede { max-width: 760px; margin: 19px 0 0; color: var(--text-muted); font-size: 16px; }
+    .theme-switch { display: flex; border: 1px solid var(--border-strong); background: var(--paper); }
+    .theme-switch button { min-height: 42px; padding: 8px 14px; border: 0; border-right: 1px solid var(--border-strong); background: transparent; cursor: pointer; font-size: 11px; font-weight: 700; }
+    .theme-switch button:last-child { border-right: 0; }
+    .theme-switch button[aria-pressed="true"] { color: var(--on-accent); background: var(--accent); }
+
+    .decision-strip { display: grid; grid-template-columns: repeat(4, 1fr); margin-top: 32px; border: 1px solid var(--border-strong); background: var(--paper); }
+    .decision { min-height: 116px; padding: 18px; border-right: 1px solid var(--border-default); }
+    .decision:last-child { border-right: 0; }
+    .decision b { display: block; margin-bottom: 6px; font: 700 13px/1.35 var(--font-serif); }
+    .decision span { display: block; color: var(--text-muted); font-size: 10px; }
+
+    .section { margin-top: 64px; }
+    .section-head { display: grid; grid-template-columns: 170px minmax(0,1fr); gap: 28px; margin-bottom: 18px; padding-bottom: 11px; border-bottom: 1px solid var(--border-strong); }
+    .section-index { color: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+    h2 { margin: 0; font: 700 27px/1.25 var(--font-serif); letter-spacing: -.02em; }
+    .section-head p { max-width: 720px; margin: 6px 0 0; color: var(--text-muted); font-size: 11px; }
+
+    .theme-map { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--border-strong); background: var(--paper); }
+    .theme-map article { padding: 24px; }
+    .theme-map article + article { border-left: 1px solid var(--border-default); }
+    .theme-map h3 { margin: 0 0 5px; font: 700 16px var(--font-serif); }
+    .theme-map p { margin: 0 0 18px; color: var(--text-muted); font-size: 10px; }
+    .token-row { display: grid; grid-template-columns: 34px 1fr auto; align-items: center; gap: 10px; min-height: 44px; border-bottom: 1px solid var(--border-subtle); }
+    .token-row:last-child { border-bottom: 0; }
+    .chip { width: 25px; height: 25px; border: 1px solid var(--border-default); }
+    .token-row b { font-size: 10px; }
+    .token-row code { color: var(--text-muted); font: 9px ui-monospace, monospace; }
+
+    .border-demo { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+    .demo-card { min-height: 155px; background: var(--paper); }
+    .demo-card h3 { margin: 0 0 5px; font: 700 14px var(--font-serif); }
+    .demo-card p { margin: 0; color: var(--text-muted); font-size: 10px; }
+    .accent-edge { padding: 20px; border-top: 1px solid var(--border-default); border-right: 1px solid var(--border-default); border-bottom: 1px solid var(--border-default); border-left: 4px solid var(--accent); }
+    .bad-edge { position: relative; padding: 20px 20px 20px 24px; border: 1px solid var(--border-default); opacity: .55; }
+    .bad-edge::before { content: ""; position: absolute; inset: 0 auto 0 3px; width: 4px; background: var(--accent); }
+    .verdict { margin-top: 16px; padding: 14px 16px; border-left: 4px solid var(--accent); background: var(--accent-faint); font-size: 11px; }
+
+    .app { min-height: 680px; border: 1px solid var(--border-strong); background: var(--paper); box-shadow: 4px 4px 0 var(--hard-shadow); }
+    .appbar { display: flex; align-items: center; justify-content: space-between; min-height: 68px; padding: 0 24px; border-bottom: 1px solid var(--border-strong); }
+    .logo { width: 148px; height: auto; color: var(--text); overflow: visible; }
+    .appbar-links { display: flex; gap: 22px; color: var(--text-muted); font-size: 11px; font-weight: 600; }
+    .appbar-links span.active { color: var(--text); box-shadow: inset 0 -3px 0 var(--accent); }
+    .appbody { display: grid; grid-template-columns: 210px minmax(0,1fr); min-height: 610px; }
+    .sidebar { padding: 26px 16px; border-right: 1px solid var(--border-strong); background: var(--canvas); }
+    .side-label { margin: 0 9px 10px; color: var(--text-muted); font-size: 9px; font-weight: 700; letter-spacing: .11em; text-transform: uppercase; }
+    .side-link { padding: 9px 10px; border-left: 3px solid transparent; color: var(--text-muted); font-size: 11px; }
+    .side-link.active { border-left-color: var(--accent); color: var(--text); background: var(--canvas-deep); font-weight: 700; }
+    .content { padding: 34px 38px 50px; background: color-mix(in srgb, var(--canvas) 70%, var(--paper)); }
+    .crumb { color: var(--text-muted); font-size: 9px; }
+    .title-row { display: flex; align-items: flex-end; justify-content: space-between; gap: 24px; margin: 9px 0 24px; }
+    .title-row h3 { margin: 0; font: 700 30px/1.25 var(--font-serif); }
+    .title-row p { margin: 5px 0 0; color: var(--text-muted); font-size: 10px; }
+
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 42px; padding: 8px 14px; border: 1px solid var(--border-default); border-bottom-color: var(--border-strong); color: var(--text); background: var(--paper); cursor: pointer; font-size: 11px; font-weight: 700; }
+    .button:hover { background: var(--canvas-deep); }
+    .button:active { border-bottom-color: var(--border-default); background: var(--canvas-deep); }
+    .button.primary { border-color: var(--accent-hover); color: var(--on-accent); background: var(--accent); }
+    .button.primary:hover { background: var(--accent-hover); }
+    .button.ghost { border-color: transparent; background: transparent; }
+
+    .product-grid { display: grid; grid-template-columns: minmax(0,1.3fr) minmax(250px,.7fr); gap: 18px; }
+    .panel { border: 1px solid var(--border-default); background: var(--paper); }
+    .panel-head { display: flex; justify-content: space-between; align-items: center; min-height: 49px; padding: 11px 15px; border-bottom: 1px solid var(--border-default); }
+    .panel-head b { font: 700 13px var(--font-serif); }
+    .panel-head span { color: var(--text-muted); font-size: 9px; }
+    .panel-body { padding: 17px; }
+    .fields { display: grid; grid-template-columns: 1fr 1fr; gap: 13px; }
+    .field { display: grid; gap: 5px; }
+    .field.full { grid-column: 1 / -1; }
+    .field label { font-size: 10px; font-weight: 700; }
+    .input { width: 100%; min-height: 41px; padding: 7px 9px; border: 1px solid var(--border-default); border-bottom-color: var(--border-strong); outline: 0; color: var(--text); background: var(--surface-raised); }
+    .input:focus { border-color: var(--border-strong); outline: 2px solid var(--accent); outline-offset: 1px; }
+    textarea.input { min-height: 72px; resize: vertical; }
+    .actions { display: flex; justify-content: flex-end; gap: 8px; margin-top: 15px; padding-top: 13px; border-top: 1px solid var(--border-subtle); }
+
+    .right-stack { display: grid; gap: 14px; align-content: start; }
+    .accent-card { padding: 16px; border-top: 1px solid var(--border-default); border-right: 1px solid var(--border-default); border-bottom: 1px solid var(--border-default); border-left: 4px solid var(--accent); background: var(--paper); }
+    .accent-card b { display: block; font: 700 13px var(--font-serif); }
+    .accent-card span { color: var(--text-muted); font-size: 9px; }
+    .stat { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--border-default); background: var(--paper); }
+    .stat div { padding: 14px; }
+    .stat div + div { border-left: 1px solid var(--border-default); }
+    .stat b { display: block; font: 700 21px var(--font-serif); }
+    .stat span { color: var(--text-muted); font-size: 8px; letter-spacing: .08em; text-transform: uppercase; }
+    .menu-stage { position: relative; min-height: 160px; border: 1px dashed var(--border-default); background: var(--canvas); }
+    .menu { position: absolute; top: 30px; right: 26px; width: 170px; border: 1px solid var(--border-strong); background: var(--surface-raised); box-shadow: 3px 3px 0 var(--hard-shadow); }
+    .menu div { padding: 9px 11px; border-bottom: 1px solid var(--border-default); font-size: 10px; }
+    .menu div:last-child { border-bottom: 0; color: var(--danger); }
+
+    .logo-study { display: grid; grid-template-columns: 1fr 1fr; gap: 18px; }
+    .logo-stage { display: grid; place-items: center; min-height: 260px; padding: 36px; border: 1px solid var(--border-default); background: var(--paper); }
+    .logo-stage.dark-context { color: #f2eee8; background: #222022; --accent: #9a8bea; --border-strong: #81777c; --border-default: #4e484b; }
+    .logo-stage .logo { width: min(100%, 210px); }
+    .catalog-lockup { width: min(100%, 270px); }
+    .catalog-lockup .logo { width: 190px; }
+    .catalog-meta { display: flex; justify-content: space-between; gap: 20px; margin-top: 13px; padding-top: 9px; border-top: 1px solid currentColor; opacity: .72; font-size: 8px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+    .logo-note { grid-column: 1 / -1; padding: 16px 18px; border-left: 4px solid var(--accent); background: var(--accent-faint); font-size: 11px; }
+
+    footer { margin-top: 50px; padding-top: 15px; border-top: 1px solid var(--border-strong); color: var(--text-muted); font-size: 9px; }
+
+    @media (max-width: 900px) {
+      .decision-strip { grid-template-columns: 1fr 1fr; }
+      .decision:nth-child(2) { border-right: 0; }
+      .decision:nth-child(-n+2) { border-bottom: 1px solid var(--border-default); }
+      .product-grid { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 680px) {
+      .page { width: min(100% - 18px, 1260px); padding-top: 28px; }
+      .top, .section-head { grid-template-columns: 1fr; gap: 8px; }
+      .theme-switch { width: fit-content; }
+      .decision-strip, .theme-map, .border-demo, .logo-study { grid-template-columns: 1fr; }
+      .decision { border-right: 0; border-bottom: 1px solid var(--border-default); }
+      .decision:last-child { border-bottom: 0; }
+      .theme-map article + article { border-left: 0; border-top: 1px solid var(--border-default); }
+      .appbody { grid-template-columns: 1fr; }
+      .sidebar, .appbar-links { display: none; }
+      .content { padding: 25px 14px 38px; }
+      .title-row { align-items: flex-start; flex-direction: column; }
+      .fields { grid-template-columns: 1fr; }
+      .field.full { grid-column: auto; }
+      .logo-note { grid-column: auto; }
+    }
+  </style>
+</head>
+<body>
+  <svg width="0" height="0" aria-hidden="true" style="position:absolute;overflow:hidden">
+    <symbol id="tadoku-wordmark" viewBox="0 0 158 29">
+      <path fill="currentColor" fill-rule="evenodd" clip-rule="evenodd" d="M13.8789062,28 L8.12695312,28 L8.12695312,5.66015625 L0.760742188,5.66015625 L0.760742188,0.873046875 L21.2451172,0.873046875 L21.2451172,5.66015625 L13.8789062,5.66015625 L13.8789062,28 Z M38.6123047,0.76171875 L48.2236328,28 L42.0263672,28 L40.0595703,21.5429688 L32.0318594,21.5427187 L33.4551316,16.71875 L31.6171875,16.71875 L30.1716461,21.5430603 L30.1699219,21.5429688 L28.203125,28 L22.0058594,28 L31.5800781,0.76171875 L38.6123047,0.76171875 Z M38.6865234,16.71875 C36.868155,10.8678093 35.8445649,7.55892311 35.6157227,6.79199219 C35.3868804,6.02506127 35.2229823,5.41894754 35.1240234,4.97363281 C34.7158183,6.55697406 33.5468846,10.471974 31.6171875,16.71875 L38.6865234,16.71875 Z M74.1445312,14.1767578 C74.1445312,18.6422749 72.8735479,22.0624881 70.331543,24.4375 C67.7895381,26.8125119 64.1188391,28 59.3193359,28 L51.6376953,28 L51.6376953,0.873046875 L60.1542969,0.873046875 C64.5827044,0.873046875 68.0214721,2.0419805 70.4707031,4.37988281 C72.9199341,6.71778513 74.1445312,9.98337747 74.1445312,14.1767578 Z M68.1699219,14.3251953 C68.1699219,8.49899431 65.5970309,5.5859375 60.4511719,5.5859375 L57.3896484,5.5859375 L57.3896484,23.25 L59.8574219,23.25 C65.3991162,23.25 68.1699219,20.2750949 68.1699219,14.3251953 Z M104.388672,14.3994141 C104.388672,18.8896709 103.275402,22.3408083 101.048828,24.7529297 C98.8222545,27.1650511 95.6308802,28.3710938 91.4746094,28.3710938 C87.3183386,28.3710938 84.1269643,27.1650511 81.9003906,24.7529297 C79.673817,22.3408083 78.5605469,18.8773012 78.5605469,14.3623047 C78.5605469,9.84730815 79.6769094,6.39926321 81.909668,4.01806641 C84.1424265,1.6368696 87.3430781,0.446289062 91.5117188,0.446289062 C95.6803594,0.446289062 98.8686413,1.64614686 101.07666,4.04589844 C103.284679,6.44565002 104.388672,9.89678738 104.388672,14.3994141 Z M84.5908203,14.3994141 C84.5908203,17.4300282 85.1660099,19.7122319 86.3164062,21.2460938 C87.4668026,22.7799556 89.1861865,23.546875 91.4746094,23.546875 C96.063825,23.546875 98.3583984,20.4977518 98.3583984,14.3994141 C98.3583984,8.28870643 96.0761947,5.23339844 91.5117188,5.23339844 C89.2232958,5.23339844 87.4977272,6.00341027 86.3349609,7.54345703 C85.1721947,9.08350379 84.5908203,11.3688 84.5908203,14.3994141 Z M115.762695,21.3230794 L115.762695,28 L110.010742,28 L110.010742,0.873046875 L115.762695,0.873046875 L115.762695,13.2861328 L118.026367,10.0947266 L125.374023,0.873046875 L131.756836,0.873046875 L115.762695,21.3230794 Z M157.325195,0.873046875 L157.325195,18.4257812 C157.325195,20.4296975 156.876795,22.1861904 155.97998,23.6953125 C155.083166,25.2044346 153.787443,26.3609986 152.092773,27.1650391 C150.398104,27.9690795 148.394217,28.3710938 146.081055,28.3710938 C142.592756,28.3710938 139.883799,27.4773852 137.954102,25.6899414 C136.024404,23.9024976 135.05957,21.4563957 135.05957,18.3515625 L135.05957,0.873046875 L140.792969,0.873046875 L140.792969,17.4794922 C140.792969,19.5699974 141.213537,21.1038363 142.054688,22.0810547 C142.895838,23.0582731 144.287425,23.546875 146.229492,23.546875 C148.10971,23.546875 149.473466,23.0551807 150.320801,22.0717773 C151.168136,21.088374 151.591797,19.5452579 151.591797,17.4423828 L157.325195,0.873046875 Z" />
+      <polygon fill="var(--accent)" points="131.853697 28.0167614 125.29276 28.0167614 118.760559 17.4854584 125.195374 17.4854584" />
+    </symbol>
+  </svg>
+
+  <main class="page">
+    <header class="top">
+      <div><div class="eyebrow">Bookplate refinement · third study</div><h1>Same library. After dark.</h1><p class="lede">Dark mode keeps the paper-and-ink hierarchy rather than simply inverting it. Surfaces become layered charcoal, rules stay neutral, and ink violet maps to a lighter tonal partner so the brand remains visible and accessible.</p></div>
+      <div class="theme-switch" aria-label="Preview theme"><button type="button" data-theme-choice="light" aria-pressed="true">Light</button><button type="button" data-theme-choice="dark" aria-pressed="false">Dark</button></div>
+    </header>
+
+    <div class="decision-strip">
+      <div class="decision"><b>Ink violet retained</b><span>#5747B8 in light mode maps to #9A8BEA in dark mode: same identity, appropriate luminance.</span></div>
+      <div class="decision"><b>Accent owns its edge</b><span>A colored left marker replaces the neutral hairline instead of sitting inside it.</span></div>
+      <div class="decision"><b>Softer interaction</b><span>Controls stay 1px on every side; only the bottom border color becomes darker.</span></div>
+      <div class="decision"><b>Logo rendering fixed</b><span>The original even-odd fill and independent accent wedge are restored.</span></div>
+    </div>
+
+    <section class="section">
+      <div class="section-head"><div class="section-index">01 / Dark mode</div><div><h2>Semantic tokens change tone, not structure.</h2><p>Dark mode uses charcoal surfaces rather than black, avoiding both glare and the “developer console” look. Structural relationships remain identical in both modes.</p></div></div>
+      <div class="theme-map">
+        <article><h3>Light Bookplate</h3><p>Warm paper, dark ink, quiet neutral rules.</p><div class="token-row"><i class="chip" style="background:#fffefa"></i><b>Surface</b><code>#FFFEFA</code></div><div class="token-row"><i class="chip" style="background:#f2efe8"></i><b>Canvas</b><code>#F2EFE8</code></div><div class="token-row"><i class="chip" style="background:#211a1d"></i><b>Text</b><code>#211A1D</code></div><div class="token-row"><i class="chip" style="background:#c7c0b5"></i><b>Rule</b><code>#C7C0B5</code></div><div class="token-row"><i class="chip" style="background:#5747b8"></i><b>Ink violet</b><code>#5747B8</code></div></article>
+        <article style="color:#f2eee8;background:#222022;--border-default:#4e484b;--border-subtle:#363235"><h3>Dark Bookplate</h3><p style="color:#b8b0ac">Charcoal paper, warm pale ink, lifted violet annotation.</p><div class="token-row"><i class="chip" style="background:#222022"></i><b>Surface</b><code>#222022</code></div><div class="token-row"><i class="chip" style="background:#171517"></i><b>Canvas</b><code>#171517</code></div><div class="token-row"><i class="chip" style="background:#f2eee8"></i><b>Text</b><code>#F2EEE8</code></div><div class="token-row"><i class="chip" style="background:#4e484b"></i><b>Rule</b><code>#4E484B</code></div><div class="token-row"><i class="chip" style="background:#9a8bea"></i><b>Ink violet</b><code>#9A8BEA</code></div></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-head"><div class="section-index">02 / Accent edge</div><div><h2>The accent replaces the left border.</h2><p>There is no neutral hairline underneath or outside the marker. The other three sides retain the standard component rule.</p></div></div>
+      <div class="border-demo"><article class="demo-card accent-edge"><h3>Recommended</h3><p>The violet edge is the boundary. Top, right, and bottom remain neutral.</p></article><article class="demo-card bad-edge"><h3>Previous preview</h3><p>A violet stripe sits inside a fully outlined component, creating a doubled left edge and awkward corners.</p></article></div>
+      <div class="verdict"><strong>Rule:</strong> a component may have a neutral four-sided border or an accented left edge with three neutral sides—never both left edges.</div>
+    </section>
+
+    <section class="section">
+      <div class="section-head"><div class="section-index">03 / Product</div><div><h2>Light and dark use the same component grammar.</h2><p>Toggle the theme at the top. Notice that the visual hierarchy survives without adding new border treatments or making every surface glow.</p></div></div>
+      <div class="app">
+        <div class="appbar"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-wordmark" /></svg><div class="appbar-links"><span class="active">Immersion log</span><span>Contests</span><span>Leaderboard</span><span>Blog</span></div><button class="button">AV</button></div>
+        <div class="appbody"><aside class="sidebar"><div class="side-label">Your library</div><div class="side-link active">Reading log</div><div class="side-link">Books & media</div><div class="side-link">Yearly overview</div><div class="side-link">Tags</div></aside><div class="content"><div class="crumb">Immersion log / New update</div><div class="title-row"><div><h3>Log a reading update</h3><p>Record progress without interrupting the reading habit.</p></div><button class="button primary">Save update</button></div><div class="product-grid"><section class="panel"><div class="panel-head"><b>New update</b><span>Draft</span></div><div class="panel-body"><div class="fields"><div class="field"><label for="language-v3">Language</label><select class="input" id="language-v3"><option>Japanese</option></select></div><div class="field"><label for="activity-v3">Activity</label><select class="input" id="activity-v3"><option>Reading</option></select></div><div class="field"><label for="amount-v3">Amount</label><input class="input" id="amount-v3" value="24 pages" /></div><div class="field"><label for="duration-v3">Duration</label><input class="input" id="duration-v3" value="00:35" /></div><div class="field full"><label for="notes-v3">Notes</label><textarea class="input" id="notes-v3">Finished chapter seven. The library scene was excellent.</textarea></div></div><div class="actions"><button class="button ghost">Cancel</button><button class="button primary">Save update</button></div></div></section><aside class="right-stack"><div class="accent-card"><b>August reading</b><span>12 active days · 438 total score</span></div><div class="stat"><div><b>62%</b><span>Book progress</span></div><div><b>186</b><span>Pages read</span></div></div><div class="menu-stage"><div class="menu"><div>Edit entry</div><div>Duplicate</div><div>Delete entry</div></div></div></aside></div></div></div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-head"><div class="section-index">04 / Logo correction</div><div><h2>The wordmark is intact again.</h2><p>The U and internal counters now use the original even-odd fill rule. The wedge receives ink violet independently in both themes.</p></div></div>
+      <div class="logo-study"><div class="logo-stage"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-wordmark" /></svg></div><div class="logo-stage dark-context"><div class="catalog-lockup"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-wordmark" /></svg><div class="catalog-meta"><span>Immersion log</span><span>Est. 2014</span></div></div></div><div class="logo-note"><strong>Recommendation:</strong> keep the existing wordmark as the primary mark. The catalog lockup is the only proposed addition; it adds context through typography and a rule without redrawing or distorting the logo.</div></div>
+    </section>
+
+    <footer>Temporary P0.2 design study. The audit, first Bookplate preview, and v2 study remain available at their original URLs.</footer>
+  </main>
+
+  <script>
+    function setTheme(theme) {
+      document.documentElement.dataset.theme = theme
+      document.querySelectorAll('[data-theme-choice]').forEach(button => {
+        button.setAttribute('aria-pressed', String(button.dataset.themeChoice === theme))
+      })
+    }
+
+    document.querySelectorAll('[data-theme-choice]').forEach(button => {
+      button.addEventListener('click', () => setTheme(button.dataset.themeChoice))
+    })
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-meter-v7.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-meter-v7.html
@@ -1,0 +1,280 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku Bookplate — Floating Surfaces and Meter Mark Study</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --accent: #5747b8;
+      --accent-hover: #49399f;
+      --accent-soft: #e8e4fa;
+      --float-shadow: 3px 3px 0 rgba(33, 26, 29, .16);
+      --showcase-shadow: 5px 5px 0 rgba(33, 26, 29, .13);
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --accent: #9a8bea;
+      --accent-hover: #ac9ff1;
+      --accent-soft: #332d52;
+      --float-shadow: 3px 3px 0 rgba(0, 0, 0, .48);
+      --showcase-shadow: 5px 5px 0 rgba(0, 0, 0, .42);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--canvas); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; }
+    button { font: inherit; color: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2 { font-family: Georgia, "Times New Roman", serif; }
+    h1 { max-width: 900px; margin-bottom: 16px; font-size: clamp(38px, 6vw, 68px); line-height: .98; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-size: clamp(26px, 3vw, 37px); line-height: 1.08; }
+    h3 { margin-bottom: 7px; font-size: 16px; }
+    p { color: var(--muted); }
+    .page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 52px; }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 850; letter-spacing: .14em; text-transform: uppercase; }
+    .lede, .section-intro { max-width: 800px; }
+    .lede { font-size: 18px; }
+    .section { margin-top: 54px; }
+    .section-intro { margin-bottom: 22px; }
+    .btn { display: inline-flex; min-height: 42px; align-items: center; justify-content: center; padding: 9px 15px 8px; border: 1px solid var(--rule-strong); border-bottom-width: 2px; border-radius: 0; background: var(--surface); cursor: pointer; font-weight: 750; }
+    .btn:hover { background: var(--surface-soft); }
+    .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-toggle { flex: none; }
+
+    .floating-system { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+    .surface-study { min-height: 260px; padding: 22px; border: 1px solid var(--rule); background: var(--surface-soft); }
+    .surface-study h3 { margin-bottom: 4px; }
+    .surface-study > p { font-size: 13px; }
+    .surface-demo { margin-top: 24px; background: var(--surface); }
+    .surface-demo.inline { padding: 18px; border: 1px solid var(--rule); }
+    .surface-demo.floating { padding: 18px; border: 1px solid var(--rule-strong); box-shadow: var(--float-shadow); }
+    .surface-demo.showcase { padding: 18px; border: 1px solid var(--rule-strong); box-shadow: var(--showcase-shadow); }
+    .surface-demo strong { display: block; margin-bottom: 4px; }
+    .surface-demo span { color: var(--muted); font-size: 12px; }
+    .usage-rule { display: grid; grid-template-columns: 180px 1fr; margin-top: 18px; border: 1px solid var(--rule-strong); background: var(--surface); }
+    .usage-rule strong { padding: 18px; border-right: 1px solid var(--rule); font-family: Georgia, serif; }
+    .usage-rule p { margin: 0; padding: 18px; font-size: 13px; }
+
+    .reference-note { display: grid; grid-template-columns: 170px 1fr; gap: 24px; align-items: center; margin-bottom: 20px; padding: 20px; border-left: 6px solid var(--accent); background: var(--surface); }
+    .reference-bars { display: flex; height: 72px; align-items: end; justify-content: center; gap: 9px; }
+    .reference-bars i { display: block; width: 22px; background: var(--text); }
+    .reference-bars i:nth-child(1) { height: 28px; }
+    .reference-bars i:nth-child(2) { height: 49px; }
+    .reference-bars i:nth-child(3) { height: 70px; }
+    .reference-note p { margin: 0; font-size: 14px; }
+
+    .marks { display: grid; grid-template-columns: repeat(5, 1fr); gap: 12px; }
+    .mark-card { display: flex; min-height: 500px; flex-direction: column; border: 1px solid var(--rule); background: var(--surface); }
+    .mono-stage { display: grid; min-height: 198px; place-items: center; border-bottom: 1px solid var(--rule); background: var(--surface); }
+    .mark-copy { display: flex; flex: 1; flex-direction: column; padding: 17px; }
+    .mark-copy p { margin-bottom: 14px; font-size: 14px; }
+    .mark-name { margin-bottom: 7px; }
+    .tag { display: inline-block; align-self: flex-start; margin-bottom: 8px; padding: 3px 6px; background: var(--accent-soft); color: var(--accent); font-size: 10px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; }
+    .mark-tests { display: grid; grid-template-columns: 1fr 1fr; gap: 1px; margin-top: auto; border: 1px solid var(--rule); background: var(--rule); }
+    .mark-test { display: grid; min-height: 78px; place-items: center; background: var(--surface); }
+    .mark-test.reverse { background: var(--text); color: var(--surface); }
+    .lockup { display: flex; align-items: center; gap: 9px; padding-top: 13px; }
+    .wordmark { font-size: 14px; font-weight: 900; letter-spacing: .13em; }
+    .mark { display: block; color: currentColor; }
+    .mark.hero { width: 100px; height: 100px; }
+    .mark.test { width: 34px; height: 34px; }
+    .mark.lock { width: 29px; height: 29px; }
+    .ink { fill: currentColor; }
+    .accent { fill: var(--accent); }
+    .accent-version .accentable { fill: var(--accent); }
+    .mono-version .accentable { fill: currentColor; }
+    .test-label { margin-left: auto; color: var(--muted); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
+    .design-rule { margin-top: 20px; padding: 21px 24px; border: 1px solid var(--rule-strong); background: var(--surface); box-shadow: var(--float-shadow); }
+    .design-rule p:last-child { margin-bottom: 0; }
+
+    @media (max-width: 1000px) {
+      .marks { grid-template-columns: repeat(2, 1fr); }
+      .floating-system { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1180px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .marks { grid-template-columns: 1fr; }
+      .usage-rule, .reference-note { grid-template-columns: 1fr; }
+      .usage-rule strong { border-right: 0; border-bottom: 1px solid var(--rule); }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tadoku design discussion · P0.2 · Study 7</p>
+        <h1>Hard-edged lift and a simpler mark.</h1>
+        <p class="lede">This pass promotes the floating treatment into the design language and narrows the logo exploration to a restrained meter family: one-color first, violet optional.</p>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">01 · Elevation role</p>
+        <h2>Floating is structural, not soft</h2>
+        <p>The hard offset shadow from the second Bookplate study fits the old print and library character. It becomes a named surface role with strict scope, alongside inline and showcase surfaces.</p>
+      </div>
+      <div class="floating-system">
+        <article class="surface-study">
+          <h3>Inline</h3>
+          <p>Normal cards and sections remain flat.</p>
+          <div class="surface-demo inline"><strong>Reading summary</strong><span>1px warm neutral boundary</span></div>
+        </article>
+        <article class="surface-study">
+          <h3>Floating</h3>
+          <p>Menus, popovers, date pickers, and dialogs.</p>
+          <div class="surface-demo floating"><strong>Choose a contest</strong><span>1px strong edge + 3px hard offset</span></div>
+        </article>
+        <article class="surface-study">
+          <h3>Showcase</h3>
+          <p>Rare branded shells and editorial specimens.</p>
+          <div class="surface-demo showcase"><strong>August Tadoku</strong><span>1px strong edge + 5px hard offset</span></div>
+        </article>
+      </div>
+      <div class="usage-rule"><strong>Approved direction</strong><p>Include hard-edged elevation in the design language. Use 3px floating depth for overlays and 5px showcase depth sparingly. Ordinary cards stay flat so elevation continues to communicate layer and importance.</p></div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Compact mark</p>
+        <h2>A meter family, tested without color</h2>
+        <p>The Bookmeter reference succeeds because three growing bars communicate accumulation immediately. These are original Tadoku-oriented variations on that broad idea—not redraws of its exact proportions. Every hero mark below is monochrome.</p>
+      </div>
+      <div class="reference-note">
+        <div class="reference-bars" aria-label="Three growing bars"><i></i><i></i><i></i></div>
+        <p><strong>What to borrow as a principle:</strong> very few shapes, a clear rhythm, and meaning visible in silhouette. <strong>What not to borrow:</strong> Bookmeter’s exact three-bar proportions or its green treatment. Tadoku needs its own construction.</p>
+      </div>
+
+      <div class="marks">
+        <article class="mark-card">
+          <div class="mono-stage">
+            <svg class="mark hero mono-version" viewBox="0 0 64 64" role="img" aria-label="Three Beat Meter monochrome logo">
+              <path class="ink" d="M8 39h12v17H8zM26 26h12v30H26zM44 8h12v48H44z"/>
+            </svg>
+          </div>
+          <div class="mark-copy">
+            <span class="tag">Pure meter</span>
+            <h3 class="mark-name">1 · Three Beat</h3>
+            <p>The clearest possible growth mark. Uneven height changes feel like listening beats as well as tracked progress.</p>
+            <div class="mark-tests">
+              <div class="mark-test reverse"><svg class="mark test" viewBox="0 0 64 64"><path class="ink" d="M8 39h12v17H8zM26 26h12v30H26zM44 8h12v48H44z"/></svg></div>
+              <div class="mark-test"><svg class="mark test accent-version" viewBox="0 0 64 64"><path class="ink" d="M8 39h12v17H8zM26 26h12v30H26z"/><path class="accentable" d="M44 8h12v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><path class="ink" d="M8 39h12v17H8zM26 26h12v30H26zM44 8h12v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="mark-card">
+          <div class="mono-stage">
+            <svg class="mark hero mono-version" viewBox="0 0 64 64" role="img" aria-label="Page Meter monochrome logo">
+              <path class="ink" d="M7 38h13v18H7zM25 25h14v31H25zM44 8h13v48H44z"/>
+              <path fill="var(--surface)" d="M7 38l13-7v7zM25 25l14-7v7zM44 8l13-7v7z"/>
+            </svg>
+          </div>
+          <div class="mark-copy">
+            <span class="tag">Reading + growth</span>
+            <h3 class="mark-name">2 · Page Meter</h3>
+            <p>Three rising bars with identical page-like notches. The silhouette remains simple while the repeated cut gives it a Tadoku-specific detail.</p>
+            <div class="mark-tests">
+              <div class="mark-test reverse"><svg class="mark test" viewBox="0 0 64 64"><path class="ink" d="M7 38h13v18H7zM25 25h14v31H25zM44 8h13v48H44z"/><path fill="var(--text)" d="M7 38l13-7v7zM25 25l14-7v7zM44 8l13-7v7z"/></svg></div>
+              <div class="mark-test"><svg class="mark test accent-version" viewBox="0 0 64 64"><path class="ink" d="M7 38h13v18H7zM25 25h14v31H25z"/><path class="accentable" d="M44 8h13v48H44z"/><path fill="var(--surface)" d="M7 38l13-7v7zM25 25l14-7v7zM44 8l13-7v7z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><path class="ink" d="M7 38h13v18H7zM25 25h14v31H25zM44 8h13v48H44z"/><path fill="var(--surface)" d="M7 38l13-7v7zM25 25l14-7v7zM44 8l13-7v7z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="mark-card">
+          <div class="mono-stage">
+            <svg class="mark hero mono-version" viewBox="0 0 64 64" role="img" aria-label="Cut Meter monochrome logo">
+              <defs><mask id="cut-hero"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="7"/></mask></defs>
+              <path class="ink" mask="url(#cut-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="mark-copy">
+            <span class="tag">Weave simplified</span>
+            <h3 class="mark-name">3 · Cut Meter</h3>
+            <p>A single diagonal passage cuts through three rising bars. It preserves the directional energy of Language Weave using only one silhouette and negative space.</p>
+            <div class="mark-tests">
+              <div class="mark-test reverse"><svg class="mark test" viewBox="0 0 64 64"><defs><mask id="cut-reverse"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="8"/></mask></defs><path class="ink" mask="url(#cut-reverse)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="mark-test"><svg class="mark test accent-version" viewBox="0 0 64 64"><defs><mask id="cut-accent"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="8"/></mask></defs><g mask="url(#cut-accent)"><path class="ink" d="M7 38h13v18H7zM25 24h14v32H25z"/><path class="accentable" d="M44 8h13v48H44z"/></g></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="cut-lock"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="8"/></mask></defs><path class="ink" mask="url(#cut-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="mark-card">
+          <div class="mono-stage">
+            <svg class="mark hero mono-version" viewBox="0 0 64 64" role="img" aria-label="Signal Rise monochrome logo">
+              <path class="ink" d="M6 43h9v13H6zM18 31h9v25h-9zM30 37h9v19h-9zM42 20h9v36h-9zM54 8h5v48h-5z"/>
+            </svg>
+          </div>
+          <div class="mark-copy">
+            <span class="tag">Listening + progress</span>
+            <h3 class="mark-name">4 · Signal Rise</h3>
+            <p>A five-beat waveform whose overall trend still rises. It broadens the association from pages to listening and media without drawing headphones.</p>
+            <div class="mark-tests">
+              <div class="mark-test reverse"><svg class="mark test" viewBox="0 0 64 64"><path class="ink" d="M6 43h9v13H6zM18 31h9v25h-9zM30 37h9v19h-9zM42 20h9v36h-9zM54 8h5v48h-5z"/></svg></div>
+              <div class="mark-test"><svg class="mark test accent-version" viewBox="0 0 64 64"><path class="ink" d="M6 43h9v13H6zM18 31h9v25h-9zM30 37h9v19h-9zM42 20h9v36h-9z"/><path class="accentable" d="M54 8h5v48h-5z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><path class="ink" d="M6 43h9v13H6zM18 31h9v25h-9zM30 37h9v19h-9zM42 20h9v36h-9zM54 8h5v48h-5z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="mark-card">
+          <div class="mono-stage">
+            <svg class="mark hero mono-version" viewBox="0 0 64 64" role="img" aria-label="Stacked Measure monochrome logo">
+              <path class="ink" d="M8 10h27v11H8zM8 27h39v11H8zM8 44h50v11H8z"/>
+            </svg>
+          </div>
+          <div class="mark-copy">
+            <span class="tag">Library + tracking</span>
+            <h3 class="mark-name">5 · Stacked Measure</h3>
+            <p>Growth expressed horizontally, like stacked books or measured activity. It is distinct from the familiar vertical chart while staying extremely simple.</p>
+            <div class="mark-tests">
+              <div class="mark-test reverse"><svg class="mark test" viewBox="0 0 64 64"><path class="ink" d="M8 10h27v11H8zM8 27h39v11H8zM8 44h50v11H8z"/></svg></div>
+              <div class="mark-test"><svg class="mark test accent-version" viewBox="0 0 64 64"><path class="ink" d="M8 10h27v11H8zM8 27h39v11H8z"/><path class="accentable" d="M8 44h50v11H8z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><path class="ink" d="M8 10h27v11H8zM8 27h39v11H8zM8 44h50v11H8z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+      </div>
+
+      <div class="design-rule">
+        <p class="eyebrow">Non-negotiable logo rule</p>
+        <h3>Black first. Reverse second. Accent third.</h3>
+        <p>The selected mark must be distinctive as a single-color SVG, work reversed on a dark field, and remain legible at 16px. Ink violet may emphasize one existing piece of the construction, but it cannot create the construction or rescue its meaning.</p>
+      </div>
+    </section>
+  </main>
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-preview.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-preview.html
@@ -1,0 +1,300 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tadoku UI — Bookplate Direction Preview</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink: #211a1d;
+      --ink-soft: #5d575a;
+      --violet: #5b5bea;
+      --violet-dark: #4848cf;
+      --paper: #fffefa;
+      --canvas: #f2efe8;
+      --canvas-cool: #f4f4f6;
+      --rule: #d8d3c8;
+      --rule-dark: #aaa49a;
+      --success-bg: #e5f3e3;
+      --success-ink: #29592f;
+      --danger: #c83737;
+      --shadow-hard: 5px 5px 0 rgba(33, 26, 29, .12);
+      --font-sans: "Open Sans", ui-sans-serif, system-ui, sans-serif;
+      --font-serif: "Merriweather", Georgia, serif;
+    }
+
+    * { box-sizing: border-box; }
+    body { margin: 0; color: var(--ink); background: var(--canvas); font-family: var(--font-sans); line-height: 1.5; }
+    button, input, select { font: inherit; }
+    button { color: inherit; }
+    a { color: inherit; }
+    :focus-visible { outline: 2px solid var(--violet); outline-offset: 2px; }
+
+    .page { width: min(1440px, calc(100% - 32px)); margin: 0 auto; padding: 46px 0 80px; }
+    .intro { display: grid; grid-template-columns: minmax(0, 1fr) auto; gap: 40px; align-items: end; margin-bottom: 28px; }
+    .kicker { margin-bottom: 14px; color: var(--violet-dark); font-size: 11px; font-weight: 700; letter-spacing: .16em; text-transform: uppercase; }
+    h1 { max-width: 850px; margin: 0; font: 700 clamp(38px, 5vw, 68px)/1.08 var(--font-serif); letter-spacing: -.035em; }
+    .intro p { max-width: 720px; margin: 18px 0 0; color: var(--ink-soft); font-size: 17px; }
+
+    .mode-switch { display: flex; border: 1px solid var(--ink); border-bottom-width: 3px; background: var(--paper); }
+    .mode-switch button { min-height: 42px; padding: 8px 14px; border: 0; border-right: 1px solid var(--ink); background: transparent; cursor: pointer; font-size: 12px; font-weight: 700; }
+    .mode-switch button:last-child { border-right: 0; }
+    .mode-switch button[aria-pressed="true"] { color: white; background: var(--ink); }
+
+    .notes { display: grid; grid-template-columns: repeat(5, 1fr); border: 1px solid var(--rule-dark); border-bottom-width: 3px; background: var(--paper); }
+    .note { min-height: 106px; padding: 17px 18px; border-right: 1px solid var(--rule); }
+    .note:last-child { border-right: 0; }
+    .note b { display: block; margin-bottom: 7px; font: 700 14px/1.3 var(--font-serif); }
+    .note span { display: block; color: var(--ink-soft); font-size: 11px; }
+
+    .specimen-label { display: flex; align-items: center; gap: 12px; margin: 50px 0 14px; font-size: 11px; font-weight: 700; letter-spacing: .13em; text-transform: uppercase; }
+    .specimen-label::after { content: ""; flex: 1; height: 1px; background: var(--rule-dark); }
+
+    .app { min-height: 820px; overflow: hidden; border: 1px solid var(--ink); background: var(--paper); box-shadow: 8px 8px 0 rgba(33, 26, 29, .14); }
+    .appbar { display: flex; align-items: center; justify-content: space-between; min-height: 68px; padding: 0 26px; border-bottom: 1px solid var(--ink); background: var(--paper); }
+    .wordmark { position: relative; font-size: 20px; font-weight: 800; letter-spacing: .06em; }
+    .wordmark::after { content: ""; position: absolute; right: 20px; bottom: -3px; width: 15px; height: 4px; background: var(--violet); transform: skew(32deg); }
+    .toplinks { display: flex; gap: 24px; color: var(--ink-soft); font-size: 12px; font-weight: 600; }
+    .toplinks span.active { color: var(--ink); text-decoration: underline 3px var(--violet); text-underline-offset: 9px; }
+    .avatar { display: grid; place-items: center; width: 36px; height: 36px; border: 1px solid var(--ink); background: var(--canvas); font-size: 11px; font-weight: 700; }
+
+    .appbody { display: grid; grid-template-columns: 218px minmax(0, 1fr); min-height: 752px; }
+    .sidebar { padding: 28px 18px; border-right: 1px solid var(--ink); background: #f9f7f1; }
+    .sidebar-title { margin: 0 10px 16px; color: var(--ink-soft); font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+    .navitem { display: flex; align-items: center; gap: 10px; min-height: 40px; padding: 8px 10px; border-left: 3px solid transparent; color: var(--ink-soft); font-size: 12px; }
+    .navitem.active { border-left-color: var(--violet); color: var(--ink); background: #ebe9e2; font-weight: 700; }
+    .navitem svg { width: 16px; height: 16px; }
+
+    .content { padding: 38px 42px 60px; min-width: 0; background: #f6f4ef; }
+    .crumb { color: #787176; font-size: 11px; }
+    .heading-row { display: flex; justify-content: space-between; gap: 28px; align-items: flex-end; margin: 12px 0 28px; }
+    h2 { margin: 0; font: 700 34px/1.2 var(--font-serif); letter-spacing: -.02em; }
+    .heading-row p { margin: 8px 0 0; color: var(--ink-soft); font-size: 13px; }
+
+    .button { display: inline-flex; align-items: center; justify-content: center; gap: 8px; min-height: 44px; padding: 8px 16px; border: 1px solid var(--ink); border-bottom-width: 3px; background: var(--paper); cursor: pointer; font-size: 13px; font-weight: 700; text-decoration: none; }
+    .button:hover { background: #f0eee8; }
+    .button:active { transform: translateY(1px); border-bottom-width: 2px; }
+    .button.primary { border-color: var(--violet-dark); color: white; background: var(--violet); }
+    .button.primary:hover { background: var(--violet-dark); }
+    .button.danger { border-color: #982a2a; color: white; background: var(--danger); }
+    .button.ghost { border-color: transparent; border-bottom-color: transparent; background: transparent; }
+    .button.compact { min-height: 36px; padding: 5px 11px; font-size: 12px; }
+    .button svg { width: 16px; height: 16px; }
+
+    .layout { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(280px, .65fr); gap: 22px; }
+    .stack { display: grid; gap: 18px; align-content: start; }
+    .panel { border: 1px solid var(--rule-dark); background: var(--paper); }
+    .panel.emphasis { border-color: var(--ink); border-bottom-width: 3px; }
+    .panel-header { display: flex; justify-content: space-between; gap: 18px; align-items: center; min-height: 52px; padding: 12px 16px; border-bottom: 1px solid var(--rule); }
+    .panel-header h3 { margin: 0; font: 700 15px/1.3 var(--font-serif); }
+    .panel-header span { color: var(--ink-soft); font-size: 11px; }
+    .panel-body { padding: 18px; }
+
+    .notice { display: grid; grid-template-columns: 4px 1fr; border: 1px solid #9ab89b; color: var(--success-ink); background: var(--success-bg); }
+    .notice::before { content: ""; background: #3f7b48; }
+    .notice div { padding: 12px 14px; font-size: 12px; }
+    .notice strong { display: block; margin-bottom: 2px; }
+
+    .fields { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+    .field { display: grid; gap: 6px; }
+    .field.full { grid-column: 1 / -1; }
+    .field label { font-size: 12px; font-weight: 700; }
+    .field small { color: var(--ink-soft); font-size: 10px; font-weight: 400; }
+    .input, .select { width: 100%; min-height: 44px; padding: 8px 11px; border: 1px solid var(--rule-dark); border-bottom: 2px solid var(--ink); color: var(--ink); background: white; outline: 0; }
+    .input:focus, .select:focus { border-color: var(--violet); box-shadow: 0 0 0 2px rgba(91,91,234,.19); }
+    textarea.input { min-height: 78px; resize: vertical; }
+    .form-actions { display: flex; gap: 10px; justify-content: flex-end; margin-top: 18px; padding-top: 16px; border-top: 1px solid var(--rule); }
+
+    .book-card { border: 1px solid var(--ink); border-bottom-width: 3px; background: var(--paper); }
+    .book-card-top { display: grid; grid-template-columns: 56px 1fr; gap: 14px; padding: 16px; }
+    .cover { display: grid; place-items: center; width: 56px; height: 76px; border: 1px solid #272329; color: #f3efe7; background: #46404a; font: 700 8px/1.4 var(--font-serif); text-align: center; }
+    .book-card h4 { margin: 2px 0 5px; font: 700 14px/1.35 var(--font-serif); }
+    .book-card p { margin: 0; color: var(--ink-soft); font-size: 11px; }
+    .progress { height: 5px; margin-top: 13px; border-top: 1px solid var(--rule-dark); border-bottom: 1px solid var(--rule-dark); background: #ece9e1; }
+    .progress i { display: block; width: 62%; height: 100%; background: var(--violet); }
+    .book-meta { display: grid; grid-template-columns: repeat(3, 1fr); border-top: 1px solid var(--rule); }
+    .book-meta div { padding: 10px 12px; border-right: 1px solid var(--rule); }
+    .book-meta div:last-child { border-right: 0; }
+    .book-meta b { display: block; font-size: 12px; }
+    .book-meta span { color: var(--ink-soft); font-size: 9px; text-transform: uppercase; letter-spacing: .08em; }
+
+    .table-wrap { overflow-x: auto; border: 1px solid var(--rule-dark); background: white; }
+    table { width: 100%; min-width: 560px; border-collapse: collapse; }
+    th { padding: 10px 13px; border-bottom: 2px solid var(--ink); color: var(--ink-soft); background: #eeece6; font-size: 10px; letter-spacing: .07em; text-align: left; text-transform: uppercase; }
+    td { padding: 12px 13px; border-bottom: 1px solid var(--rule); font-size: 11px; }
+    tr:last-child td { border-bottom: 0; }
+    td.score { font-weight: 700; text-align: right; }
+    .tag { display: inline-flex; padding: 2px 6px; border: 1px solid var(--rule-dark); background: #f2f0ea; color: var(--ink-soft); font-size: 9px; }
+
+    .popover-demo { position: relative; display: flex; align-items: center; justify-content: flex-end; min-height: 150px; padding-right: 26px; border: 1px dashed var(--rule-dark); background: #f4f1ea; }
+    .popover { position: absolute; top: 54px; right: 26px; z-index: 2; width: 190px; border: 1px solid var(--ink); background: white; box-shadow: var(--shadow-hard); }
+    .popover a { display: block; padding: 10px 12px; border-bottom: 1px solid var(--rule); font-size: 11px; text-decoration: none; }
+    .popover a:last-child { border-bottom: 0; color: var(--danger); }
+    .popover a:hover { background: #f0eee8; }
+
+    .interpretation { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin-top: 30px; }
+    .interpretation article { padding: 22px; border: 1px solid var(--rule-dark); background: var(--paper); }
+    .interpretation h3 { margin: 0 0 9px; font: 700 16px/1.35 var(--font-serif); }
+    .interpretation p { margin: 0; color: var(--ink-soft); font-size: 12px; }
+
+    /* Flat archival comparison mode: same sharp geometry, less tactile weight. */
+    body.flat .button,
+    body.flat .mode-switch,
+    body.flat .notes,
+    body.flat .panel.emphasis,
+    body.flat .book-card { border-bottom-width: 1px; }
+    body.flat .input,
+    body.flat .select { border-bottom-color: var(--rule-dark); border-bottom-width: 1px; }
+    body.flat .app,
+    body.flat .popover { box-shadow: none; }
+    body.flat .panel.emphasis { border-color: var(--rule-dark); }
+
+    @media (max-width: 1000px) {
+      .intro { grid-template-columns: 1fr; align-items: start; }
+      .mode-switch { width: fit-content; }
+      .notes { grid-template-columns: repeat(2, 1fr); }
+      .note { border-bottom: 1px solid var(--rule); }
+      .layout { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 700px) {
+      .page { width: min(100% - 18px, 1440px); padding-top: 28px; }
+      .appbody { grid-template-columns: 1fr; }
+      .sidebar, .toplinks { display: none; }
+      .content { padding: 26px 16px 40px; }
+      .heading-row { align-items: flex-start; flex-direction: column; }
+      .notes, .fields, .interpretation { grid-template-columns: 1fr; }
+      .note { border-right: 0; }
+      .field.full { grid-column: auto; }
+      .appbar { padding: 0 16px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="intro">
+      <div>
+        <div class="kicker">Tadoku visual grammar study · P0.2</div>
+        <h1>Sharp, tactile, and quietly bookish.</h1>
+        <p>This preview keeps every edge square. The “Bookplate” direction creates refinement through typographic hierarchy, paper-like surfaces, ruled borders, and deliberate weight under interactive controls.</p>
+      </div>
+      <div class="mode-switch" aria-label="Compare depth treatments">
+        <button id="bookplate" type="button" aria-pressed="true">Bookplate</button>
+        <button id="flat" type="button" aria-pressed="false">Flat archival</button>
+      </div>
+    </header>
+
+    <section class="notes" aria-label="Design rules demonstrated">
+      <div class="note"><b>Zero radius</b><span>Cards, controls, menus, tags, and navigation retain square corners.</span></div>
+      <div class="note"><b>Weighted controls</b><span>A heavier lower rule makes actions feel tactile without becoming glossy.</span></div>
+      <div class="note"><b>Paper & ink</b><span>Warm canvas, near-black ink, and ruled separators support the library character.</span></div>
+      <div class="note"><b>Selective depth</b><span>Hard offset shadows are reserved for the app frame and floating menu.</span></div>
+      <div class="note"><b>Violet markers</b><span>The brand color acts like an annotation: active rules, progress, and primary action.</span></div>
+    </section>
+
+    <div class="specimen-label">Product specimen</div>
+    <section class="app" aria-label="Tadoku interface rendered in the Bookplate direction">
+      <header class="appbar">
+        <div class="wordmark">TADOKU</div>
+        <div class="toplinks"><span class="active">Immersion log</span><span>Contests</span><span>Leaderboard</span><span>Blog</span></div>
+        <div class="avatar">AV</div>
+      </header>
+      <div class="appbody">
+        <aside class="sidebar">
+          <div class="sidebar-title">Your library</div>
+          <div class="navitem active"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 5h16v14H4zM8 5v14M12 9h5M12 13h5"/></svg>Reading log</div>
+          <div class="navitem"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><path d="M4 19.5A2.5 2.5 0 016.5 17H20V4H6.5A2.5 2.5 0 004 6.5v13z"/></svg>Books & media</div>
+          <div class="navitem"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8"><circle cx="12" cy="12" r="8"/><path d="M12 8v8M8 12h8"/></svg>New update</div>
+          <div class="sidebar-title" style="margin-top:28px">Browse</div>
+          <div class="navitem">Yearly overview</div>
+          <div class="navitem">Tags</div>
+          <div class="navitem">Export</div>
+        </aside>
+
+        <div class="content">
+          <div class="crumb">Immersion log / 2026 / August</div>
+          <div class="heading-row">
+            <div><h2>Reading log</h2><p>A quiet record of what you have read, watched, and listened to.</p></div>
+            <button class="button primary"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>Log update</button>
+          </div>
+
+          <div class="layout">
+            <div class="stack">
+              <div class="notice"><div><strong>Update recorded</strong>Your 24 pages of Japanese reading were added to the August log.</div></div>
+
+              <section class="panel emphasis">
+                <div class="panel-header"><div><h3>New reading update</h3><span>Fields marked required must be completed.</span></div><span>Draft</span></div>
+                <div class="panel-body">
+                  <div class="fields">
+                    <div class="field"><label for="language">Language</label><select class="select" id="language"><option>Japanese</option></select></div>
+                    <div class="field"><label for="activity">Activity</label><select class="select" id="activity"><option>Reading</option></select></div>
+                    <div class="field"><label for="amount">Amount <small>pages</small></label><input class="input" id="amount" value="24" /></div>
+                    <div class="field"><label for="duration">Duration <small>optional</small></label><input class="input" id="duration" value="00:35" /></div>
+                    <div class="field full"><label for="notes">Notes</label><textarea class="input" id="notes">Finished chapter 7. The library scene was excellent.</textarea></div>
+                  </div>
+                  <div class="form-actions"><button class="button ghost">Cancel</button><button class="button primary">Save update</button></div>
+                </div>
+              </section>
+
+              <section>
+                <div class="panel-header" style="padding-inline:0"><div><h3>Recent entries</h3><span>August 2026</span></div><button class="button compact">View all</button></div>
+                <div class="table-wrap">
+                  <table>
+                    <thead><tr><th>Date</th><th>Entry</th><th>Tags</th><th style="text-align:right">Score</th></tr></thead>
+                    <tbody>
+                      <tr><td>Aug 7</td><td><strong>Sword Art Online v15</strong><br />24 pages · Japanese</td><td><span class="tag">light novel</span></td><td class="score">24</td></tr>
+                      <tr><td>Aug 6</td><td><strong>NHK Easy</strong><br />3 articles · Japanese</td><td><span class="tag">news</span></td><td class="score">9</td></tr>
+                      <tr><td>Aug 4</td><td><strong>Frieren episode 18</strong><br />24 minutes · Japanese</td><td><span class="tag">anime</span></td><td class="score">12</td></tr>
+                    </tbody>
+                  </table>
+                </div>
+              </section>
+            </div>
+
+            <aside class="stack">
+              <article class="book-card">
+                <div class="book-card-top"><div class="cover">本<br />LIGHT<br />NOVEL</div><div><p>Currently reading</p><h4>Sword Art Online, Volume 15</h4><p>Japanese · Light novel</p><div class="progress"><i></i></div></div></div>
+                <div class="book-meta"><div><b>62%</b><span>Progress</span></div><div><b>186</b><span>Pages</span></div><div><b>7</b><span>Sessions</span></div></div>
+              </article>
+
+              <section class="panel">
+                <div class="panel-header"><div><h3>August</h3><span>Monthly progress</span></div></div>
+                <div class="panel-body" style="display:grid;grid-template-columns:1fr 1fr;gap:16px"><div><strong style="font:700 24px var(--font-serif)">438</strong><br /><span style="font-size:10px;color:var(--ink-soft)">TOTAL SCORE</span></div><div><strong style="font:700 24px var(--font-serif)">12</strong><br /><span style="font-size:10px;color:var(--ink-soft)">ACTIVE DAYS</span></div></div>
+              </section>
+
+              <div class="popover-demo">
+                <button class="button compact">Actions ▾</button>
+                <div class="popover"><a href="#">Edit entry</a><a href="#">Duplicate</a><a href="#">Delete entry</a></div>
+              </div>
+            </aside>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="interpretation">
+      <article><h3>Bookplate mode</h3><p>Interactive controls carry a heavier lower rule, and floating surfaces use a hard offset shadow. It feels physical, like a labeled drawer, bookplate, or stamped library card.</p></article>
+      <article><h3>Flat archival mode</h3><p>The toggle removes weighted edges and shadows while keeping the exact same square geometry. Use it to judge whether the tactile treatment adds character or merely noise.</p></article>
+    </section>
+  </main>
+
+  <script>
+    const bookplate = document.getElementById('bookplate')
+    const flat = document.getElementById('flat')
+
+    function setMode(mode) {
+      const isFlat = mode === 'flat'
+      document.body.classList.toggle('flat', isFlat)
+      bookplate.setAttribute('aria-pressed', String(!isFlat))
+      flat.setAttribute('aria-pressed', String(isFlat))
+    }
+
+    bookplate.addEventListener('click', () => setMode('bookplate'))
+    flat.addEventListener('click', () => setMode('flat'))
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-bookplate-refinement-v2.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-bookplate-refinement-v2.html
@@ -1,0 +1,266 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Tadoku UI — Bookplate Refinement Study</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&family=Open+Sans:wght@400;500;600;700&display=swap" rel="stylesheet" />
+  <style>
+    :root {
+      --ink: #211a1d;
+      --ink-muted: #625b5f;
+      --paper: #fffefa;
+      --canvas: #f2efe8;
+      --canvas-deep: #e8e3d9;
+      --border-strong: #393235;
+      --border-default: #c7c0b5;
+      --border-subtle: #e2ddd4;
+      --accent: #5747b8;
+      --accent-hover: #46389d;
+      --accent-faint: rgba(87, 71, 184, .10);
+      --status-success: #3f7048;
+      --status-danger: #a33333;
+      --font-serif: "Merriweather", Georgia, serif;
+      --font-sans: "Open Sans", ui-sans-serif, system-ui, sans-serif;
+    }
+
+    * { box-sizing: border-box; }
+    body { margin: 0; color: var(--ink); background: var(--canvas); font-family: var(--font-sans); line-height: 1.55; }
+    button, input, select { font: inherit; }
+    button { color: inherit; }
+    :focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+    .page { width: min(1260px, calc(100% - 32px)); margin: 0 auto; padding: 54px 0 90px; }
+    .eyebrow { margin-bottom: 13px; color: var(--accent); font-size: 11px; font-weight: 700; letter-spacing: .14em; text-transform: uppercase; }
+    h1 { max-width: 920px; margin: 0; font: 700 clamp(40px, 5.5vw, 70px)/1.08 var(--font-serif); letter-spacing: -.04em; }
+    .lede { max-width: 760px; margin: 20px 0 0; color: var(--ink-muted); font-size: 17px; }
+    .decision { margin: 30px 0 0; padding: 18px 20px; border-left: 4px solid var(--accent); background: var(--paper); font-size: 13px; }
+    .decision strong { font-family: var(--font-serif); }
+
+    .section { margin-top: 64px; }
+    .section-heading { display: grid; grid-template-columns: 175px minmax(0,1fr); gap: 30px; margin-bottom: 20px; padding-bottom: 12px; border-bottom: 1px solid var(--border-strong); }
+    .section-number { color: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: .12em; text-transform: uppercase; }
+    h2 { margin: 0; font: 700 27px/1.25 var(--font-serif); letter-spacing: -.02em; }
+    .section-heading p { max-width: 690px; margin: 7px 0 0; color: var(--ink-muted); font-size: 12px; }
+
+    .border-system { display: grid; grid-template-columns: repeat(4, 1fr); border: 1px solid var(--border-strong); background: var(--paper); }
+    .border-role { min-height: 225px; padding: 22px; border-right: 1px solid var(--border-default); }
+    .border-role:last-child { border-right: 0; }
+    .border-role small { color: var(--ink-muted); font-size: 9px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+    .border-role h3 { margin: 8px 0 8px; font: 700 16px/1.3 var(--font-serif); }
+    .border-role p { margin: 0; color: var(--ink-muted); font-size: 11px; }
+    .sample { display: grid; place-items: center; height: 66px; margin-top: 22px; background: #faf8f2; font-size: 10px; }
+    .sample.structural { border: 1px solid var(--border-strong); }
+    .sample.component { border: 1px solid var(--border-default); }
+    .sample.interactive { border: 1px solid var(--border-strong); border-bottom-width: 2px; font-weight: 700; }
+    .sample.floating { border: 1px solid var(--border-strong); box-shadow: 3px 3px 0 rgba(33,26,29,.15); }
+    .border-rule { display: grid; grid-template-columns: 1fr 1fr; margin-top: 14px; border: 1px solid var(--border-default); background: var(--paper); }
+    .border-rule div { padding: 13px 16px; font-size: 11px; }
+    .border-rule div + div { border-left: 1px solid var(--border-default); }
+    .border-rule b { display: block; margin-bottom: 3px; }
+    .border-rule span { color: var(--ink-muted); }
+
+    .accent-toolbar { display: flex; flex-wrap: wrap; gap: 0; margin-bottom: 18px; }
+    .accent-option { min-height: 42px; padding: 8px 14px; border: 1px solid var(--border-strong); border-right: 0; background: var(--paper); cursor: pointer; font-size: 11px; font-weight: 700; }
+    .accent-option:last-child { border-right: 1px solid var(--border-strong); }
+    .accent-option[aria-pressed="true"] { color: white; background: var(--ink); }
+    .accent-option i { display: inline-block; width: 9px; height: 9px; margin-right: 7px; background: var(--swatch); vertical-align: -1px; }
+    .color-study { display: grid; grid-template-columns: 1fr 1.3fr; gap: 22px; }
+    .palette { display: grid; border: 1px solid var(--border-strong); background: var(--paper); }
+    .swatch { display: grid; grid-template-columns: 62px 1fr auto; align-items: center; gap: 14px; min-height: 74px; padding: 10px 16px; border-bottom: 1px solid var(--border-default); }
+    .swatch:last-child { border-bottom: 0; }
+    .swatch-color { width: 44px; height: 44px; border: 1px solid var(--border-default); background: var(--color); }
+    .swatch b { display: block; font-size: 12px; }
+    .swatch span, .swatch code { color: var(--ink-muted); font-size: 10px; }
+    .swatch code { font-family: ui-monospace, monospace; }
+
+    .accent-demo { border: 1px solid var(--border-strong); background: var(--paper); }
+    .accent-demo-header { padding: 16px 18px; border-bottom: 1px solid var(--border-default); }
+    .accent-demo-header h3 { margin: 0; font: 700 17px/1.3 var(--font-serif); }
+    .accent-demo-header p { margin: 4px 0 0; color: var(--ink-muted); font-size: 10px; }
+    .accent-demo-body { display: grid; gap: 18px; padding: 22px; }
+    .button-row { display: flex; flex-wrap: wrap; gap: 10px; }
+    .button { display: inline-flex; align-items: center; justify-content: center; min-height: 42px; padding: 8px 15px; border: 1px solid var(--border-strong); border-bottom-width: 2px; background: var(--paper); cursor: pointer; font-size: 12px; font-weight: 700; }
+    .button.primary { border-color: var(--accent-hover); color: white; background: var(--accent); }
+    .button.primary:hover { background: var(--accent-hover); }
+    .button.ghost { border-color: transparent; background: transparent; }
+    .field { display: grid; gap: 6px; }
+    .field label { font-size: 11px; font-weight: 700; }
+    .input { width: 100%; min-height: 43px; padding: 8px 10px; border: 1px solid var(--border-default); border-bottom: 2px solid var(--border-strong); outline: 0; background: white; }
+    .input:focus { border-color: var(--border-strong); box-shadow: 0 0 0 2px var(--accent-faint); outline: 2px solid var(--accent); outline-offset: 1px; }
+    .active-row { display: grid; grid-template-columns: 4px 1fr auto; align-items: center; border: 1px solid var(--border-default); background: #faf8f2; }
+    .active-row::before { content: ""; align-self: stretch; background: var(--accent); }
+    .active-row div { padding: 12px 13px; }
+    .active-row b { display: block; font-size: 12px; }
+    .active-row span { color: var(--ink-muted); font-size: 10px; }
+    .active-row strong { padding: 12px 14px; color: var(--accent-hover); font: 700 17px var(--font-serif); }
+    .status { display: grid; grid-template-columns: 4px 1fr; border: 1px solid var(--border-default); background: white; }
+    .status::before { content: ""; background: var(--status-success); }
+    .status div { padding: 10px 12px; font-size: 10px; }
+    .status b { color: var(--status-success); }
+
+    .logo-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 18px; }
+    .logo-card { display: grid; grid-template-rows: 1fr auto; min-height: 260px; border: 1px solid var(--border-default); background: var(--paper); }
+    .logo-stage { display: grid; place-items: center; padding: 32px; }
+    .logo-caption { padding: 14px 16px; border-top: 1px solid var(--border-default); }
+    .logo-caption b { display: block; font-size: 12px; }
+    .logo-caption span { color: var(--ink-muted); font-size: 10px; }
+    .logo { width: min(100%, 190px); height: auto; overflow: visible; }
+    .logo .word { fill: var(--ink); }
+    .logo .mark { fill: var(--accent); }
+    .catalog-lockup { display: grid; gap: 10px; width: min(100%, 230px); }
+    .catalog-lockup .logo { width: 170px; }
+    .catalog-meta { display: flex; justify-content: space-between; gap: 12px; padding-top: 8px; border-top: 1px solid var(--border-strong); color: var(--ink-muted); font-size: 8px; font-weight: 700; letter-spacing: .1em; text-transform: uppercase; }
+    .plate-lockup { width: min(100%, 250px); padding: 22px 20px 18px; border: 1px solid var(--border-strong); border-bottom-width: 2px; background: #faf8f2; }
+    .plate-lockup .logo { width: 170px; }
+    .plate-lockup p { margin: 12px 0 0; padding-top: 9px; border-top: 1px solid var(--border-default); color: var(--ink-muted); font-size: 8px; letter-spacing: .12em; text-transform: uppercase; }
+
+    .recommendation { display: grid; grid-template-columns: 190px 1fr; margin-top: 18px; border: 1px solid var(--border-strong); background: var(--paper); }
+    .recommendation strong { padding: 18px; border-right: 1px solid var(--border-default); font: 700 15px/1.4 var(--font-serif); }
+    .recommendation p { margin: 0; padding: 18px; color: var(--ink-muted); font-size: 12px; }
+
+    .mini-product { display: grid; grid-template-columns: 220px minmax(0,1fr); min-height: 560px; border: 1px solid var(--border-strong); background: var(--paper); box-shadow: 5px 5px 0 rgba(33,26,29,.13); }
+    .mini-sidebar { padding: 25px 18px; border-right: 1px solid var(--border-strong); background: #f7f4ed; }
+    .mini-sidebar .logo { width: 125px; margin: 2px 8px 30px; }
+    .mini-nav { padding: 9px 10px; border-left: 3px solid transparent; color: var(--ink-muted); font-size: 11px; }
+    .mini-nav.active { border-left-color: var(--accent); color: var(--ink); background: #e9e5dc; font-weight: 700; }
+    .mini-content { padding: 32px; background: #f7f4ef; }
+    .mini-content h3 { margin: 0; font: 700 27px/1.3 var(--font-serif); }
+    .mini-content > p { margin: 5px 0 22px; color: var(--ink-muted); font-size: 11px; }
+    .entry-panel { border: 1px solid var(--border-strong); border-bottom-width: 2px; background: white; }
+    .entry-head { display: flex; align-items: center; justify-content: space-between; padding: 13px 15px; border-bottom: 1px solid var(--border-default); }
+    .entry-head b { font: 700 13px var(--font-serif); }
+    .entry-head span { color: var(--ink-muted); font-size: 9px; }
+    .entry-body { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; padding: 18px; }
+    .entry-body .field:last-child { grid-column: 1 / -1; }
+    .entry-actions { display: flex; justify-content: flex-end; gap: 9px; padding: 14px 18px; border-top: 1px solid var(--border-default); }
+
+    footer { margin-top: 48px; padding-top: 16px; border-top: 1px solid var(--border-strong); color: var(--ink-muted); font-size: 10px; }
+
+    @media (max-width: 900px) {
+      .border-system { grid-template-columns: 1fr 1fr; }
+      .border-role:nth-child(2) { border-right: 0; }
+      .border-role:nth-child(-n+2) { border-bottom: 1px solid var(--border-default); }
+      .color-study { grid-template-columns: 1fr; }
+      .logo-grid { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 650px) {
+      .page { width: min(100% - 18px, 1260px); padding-top: 30px; }
+      .section-heading { grid-template-columns: 1fr; gap: 4px; }
+      .border-system { grid-template-columns: 1fr; }
+      .border-role { border-right: 0; border-bottom: 1px solid var(--border-default); }
+      .border-role:last-child { border-bottom: 0; }
+      .border-rule, .recommendation { grid-template-columns: 1fr; }
+      .border-rule div + div { border-left: 0; border-top: 1px solid var(--border-default); }
+      .recommendation strong { border-right: 0; border-bottom: 1px solid var(--border-default); }
+      .mini-product { grid-template-columns: 1fr; }
+      .mini-sidebar { display: none; }
+      .mini-content { padding: 22px 14px; }
+      .entry-body { grid-template-columns: 1fr; }
+      .entry-body .field:last-child { grid-column: auto; }
+    }
+  </style>
+</head>
+<body>
+  <svg width="0" height="0" aria-hidden="true" style="position:absolute">
+    <symbol id="tadoku-logo" viewBox="0 0 158 29">
+      <path class="word" d="M13.8789062,28 L8.12695312,28 L8.12695312,5.66015625 L0.760742188,5.66015625 L0.760742188,0.873046875 L21.2451172,0.873046875 L21.2451172,5.66015625 L13.8789062,5.66015625 L13.8789062,28 Z M38.6123047,0.76171875 L48.2236328,28 L42.0263672,28 L40.0595703,21.5429688 L32.0318594,21.5427187 L33.4551316,16.71875 L31.6171875,16.71875 L30.1716461,21.5430603 L30.1699219,21.5429688 L28.203125,28 L22.0058594,28 L31.5800781,0.76171875 L38.6123047,0.76171875 Z M38.6865234,16.71875 C36.868155,10.8678093 35.8445649,7.55892311 35.6157227,6.79199219 C35.3868804,6.02506127 35.2229823,5.41894754 35.1240234,4.97363281 C34.7158183,6.55697406 33.5468846,10.471974 31.6171875,16.71875 L38.6865234,16.71875 Z M74.1445312,14.1767578 C74.1445312,18.6422749 72.8735479,22.0624881 70.331543,24.4375 C67.7895381,26.8125119 64.1188391,28 59.3193359,28 L51.6376953,28 L51.6376953,0.873046875 L60.1542969,0.873046875 C64.5827044,0.873046875 68.0214721,2.0419805 70.4707031,4.37988281 C72.9199341,6.71778513 74.1445312,9.98337747 74.1445312,14.1767578 Z M68.1699219,14.3251953 C68.1699219,8.49899431 65.5970309,5.5859375 60.4511719,5.5859375 L57.3896484,5.5859375 L57.3896484,23.25 L59.8574219,23.25 C65.3991162,23.25 68.1699219,20.2750949 68.1699219,14.3251953 Z M104.388672,14.3994141 C104.388672,18.8896709 103.275402,22.3408083 101.048828,24.7529297 C98.8222545,27.1650511 95.6308802,28.3710938 91.4746094,28.3710938 C87.3183386,28.3710938 84.1269643,27.1650511 81.9003906,24.7529297 C79.673817,22.3408083 78.5605469,18.8773012 78.5605469,14.3623047 C78.5605469,9.84730815 79.6769094,6.39926321 81.909668,4.01806641 C84.1424265,1.6368696 87.3430781,0.446289062 91.5117188,0.446289062 C95.6803594,0.446289062 98.8686413,1.64614686 101.07666,4.04589844 C103.284679,6.44565002 104.388672,9.89678738 104.388672,14.3994141 Z M84.5908203,14.3994141 C84.5908203,17.4300282 85.1660099,19.7122319 86.3164062,21.2460938 C87.4668026,22.7799556 89.1861865,23.546875 91.4746094,23.546875 C96.063825,23.546875 98.3583984,20.4977518 98.3583984,14.3994141 C98.3583984,8.28870643 96.0761947,5.23339844 91.5117188,5.23339844 C89.2232958,5.23339844 87.4977272,6.00341027 86.3349609,7.54345703 C85.1721947,9.08350379 84.5908203,11.3688 84.5908203,14.3994141 Z M115.762695,21.3230794 L115.762695,28 L110.010742,28 L110.010742,0.873046875 L115.762695,0.873046875 L115.762695,13.2861328 L118.026367,10.0947266 L125.374023,0.873046875 L131.756836,0.873046875 L115.762695,21.3230794 Z M157.325195,0.873046875 L157.325195,18.4257812 C157.325195,20.4296975 156.876795,22.1861904 155.97998,23.6953125 C155.083166,25.2044346 153.787443,26.3609986 152.092773,27.1650391 C150.398104,27.9690795 148.394217,28.3710938 146.081055,28.3710938 C142.592756,28.3710938 139.883799,27.4773852 137.954102,25.6899414 C136.024404,23.9024976 135.05957,21.4563957 135.05957,18.3515625 L135.05957,0.873046875 L140.792969,0.873046875 L140.792969,17.4794922 C140.792969,19.5699974 141.213537,21.1038363 142.054688,22.0810547 C142.895838,23.0582731 144.287425,23.546875 146.229492,23.546875 C148.10971,23.546875 149.473466,23.0551807 150.320801,22.0717773 C151.168136,21.088374 151.591797,19.5452579 151.591797,17.4423828 L157.325195,0.873046875 Z" />
+      <polygon class="mark" points="131.853697 28.0167614 125.29276 28.0167614 118.760559 17.4854584 125.195374 17.4854584" />
+    </symbol>
+  </svg>
+
+  <main class="page">
+    <header>
+      <div class="eyebrow">Bookplate refinement · second study</div>
+      <h1>One border language. One annotation color.</h1>
+      <p class="lede">This pass removes the competing outlines from the first preview. Every boundary now comes from one neutral ink family; thickness communicates role, and color is reserved for meaning.</p>
+      <div class="decision"><strong>Working recommendation:</strong> keep Bookplate, simplify it. Preserve the current wordmark, shift the accent toward a darker ink violet, and treat any “library plate” treatment as an optional lockup—not as a replacement logo.</div>
+    </header>
+
+    <section class="section">
+      <div class="section-heading"><div class="section-number">01 / Borders</div><div><h2>A four-role border grammar</h2><p>These are the only border treatments available to components. Statuses no longer invent their own outlines, and violet is never a normal border color.</p></div></div>
+      <div class="border-system">
+        <article class="border-role"><small>Role 01</small><h3>Structural</h3><p>Major shells, navigation boundaries, and dialog edges.</p><div class="sample structural">1px · ink neutral</div></article>
+        <article class="border-role"><small>Role 02</small><h3>Component</h3><p>Fields, cards, rows, tags, and internal separation.</p><div class="sample component">1px · warm neutral</div></article>
+        <article class="border-role"><small>Role 03</small><h3>Interactive</h3><p>Buttons and fields gain tactile weight only underneath.</p><div class="sample interactive">1px + 2px lower rule</div></article>
+        <article class="border-role"><small>Role 04</small><h3>Floating</h3><p>Menus and dialogs use structural borders plus hard depth.</p><div class="sample floating">1px + 3px offset</div></article>
+      </div>
+      <div class="border-rule"><div><b>Color never defines the boundary.</b><span>Focus uses an outside outline. Status uses a narrow marker. The component outline stays neutral.</span></div><div><b>Avoid doubled borders.</b><span>Adjacent rows share one separator; nested panels do not each draw a competing box.</span></div></div>
+    </section>
+
+    <section class="section">
+      <div class="section-heading"><div class="section-number">02 / Accent</div><div><h2>Does purple still belong?</h2><p>Yes—but it works better as annotation ink than as a glowing digital color. Switch between the three studies below; the controls, active marker, focus treatment, and logo wedge update together.</p></div></div>
+      <div class="accent-toolbar" aria-label="Accent color studies">
+        <button class="accent-option" style="--swatch:#6969ff" data-accent="current" aria-pressed="false"><i></i>Current violet</button>
+        <button class="accent-option" style="--swatch:#5747b8" data-accent="ink" aria-pressed="true"><i></i>Ink violet · recommended</button>
+        <button class="accent-option" style="--swatch:#6b465c" data-accent="plum" aria-pressed="false"><i></i>Library plum</button>
+      </div>
+      <div class="color-study">
+        <div class="palette">
+          <div class="swatch"><div class="swatch-color" style="--color:var(--paper)"></div><div><b>Paper</b><span>Primary surface</span></div><code>#FFFEFA</code></div>
+          <div class="swatch"><div class="swatch-color" style="--color:var(--canvas)"></div><div><b>Canvas</b><span>Page and grouping</span></div><code>#F2EFE8</code></div>
+          <div class="swatch"><div class="swatch-color" style="--color:var(--ink)"></div><div><b>Ink</b><span>Text and structure</span></div><code>#211A1D</code></div>
+          <div class="swatch"><div class="swatch-color" style="--color:var(--border-default)"></div><div><b>Rule</b><span>Component boundary</span></div><code>#C7C0B5</code></div>
+          <div class="swatch"><div class="swatch-color" style="--color:var(--accent)"></div><div><b>Annotation</b><span>Action and active state</span></div><code id="accent-code">#5747B8</code></div>
+        </div>
+        <div class="accent-demo">
+          <div class="accent-demo-header"><h3>Accent in context</h3><p>The accent has four jobs: primary action, active marker, focus, and the logo wedge.</p></div>
+          <div class="accent-demo-body">
+            <div class="button-row"><button class="button primary">Save update</button><button class="button">Secondary</button><button class="button ghost">Cancel</button></div>
+            <div class="field"><label for="study-input">Book or media title</label><input class="input" id="study-input" value="Sōsō no Frieren, volume 8" /></div>
+            <div class="active-row"><div><b>Japanese reading</b><span>24 pages · today</span></div><strong>+24</strong></div>
+            <div class="status"><div><b>Recorded.</b> Your update has been added to the August log.</div></div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-heading"><div class="section-number">03 / Logo</div><div><h2>Refine the setting, not the wordmark.</h2><p>The existing geometric wordmark already suits the sharp system. Its angled violet wedge is useful: it reads like a page marker. The lowest-risk improvement is to unify that wedge with the chosen annotation ink and establish intentional lockups.</p></div></div>
+      <div class="logo-grid">
+        <article class="logo-card"><div class="logo-stage"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-logo" /></svg></div><div class="logo-caption"><b>Wordmark · recommended default</b><span>Keep the existing drawing; update only the accent token.</span></div></article>
+        <article class="logo-card"><div class="logo-stage"><div class="catalog-lockup"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-logo" /></svg><div class="catalog-meta"><span>Immersion log</span><span>Est. 2014</span></div></div></div><div class="logo-caption"><b>Catalog lockup · recommended secondary</b><span>A typographic context lockup, not a replacement logo.</span></div></article>
+        <article class="logo-card"><div class="logo-stage"><div class="plate-lockup"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-logo" /></svg><p>Read more · track less</p></div></div><div class="logo-caption"><b>Bookplate lockup · occasional use</b><span>Suitable for onboarding, empty states, print, or editorial pages—not the navbar.</span></div></article>
+      </div>
+      <div class="recommendation"><strong>Logo recommendation</strong><p>Do not redraw the wordmark during this migration. Recolor its wedge through the semantic accent token, preserve the unboxed wordmark in navigation, and introduce the catalog lockup as an optional branded composition. A separate favicon/compact-mark study can follow once the main system is stable.</p></div>
+    </section>
+
+    <section class="section">
+      <div class="section-heading"><div class="section-number">04 / Together</div><div><h2>A calmer Bookplate specimen</h2><p>One structural border, one component rule, one interactive lower edge, and one accent. No component chooses its own outline color.</p></div></div>
+      <div class="mini-product">
+        <aside class="mini-sidebar"><svg class="logo" role="img" aria-label="Tadoku"><use href="#tadoku-logo" /></svg><div class="mini-nav active">Reading log</div><div class="mini-nav">Books & media</div><div class="mini-nav">Yearly overview</div><div class="mini-nav">Export</div></aside>
+        <div class="mini-content"><h3>Log a reading update</h3><p>Record progress without interrupting the reading habit.</p><section class="entry-panel"><div class="entry-head"><b>New update</b><span>Draft</span></div><div class="entry-body"><div class="field"><label for="mini-language">Language</label><select class="input" id="mini-language"><option>Japanese</option></select></div><div class="field"><label for="mini-activity">Activity</label><select class="input" id="mini-activity"><option>Reading</option></select></div><div class="field"><label for="mini-notes">Notes</label><input class="input" id="mini-notes" value="Finished chapter seven" /></div></div><div class="entry-actions"><button class="button ghost">Cancel</button><button class="button primary">Save update</button></div></section></div>
+      </div>
+    </section>
+
+    <footer>Temporary P0.2 design study. The original audit and first Bookplate preview remain unchanged.</footer>
+  </main>
+
+  <script>
+    const accents = {
+      current: { accent: '#6969FF', hover: '#5656E5', faint: 'rgba(105,105,255,.10)' },
+      ink: { accent: '#5747B8', hover: '#46389D', faint: 'rgba(87,71,184,.10)' },
+      plum: { accent: '#6B465C', hover: '#553548', faint: 'rgba(107,70,92,.10)' },
+    }
+
+    function setAccent(name) {
+      const value = accents[name]
+      document.documentElement.style.setProperty('--accent', value.accent)
+      document.documentElement.style.setProperty('--accent-hover', value.hover)
+      document.documentElement.style.setProperty('--accent-faint', value.faint)
+      document.getElementById('accent-code').textContent = value.accent
+      document.querySelectorAll('[data-accent]').forEach(button => {
+        button.setAttribute('aria-pressed', String(button.dataset.accent === name))
+      })
+    }
+
+    document.querySelectorAll('[data-accent]').forEach(button => {
+      button.addEventListener('click', () => setAccent(button.dataset.accent))
+    })
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-cut-meter-soft-v9.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-cut-meter-soft-v9.html
@@ -1,0 +1,218 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku — Softer Cut Meter Study</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --accent: #5747b8;
+      --accent-soft: #e8e4fa;
+      --shadow: 3px 3px 0 rgba(33, 26, 29, .16);
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --accent: #9a8bea;
+      --accent-soft: #332d52;
+      --shadow: 3px 3px 0 rgba(0, 0, 0, .48);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--canvas); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; }
+    button { font: inherit; color: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2 { font-family: Georgia, "Times New Roman", serif; }
+    h1 { max-width: 880px; margin-bottom: 16px; font-size: clamp(38px, 6vw, 68px); line-height: .98; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-size: clamp(26px, 3vw, 37px); line-height: 1.08; }
+    h3 { margin-bottom: 7px; font-size: 16px; }
+    p { color: var(--muted); }
+    .page { width: min(1120px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 52px; }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 850; letter-spacing: .14em; text-transform: uppercase; }
+    .lede, .section-intro { max-width: 790px; }
+    .lede { font-size: 18px; }
+    .section { margin-top: 52px; }
+    .section-intro { margin-bottom: 22px; }
+    .btn { display: inline-flex; min-height: 42px; align-items: center; justify-content: center; padding: 9px 15px 8px; border: 1px solid var(--rule-strong); border-bottom-width: 2px; border-radius: 0; background: var(--surface); cursor: pointer; font-weight: 750; }
+    .btn:hover { background: var(--surface-soft); }
+    .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-toggle { flex: none; }
+
+    .explanation { display: grid; grid-template-columns: 190px 1fr; margin-bottom: 24px; border: 1px solid var(--rule-strong); background: var(--surface); box-shadow: var(--shadow); }
+    .explanation strong { padding: 18px; border-right: 1px solid var(--rule); font-family: Georgia, serif; }
+    .explanation p { margin: 0; padding: 18px; font-size: 14px; }
+    .variations { display: grid; grid-template-columns: repeat(2, 1fr); gap: 18px; }
+    .variation { display: grid; grid-template-columns: minmax(190px, .8fr) 1.2fr; min-height: 330px; border: 1px solid var(--rule); background: var(--surface); }
+    .stage { display: grid; place-items: center; border-right: 1px solid var(--rule); background: var(--surface); }
+    .copy { display: flex; flex-direction: column; padding: 22px; }
+    .copy p { margin-bottom: 16px; font-size: 14px; }
+    .tag { display: inline-block; align-self: flex-start; margin-bottom: 8px; padding: 3px 6px; background: var(--accent-soft); color: var(--accent); font-size: 10px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; }
+    .tests { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; margin-top: auto; border: 1px solid var(--rule); background: var(--rule); }
+    .test { display: grid; min-height: 68px; place-items: center; background: var(--surface); }
+    .test.reverse { background: var(--text); color: var(--surface); }
+    .lockup { display: flex; align-items: center; gap: 10px; padding-top: 14px; }
+    .wordmark { font-size: 14px; font-weight: 900; letter-spacing: .13em; }
+    .meta { margin-left: auto; color: var(--muted); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
+    .mark { display: block; color: currentColor; }
+    .mark.hero { width: 120px; height: 120px; }
+    .mark.small { width: 28px; height: 28px; }
+    .mark.favicon { width: 16px; height: 16px; }
+    .mark.lock { width: 29px; height: 29px; }
+    .ink { fill: currentColor; }
+
+    .scale { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); }
+    .scale-item { padding: 18px; background: var(--surface); text-align: center; }
+    .scale-item strong { display: block; margin-bottom: 4px; }
+    .scale-item span { color: var(--muted); font-size: 12px; }
+
+    @media (max-width: 950px) {
+      .variations { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1120px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .explanation, .variation, .scale { grid-template-columns: 1fr; }
+      .explanation strong, .stage { border-right: 0; border-bottom: 1px solid var(--rule); }
+      .stage { min-height: 205px; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tadoku compact mark · Study 9</p>
+        <h1>What if the cut were actually soft?</h1>
+        <p class="lede">The previous round rounded the ends of one long line, but those ends lived outside the bars. This round places rounded geometry inside every bar, where it materially changes the silhouette.</p>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section class="section">
+      <div class="explanation"><strong>Construction correction</strong><p>Each visible piece of the cut is now its own capsule, arc, or circle. That preserves the upward rhythm while making the softness visible in monochrome and at small sizes.</p></div>
+      <div class="section-intro">
+        <p class="eyebrow">01 · Rounded cut family</p>
+        <h2>Four genuine softness levels</h2>
+        <p>The bars and proportions remain unchanged. Only the three interior interruptions vary.</p>
+      </div>
+
+      <div class="variations">
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Restrained capsule Cut Meter">
+              <defs><mask id="restrained-hero"><rect width="64" height="64" fill="white"/><path d="M9 43L19 38.5M27 34L37 29.5M46 25.5L55 21.5" stroke="black" stroke-width="6" stroke-linecap="round"/></mask></defs>
+              <path class="ink" mask="url(#restrained-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Low softness</span><h3>1 · Restrained capsules</h3>
+            <p>Three slim pill-shaped cuts preserve the original angle. Rounded endpoints are visible, but the mark still feels disciplined and typographic.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="restrained-small"><rect width="64" height="64" fill="white"/><path d="M9 43L19 38.5M27 34L37 29.5M46 25.5L55 21.5" stroke="black" stroke-width="7" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#restrained-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="restrained-fav"><rect width="64" height="64" fill="white"/><path d="M9 43L19 38.5M27 34L37 29.5M46 25.5L55 21.5" stroke="black" stroke-width="9" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#restrained-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="restrained-rev"><rect width="64" height="64" fill="white"/><path d="M9 43L19 38.5M27 34L37 29.5M46 25.5L55 21.5" stroke="black" stroke-width="7" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#restrained-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="restrained-lock"><rect width="64" height="64" fill="white"/><path d="M9 43L19 38.5M27 34L37 29.5M46 25.5L55 21.5" stroke="black" stroke-width="7" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#restrained-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="meta">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Full capsule Cut Meter">
+              <defs><mask id="full-hero"><rect width="64" height="64" fill="white"/><path d="M10 43L18 39.5M28 34L36 30.5M47 25L54 22" stroke="black" stroke-width="9" stroke-linecap="round"/></mask></defs>
+              <path class="ink" mask="url(#full-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Medium softness</span><h3>2 · Full capsules</h3>
+            <p>Shorter, wider pills make the roundness unmistakable. The gaps feel friendly and tactile while retaining a clear rising direction.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="full-small"><rect width="64" height="64" fill="white"/><path d="M10 43L18 39.5M28 34L36 30.5M47 25L54 22" stroke="black" stroke-width="10" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#full-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="full-fav"><rect width="64" height="64" fill="white"/><path d="M10 43L18 39.5M28 34L36 30.5M47 25L54 22" stroke="black" stroke-width="11" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#full-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="full-rev"><rect width="64" height="64" fill="white"/><path d="M10 43L18 39.5M28 34L36 30.5M47 25L54 22" stroke="black" stroke-width="10" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#full-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="full-lock"><rect width="64" height="64" fill="white"/><path d="M10 43L18 39.5M28 34L36 30.5M47 25L54 22" stroke="black" stroke-width="10" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#full-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="meta">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Bowed capsule Cut Meter">
+              <defs><mask id="bowed-hero"><rect width="64" height="64" fill="white"/><path d="M9 42.5Q14 39 19 40M27 34Q32 29.5 37 30.5M46 25Q50.5 20.5 55 22" fill="none" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs>
+              <path class="ink" mask="url(#bowed-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Flow</span><h3>3 · Bowed capsules</h3>
+            <p>Each pill bends gently upward. Together they imply one flowing path, with more listening and language cadence than a strict chart line.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="bowed-small"><rect width="64" height="64" fill="white"/><path d="M9 42.5Q14 39 19 40M27 34Q32 29.5 37 30.5M46 25Q50.5 20.5 55 22" fill="none" stroke="black" stroke-width="9" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#bowed-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="bowed-fav"><rect width="64" height="64" fill="white"/><path d="M9 42.5Q14 39 19 40M27 34Q32 29.5 37 30.5M46 25Q50.5 20.5 55 22" fill="none" stroke="black" stroke-width="11" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#bowed-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="bowed-rev"><rect width="64" height="64" fill="white"/><path d="M9 42.5Q14 39 19 40M27 34Q32 29.5 37 30.5M46 25Q50.5 20.5 55 22" fill="none" stroke="black" stroke-width="9" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#bowed-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="bowed-lock"><rect width="64" height="64" fill="white"/><path d="M9 42.5Q14 39 19 40M27 34Q32 29.5 37 30.5M46 25Q50.5 20.5 55 22" fill="none" stroke="black" stroke-width="9" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#bowed-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="meta">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Circular Cut Meter">
+              <defs><mask id="circle-hero"><rect width="64" height="64" fill="white"/><circle cx="14" cy="41" r="5" fill="black"/><circle cx="32" cy="32" r="5" fill="black"/><circle cx="50.5" cy="23" r="5" fill="black"/></mask></defs>
+              <path class="ink" mask="url(#circle-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Maximum softness</span><h3>4 · Circular passage</h3>
+            <p>The diagonal becomes three circular apertures. This is the strongest rounded treatment and the easiest to recognize small, but it shifts from “cut” toward “signal.”</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="circle-small"><rect width="64" height="64" fill="white"/><circle cx="14" cy="41" r="5.5" fill="black"/><circle cx="32" cy="32" r="5.5" fill="black"/><circle cx="50.5" cy="23" r="5.5" fill="black"/></mask></defs><path class="ink" mask="url(#circle-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="circle-fav"><rect width="64" height="64" fill="white"/><circle cx="13.5" cy="41" r="6.5" fill="black"/><circle cx="32" cy="32" r="6.5" fill="black"/><circle cx="50.5" cy="23" r="6.5" fill="black"/></mask></defs><path class="ink" mask="url(#circle-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="circle-rev"><rect width="64" height="64" fill="white"/><circle cx="14" cy="41" r="5.5" fill="black"/><circle cx="32" cy="32" r="5.5" fill="black"/><circle cx="50.5" cy="23" r="5.5" fill="black"/></mask></defs><path class="ink" mask="url(#circle-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="circle-lock"><rect width="64" height="64" fill="white"/><circle cx="14" cy="41" r="5.5" fill="black"/><circle cx="32" cy="32" r="5.5" fill="black"/><circle cx="50.5" cy="23" r="5.5" fill="black"/></mask></defs><path class="ink" mask="url(#circle-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="meta">Lockup</span></div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Softness scale</p>
+        <h2>Where the character changes</h2>
+      </div>
+      <div class="scale">
+        <div class="scale-item"><strong>Restrained</strong><span>Still graphic and editorial</span></div>
+        <div class="scale-item"><strong>Full</strong><span>Friendly without becoming playful</span></div>
+        <div class="scale-item"><strong>Bowed</strong><span>More organic and media-oriented</span></div>
+        <div class="scale-item"><strong>Circular</strong><span>Softest, but changes the metaphor</span></div>
+      </div>
+    </section>
+  </main>
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-cut-meter-variations-v8.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-cut-meter-variations-v8.html
@@ -1,0 +1,261 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku — Cut Meter Variations and Decision Queue</title>
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --accent: #5747b8;
+      --accent-soft: #e8e4fa;
+      --shadow: 3px 3px 0 rgba(33, 26, 29, .16);
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --accent: #9a8bea;
+      --accent-soft: #332d52;
+      --shadow: 3px 3px 0 rgba(0, 0, 0, .48);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--canvas); color: var(--text); font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; line-height: 1.5; }
+    button { font: inherit; color: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2 { font-family: Georgia, "Times New Roman", serif; }
+    h1 { max-width: 900px; margin-bottom: 16px; font-size: clamp(38px, 6vw, 68px); line-height: .98; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-size: clamp(26px, 3vw, 37px); line-height: 1.08; }
+    h3 { margin-bottom: 7px; font-size: 16px; }
+    p { color: var(--muted); }
+    .page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 52px; }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 850; letter-spacing: .14em; text-transform: uppercase; }
+    .lede, .section-intro { max-width: 800px; }
+    .lede { font-size: 18px; }
+    .section { margin-top: 54px; }
+    .section-intro { margin-bottom: 22px; }
+    .btn { display: inline-flex; min-height: 42px; align-items: center; justify-content: center; padding: 9px 15px 8px; border: 1px solid var(--rule-strong); border-bottom-width: 2px; border-radius: 0; background: var(--surface); cursor: pointer; font-weight: 750; }
+    .btn:hover { background: var(--surface-soft); }
+    .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-toggle { flex: none; }
+
+    .confirmed { display: grid; grid-template-columns: 180px 1fr; margin-bottom: 22px; border: 1px solid var(--rule-strong); background: var(--surface); box-shadow: var(--shadow); }
+    .confirmed strong { padding: 17px; border-right: 1px solid var(--rule); font-family: Georgia, serif; }
+    .confirmed p { margin: 0; padding: 17px; font-size: 13px; }
+    .variations { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; }
+    .variation { display: flex; min-height: 430px; flex-direction: column; border: 1px solid var(--rule); background: var(--surface); }
+    .variation.preferred { border-top: 4px solid var(--accent); }
+    .stage { display: grid; min-height: 205px; place-items: center; border-bottom: 1px solid var(--rule); background: var(--surface); }
+    .copy { display: flex; flex: 1; flex-direction: column; padding: 18px; }
+    .copy p { margin-bottom: 14px; font-size: 14px; }
+    .tag { display: inline-block; align-self: flex-start; margin-bottom: 8px; padding: 3px 6px; background: var(--accent-soft); color: var(--accent); font-size: 10px; font-weight: 850; letter-spacing: .08em; text-transform: uppercase; }
+    .tests { display: grid; grid-template-columns: 1fr 1fr 1fr; gap: 1px; margin-top: auto; border: 1px solid var(--rule); background: var(--rule); }
+    .test { display: grid; min-height: 70px; place-items: center; background: var(--surface); }
+    .test.reverse { background: var(--text); color: var(--surface); }
+    .lockup { display: flex; align-items: center; gap: 10px; padding-top: 13px; }
+    .wordmark { font-size: 14px; font-weight: 900; letter-spacing: .13em; }
+    .mark { display: block; color: currentColor; }
+    .mark.hero { width: 108px; height: 108px; }
+    .mark.small { width: 28px; height: 28px; }
+    .mark.favicon { width: 16px; height: 16px; }
+    .mark.lock { width: 29px; height: 29px; }
+    .ink { fill: currentColor; }
+    .accent { fill: var(--accent); }
+    .test-label { margin-left: auto; color: var(--muted); font-size: 9px; letter-spacing: .08em; text-transform: uppercase; }
+
+    .queue { display: grid; grid-template-columns: repeat(2, 1fr); gap: 14px; }
+    .question { position: relative; padding: 21px 22px 20px 28px; border-top: 1px solid var(--rule); border-right: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: var(--surface); }
+    .question::before { content: ""; position: absolute; top: -1px; bottom: -1px; left: 0; width: 6px; background: var(--accent); }
+    .question p { margin-bottom: 0; font-size: 14px; }
+    .question .status { margin-bottom: 8px; color: var(--accent); font-size: 10px; font-weight: 850; letter-spacing: .1em; text-transform: uppercase; }
+    .queue-note { margin-top: 16px; padding: 18px 20px; border: 1px solid var(--rule); background: var(--surface); font-size: 13px; }
+    .queue-note p { margin: 0; }
+
+    @media (max-width: 900px) { .variations { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1180px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .variations, .queue, .confirmed { grid-template-columns: 1fr; }
+      .confirmed strong { border-right: 0; border-bottom: 1px solid var(--rule); }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div>
+        <p class="eyebrow">Tadoku design discussion · P0.2 · Study 8</p>
+        <h1>One solid idea, six ways to cut it.</h1>
+        <p class="lede">The three rising bars stay fixed. Only the negative-space gesture changes, so we can refine character without losing the simplicity that made Cut Meter work.</p>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section class="section">
+      <div class="confirmed"><strong>System direction retained</strong><p>Sharp component geometry, ink violet as optional annotation, straight accent rails, subtle 2px field edges, light text on dark primary actions, and named 3px/5px hard-offset elevation.</p></div>
+      <div class="section-intro">
+        <p class="eyebrow">01 · Cut Meter family</p>
+        <h2>Shape first; color still optional</h2>
+        <p>Every large mark is a single-color silhouette. Each card also shows the 28px mark, a 16px favicon, and a reversed version. The bars retain identical proportions across all six candidates.</p>
+      </div>
+      <div class="variations">
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Square diagonal Cut Meter">
+              <defs><mask id="square-hero"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="7"/></mask></defs>
+              <path class="ink" mask="url(#square-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Original</span><h3>1 · Square diagonal</h3>
+            <p>The current Cut Meter: a seven-pixel straight cut with square ends. Crisp, graphic, and most aligned with the sharp interface geometry.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="square-small"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="8"/></mask></defs><path class="ink" mask="url(#square-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="square-fav"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="10"/></mask></defs><path class="ink" mask="url(#square-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="square-rev"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="8"/></mask></defs><path class="ink" mask="url(#square-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="square-lock"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="8"/></mask></defs><path class="ink" mask="url(#square-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation preferred">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Soft diagonal Cut Meter">
+              <defs><mask id="soft-hero"><rect width="64" height="64" fill="white"/><path d="M3 43L61 17" stroke="black" stroke-width="7" stroke-linecap="round"/></mask></defs>
+              <path class="ink" mask="url(#soft-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Suggested refinement</span><h3>2 · Soft diagonal</h3>
+            <p>The same straight trajectory with slightly rounded endpoints. The softness exists only inside the cut, giving the mark a friendlier gesture without rounding the bars.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="soft-small"><rect width="64" height="64" fill="white"/><path d="M3 43L61 17" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#soft-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="soft-fav"><rect width="64" height="64" fill="white"/><path d="M3 43L61 17" stroke="black" stroke-width="10" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#soft-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="soft-rev"><rect width="64" height="64" fill="white"/><path d="M3 43L61 17" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#soft-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="soft-lock"><rect width="64" height="64" fill="white"/><path d="M3 43L61 17" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#soft-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Tapered Cut Meter">
+              <defs><mask id="taper-hero"><rect width="64" height="64" fill="white"/><path d="M1 48L63 14L63 20L1 42Z" fill="black"/></mask></defs>
+              <path class="ink" mask="url(#taper-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Motion</span><h3>3 · Tapered passage</h3>
+            <p>A wedge-shaped cut narrows as it rises. It adds forward motion and a page-turn quality while remaining entirely negative space.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="taper-small"><rect width="64" height="64" fill="white"/><path d="M1 49L63 13L63 21L1 41Z" fill="black"/></mask></defs><path class="ink" mask="url(#taper-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="taper-fav"><rect width="64" height="64" fill="white"/><path d="M0 50L64 12L64 22L0 40Z" fill="black"/></mask></defs><path class="ink" mask="url(#taper-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="taper-rev"><rect width="64" height="64" fill="white"/><path d="M1 49L63 13L63 21L1 41Z" fill="black"/></mask></defs><path class="ink" mask="url(#taper-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="taper-lock"><rect width="64" height="64" fill="white"/><path d="M1 49L63 13L63 21L1 41Z" fill="black"/></mask></defs><path class="ink" mask="url(#taper-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Curved Cut Meter">
+              <defs><mask id="curve-hero"><rect width="64" height="64" fill="white"/><path d="M2 43C20 48 39 14 62 18" fill="none" stroke="black" stroke-width="7" stroke-linecap="round"/></mask></defs>
+              <path class="ink" mask="url(#curve-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Listening</span><h3>4 · Gentle wave</h3>
+            <p>A shallow curved cut introduces cadence and listening without adding a waveform icon. It is the softest and most organic member of the family.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="curve-small"><rect width="64" height="64" fill="white"/><path d="M2 43C20 48 39 14 62 18" fill="none" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#curve-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="curve-fav"><rect width="64" height="64" fill="white"/><path d="M2 43C20 48 39 14 62 18" fill="none" stroke="black" stroke-width="10" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#curve-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="curve-rev"><rect width="64" height="64" fill="white"/><path d="M2 43C20 48 39 14 62 18" fill="none" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#curve-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="curve-lock"><rect width="64" height="64" fill="white"/><path d="M2 43C20 48 39 14 62 18" fill="none" stroke="black" stroke-width="8" stroke-linecap="round"/></mask></defs><path class="ink" mask="url(#curve-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Stepped Cut Meter">
+              <defs><mask id="step-hero"><rect width="64" height="64" fill="white"/><path d="M1 43h18v-8h19v-8h25v8H45v8H26v8H1z" fill="black"/></mask></defs>
+              <path class="ink" mask="url(#step-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Tracking</span><h3>5 · Stepped cut</h3>
+            <p>A stair-step passage turns the diagonal into discrete milestones. It feels more like tracking and competition, but also more digital.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="step-small"><rect width="64" height="64" fill="white"/><path d="M1 43h18v-8h19v-8h25v9H45v8H26v8H1z" fill="black"/></mask></defs><path class="ink" mask="url(#step-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="step-fav"><rect width="64" height="64" fill="white"/><path d="M0 44h20v-9h19v-9h25v11H46v9H27v9H0z" fill="black"/></mask></defs><path class="ink" mask="url(#step-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="step-rev"><rect width="64" height="64" fill="white"/><path d="M1 43h18v-8h19v-8h25v9H45v8H26v8H1z" fill="black"/></mask></defs><path class="ink" mask="url(#step-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="step-lock"><rect width="64" height="64" fill="white"/><path d="M1 43h18v-8h19v-8h25v9H45v8H26v8H1z" fill="black"/></mask></defs><path class="ink" mask="url(#step-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+
+        <article class="variation">
+          <div class="stage">
+            <svg class="mark hero" viewBox="0 0 64 64" role="img" aria-label="Notched Cut Meter">
+              <defs><mask id="notch-hero"><rect width="64" height="64" fill="white"/><path d="M6 40h16v7H6zM23 29h18v7H23zM42 17h17v7H42z" fill="black"/></mask></defs>
+              <path class="ink" mask="url(#notch-hero)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+            </svg>
+          </div>
+          <div class="copy">
+            <span class="tag">Rhythm</span><h3>6 · Separate notches</h3>
+            <p>The passage becomes three aligned interruptions rather than one continuous line. It is highly legible small, though less obviously a single gesture.</p>
+            <div class="tests">
+              <div class="test"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="notch-small"><rect width="64" height="64" fill="white"/><path d="M6 39h16v9H6zM23 28h18v9H23zM42 16h17v9H42z" fill="black"/></mask></defs><path class="ink" mask="url(#notch-small)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+              <div class="test"><svg class="mark favicon" viewBox="0 0 64 64"><defs><mask id="notch-fav"><rect width="64" height="64" fill="white"/><path d="M5 38h18v11H5zM22 27h20v11H22zM41 15h19v11H41z" fill="black"/></mask></defs><path class="ink" mask="url(#notch-fav)" d="M6 37h15v20H6zM24 23h16v34H24zM43 7h15v50H43z"/></svg></div>
+              <div class="test reverse"><svg class="mark small" viewBox="0 0 64 64"><defs><mask id="notch-rev"><rect width="64" height="64" fill="white"/><path d="M6 39h16v9H6zM23 28h18v9H23zM42 16h17v9H42z" fill="black"/></mask></defs><path class="ink" mask="url(#notch-rev)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg></div>
+            </div>
+            <div class="lockup"><svg class="mark lock" viewBox="0 0 64 64"><defs><mask id="notch-lock"><rect width="64" height="64" fill="white"/><path d="M6 39h16v9H6zM23 28h18v9H23zM42 16h17v9H42z" fill="black"/></mask></defs><path class="ink" mask="url(#notch-lock)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/></svg><span class="wordmark">TADOKU</span><span class="test-label">Lockup</span></div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Decision queue</p>
+        <h2>What we still need to decide</h2>
+        <p>The visual grammar is close enough that the remaining questions can now be made explicit. We should continue resolving them one at a time.</p>
+      </div>
+      <div class="queue">
+        <article class="question"><div class="status">P0.2 · Recommended next</div><h3>Density</h3><p>Do we adopt two named modes—44px comfortable controls for public/auth and 36px compact controls for admin—or keep one density everywhere?</p></article>
+        <article class="question"><div class="status">P0.2 · Still open</div><h3>Typography and icon grammar</h3><p>What are the canonical heading/body scales, and should icons inherit the sharp geometry or retain softer line endings for legibility?</p></article>
+        <article class="question"><div class="status">P0.5 · Needs discussion</div><h3>Button API</h3><p>Choose the typed variant names, model destructive tone, and confirm separate Button and LinkButton components.</p></article>
+        <article class="question"><div class="status">P2.4 · Needs discussion</div><h3>Package boundary</h3><p>Decide whether UI remains Next-specific, define supported entry points, and determine how long the compatibility stylesheet stays.</p></article>
+        <article class="question"><div class="status">Migration · Plan input</div><h3>Application rollout order</h3><p>After the style guide pilot, should auth, admin, or a representative webv2 route become the first real consumer of the refined theme?</p></article>
+        <article class="question"><div class="status">Testing · Plan input</div><h3>Regression baseline</h3><p>Which representative states must receive rendered component tests immediately, before the broader visual-regression issue is implemented?</p></article>
+      </div>
+      <div class="queue-note"><p><strong>Suggested sequence:</strong> finish the Cut Meter choice, decide density to close P0.2, then discuss the Button API and package boundary. Migration order and testing fixtures can be locked into the implementation plan afterward.</p></div>
+    </section>
+  </main>
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-refinement-audit.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-refinement-audit.html
@@ -1,0 +1,575 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="A design critique and refinement roadmap for the Tadoku design system and its style guide." />
+  <title>Tadoku UI — Design System Refinement Audit</title>
+  <style>
+    :root {
+      --ink: #17171d;
+      --muted: #666873;
+      --faint: #8d909c;
+      --line: #e2e3e9;
+      --line-strong: #cfd1da;
+      --paper: #f6f6f8;
+      --surface: #ffffff;
+      --surface-soft: #fbfbfc;
+      --violet: #5f5ff5;
+      --violet-deep: #4848d7;
+      --violet-soft: #eeeeff;
+      --mint: #22c7a9;
+      --mint-soft: #e6faf5;
+      --amber: #b66c0d;
+      --amber-soft: #fff5df;
+      --red: #c93737;
+      --red-soft: #fff0f0;
+      --radius-sm: 6px;
+      --radius-md: 12px;
+      --radius-lg: 20px;
+      --shadow-sm: 0 1px 2px rgba(22, 22, 29, .06), 0 1px 8px rgba(22, 22, 29, .035);
+      --shadow-md: 0 14px 40px rgba(22, 22, 29, .09);
+      --serif: Georgia, "Times New Roman", serif;
+      --sans: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      --mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+    }
+
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      margin: 0;
+      color: var(--ink);
+      background:
+        radial-gradient(circle at 85% 0%, rgba(95, 95, 245, .09), transparent 28rem),
+        radial-gradient(circle at 5% 24rem, rgba(34, 199, 169, .06), transparent 24rem),
+        var(--paper);
+      font-family: var(--sans);
+      font-size: 16px;
+      line-height: 1.6;
+      text-rendering: optimizeLegibility;
+    }
+
+    a { color: var(--violet-deep); text-underline-offset: 3px; }
+    a:hover { color: var(--ink); }
+    a:focus-visible { outline: 3px solid rgba(95, 95, 245, .35); outline-offset: 3px; border-radius: 3px; }
+    code { font-family: var(--mono); font-size: .88em; }
+
+    .shell { width: min(1240px, calc(100% - 40px)); margin: 0 auto; }
+    .reading { width: min(820px, 100%); }
+
+    .masthead { padding: 76px 0 56px; }
+    .eyebrow {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 26px;
+      color: var(--violet-deep);
+      font-size: 12px;
+      font-weight: 800;
+      letter-spacing: .12em;
+      text-transform: uppercase;
+    }
+    .eyebrow::before { content: ""; width: 28px; height: 3px; border-radius: 2px; background: var(--violet); }
+    h1, h2, h3 { margin: 0; line-height: 1.12; letter-spacing: -.025em; }
+    h1 { max-width: 960px; font-family: var(--serif); font-size: clamp(46px, 6.5vw, 86px); font-weight: 700; }
+    h1 em { color: var(--violet); font-style: normal; }
+    .lede { max-width: 790px; margin: 30px 0 0; color: #43454f; font-size: clamp(19px, 2vw, 24px); line-height: 1.5; }
+    .lede strong { color: var(--ink); }
+
+    .facts { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; margin-top: 42px; }
+    .fact { padding: 18px 20px; border: 1px solid var(--line); border-radius: var(--radius-md); background: rgba(255,255,255,.76); box-shadow: var(--shadow-sm); }
+    .fact strong { display: block; margin-bottom: 1px; font-family: var(--serif); font-size: 28px; line-height: 1.1; }
+    .fact span { color: var(--muted); font-size: 13px; }
+
+    .nav-wrap { position: sticky; top: 0; z-index: 20; border-block: 1px solid var(--line); background: rgba(246, 246, 248, .9); backdrop-filter: blur(14px); }
+    .nav { display: flex; gap: 4px; padding: 10px 0; overflow-x: auto; scrollbar-width: none; }
+    .nav::-webkit-scrollbar { display: none; }
+    .nav a { flex: 0 0 auto; padding: 7px 11px; border-radius: var(--radius-sm); color: var(--muted); font-size: 13px; font-weight: 700; text-decoration: none; }
+    .nav a:hover { color: var(--ink); background: var(--surface); }
+
+    section { padding: 80px 0; border-bottom: 1px solid var(--line); }
+    .section-head { display: grid; grid-template-columns: 220px minmax(0, 1fr); gap: 50px; margin-bottom: 38px; }
+    .section-number { color: var(--violet); font-family: var(--mono); font-size: 13px; font-weight: 800; }
+    h2 { font-family: var(--serif); font-size: clamp(32px, 4vw, 52px); }
+    .section-intro { max-width: 760px; margin: 18px 0 0; color: var(--muted); font-size: 18px; }
+
+    .diagnosis {
+      display: grid;
+      grid-template-columns: 1.05fr .95fr;
+      gap: 1px;
+      overflow: hidden;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-lg);
+      background: var(--line);
+      box-shadow: var(--shadow-md);
+    }
+    .diagnosis > div { padding: clamp(28px, 4vw, 52px); background: var(--surface); }
+    .diagnosis .verdict { background: var(--ink); color: white; }
+    .diagnosis .label { display: inline-flex; margin-bottom: 22px; color: #b9bbff; font-size: 12px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+    .diagnosis h3 { max-width: 470px; font-family: var(--serif); font-size: clamp(30px, 3.5vw, 48px); }
+    .diagnosis p { margin: 22px 0 0; color: #c8cad3; font-size: 17px; }
+    .diagnosis ul { margin: 6px 0 0; padding: 0; list-style: none; }
+    .diagnosis li { display: grid; grid-template-columns: 24px 1fr; gap: 12px; padding: 15px 0; border-bottom: 1px solid var(--line); }
+    .diagnosis li:last-child { border-bottom: 0; }
+    .diagnosis li::before { content: "↗"; color: var(--violet); font-weight: 800; }
+    .diagnosis li strong { display: block; }
+    .diagnosis li span { display: block; margin-top: 3px; color: var(--muted); font-size: 14px; }
+
+    .score-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 28px; }
+    .score { padding: 22px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); }
+    .score-top { display: flex; justify-content: space-between; gap: 20px; font-weight: 750; }
+    .score-top span:last-child { color: var(--muted); font-family: var(--mono); }
+    .meter { height: 6px; margin: 16px 0 12px; overflow: hidden; border-radius: 99px; background: #ececf1; }
+    .meter i { display: block; width: var(--score); height: 100%; border-radius: inherit; background: var(--violet); }
+    .score p { margin: 0; color: var(--muted); font-size: 13px; }
+    .note { margin: 14px 0 0; color: var(--faint); font-size: 12px; }
+
+    .comparison { width: 100%; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-md); border-collapse: separate; border-spacing: 0; background: var(--surface); }
+    .comparison th, .comparison td { padding: 18px 20px; border-bottom: 1px solid var(--line); text-align: left; vertical-align: top; }
+    .comparison th { color: var(--muted); background: var(--surface-soft); font-size: 12px; letter-spacing: .06em; text-transform: uppercase; }
+    .comparison td { font-size: 14px; }
+    .comparison tr:last-child td { border-bottom: 0; }
+    .comparison td:first-child { width: 26%; color: var(--muted); }
+    .comparison td:nth-child(2) { width: 34%; font-weight: 700; }
+
+    .north-star { overflow: hidden; border: 1px solid var(--line-strong); border-radius: var(--radius-lg); background: var(--surface); box-shadow: var(--shadow-md); }
+    .browser-bar { display: flex; align-items: center; gap: 6px; height: 42px; padding: 0 16px; border-bottom: 1px solid var(--line); background: #fafafd; }
+    .browser-bar i { width: 8px; height: 8px; border-radius: 50%; background: #d8d9df; }
+    .mock-shell { display: grid; grid-template-columns: 184px minmax(0, 1fr) 180px; min-height: 680px; }
+    .mock-side { padding: 24px 16px; border-right: 1px solid var(--line); background: #fcfcfd; }
+    .mock-brand { margin: 0 8px 22px; font-family: var(--serif); font-weight: 800; }
+    .mock-side small { display: block; margin: 20px 8px 8px; color: var(--faint); font-size: 9px; font-weight: 800; letter-spacing: .1em; text-transform: uppercase; }
+    .mock-side span { display: block; padding: 7px 8px; border-radius: 5px; color: var(--muted); font-size: 11px; }
+    .mock-side span.active { color: var(--violet-deep); background: var(--violet-soft); font-weight: 800; }
+    .mock-main { padding: 38px 42px 60px; min-width: 0; }
+    .crumb { color: var(--faint); font-size: 10px; font-weight: 750; }
+    .mock-title-row { display: flex; align-items: flex-start; justify-content: space-between; gap: 20px; margin-top: 10px; }
+    .mock-title-row h3 { font-family: var(--serif); font-size: 31px; }
+    .badge { display: inline-flex; align-items: center; gap: 6px; padding: 5px 9px; border-radius: 99px; color: #126d5e; background: var(--mint-soft); font-size: 10px; font-weight: 800; white-space: nowrap; }
+    .mock-lede { max-width: 570px; margin: 12px 0 22px; color: var(--muted); font-size: 12px; }
+    .mini-tabs { display: flex; gap: 18px; border-bottom: 1px solid var(--line); }
+    .mini-tabs span { padding: 8px 0; color: var(--muted); font-size: 10px; font-weight: 750; }
+    .mini-tabs .active { margin-bottom: -1px; color: var(--ink); border-bottom: 2px solid var(--violet); }
+    .canvas { display: grid; place-items: center; min-height: 170px; margin: 18px 0; border: 1px solid var(--line); border-radius: 10px; background: linear-gradient(45deg,#fafafd 25%,transparent 25%),linear-gradient(-45deg,#fafafd 25%,transparent 25%),linear-gradient(45deg,transparent 75%,#fafafd 75%),linear-gradient(-45deg,transparent 75%,#fafafd 75%); background-size: 20px 20px; background-position: 0 0,0 10px,10px -10px,-10px 0; }
+    .button-row { display: flex; flex-wrap: wrap; align-items: center; justify-content: center; gap: 10px; }
+    .demo-button { padding: 9px 15px; border: 1px solid rgba(0,0,0,.1); border-radius: 6px; color: white; background: var(--violet); box-shadow: 0 1px 2px rgba(0,0,0,.08); font-size: 11px; font-weight: 800; }
+    .demo-button.secondary { color: var(--ink); background: white; }
+    .demo-button.danger { background: var(--red); }
+    .mock-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px; }
+    .mock-card { padding: 16px; border: 1px solid var(--line); border-radius: 8px; }
+    .mock-card strong { display: block; margin-bottom: 4px; font-size: 11px; }
+    .mock-card p { margin: 0; color: var(--muted); font-size: 10px; }
+    .mock-toc { padding: 38px 24px; border-left: 1px solid var(--line); }
+    .mock-toc strong { display: block; margin-bottom: 12px; font-size: 10px; }
+    .mock-toc span { display: block; padding: 4px 0; color: var(--muted); font-size: 9px; }
+    .mock-toc span.active { color: var(--violet-deep); font-weight: 800; }
+    .caption { display: flex; justify-content: space-between; gap: 24px; margin-top: 15px; color: var(--muted); font-size: 13px; }
+    .caption strong { color: var(--ink); }
+
+    .rec-groups { display: grid; gap: 46px; }
+    .group-head { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+    .group-head h3 { font-family: var(--serif); font-size: 26px; }
+    .priority { display: inline-flex; padding: 4px 8px; border-radius: 99px; color: var(--violet-deep); background: var(--violet-soft); font-size: 10px; font-weight: 900; letter-spacing: .08em; }
+    .priority.next { color: #126d5e; background: var(--mint-soft); }
+    .priority.later { color: #8a5410; background: var(--amber-soft); }
+    .rec-list { display: grid; gap: 12px; counter-reset: rec; }
+    .rec {
+      display: grid;
+      grid-template-columns: 54px minmax(0, 1fr) 190px;
+      gap: 22px;
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius-md);
+      background: var(--surface);
+      box-shadow: var(--shadow-sm);
+      counter-increment: rec;
+    }
+    .rec::before { content: counter(rec, decimal-leading-zero); color: var(--violet); font-family: var(--mono); font-size: 14px; font-weight: 900; }
+    .rec h4 { margin: 0; font-size: 19px; line-height: 1.3; }
+    .rec p { margin: 8px 0 0; color: var(--muted); font-size: 14px; }
+    .rec ul { margin: 13px 0 0; padding-left: 18px; color: #454751; font-size: 13px; }
+    .rec li { margin: 5px 0; }
+    .rec aside { align-self: start; padding: 14px; border-radius: 8px; background: var(--surface-soft); font-size: 12px; }
+    .rec aside span { display: flex; justify-content: space-between; gap: 10px; padding: 4px 0; color: var(--muted); }
+    .rec aside strong { color: var(--ink); }
+    .token-code { margin: 16px 0 0; padding: 15px 17px; overflow-x: auto; border-radius: 8px; color: #e8e8f3; background: #1d1d25; font: 12px/1.65 var(--mono); }
+
+    .quick-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 12px; }
+    .quick { min-height: 190px; padding: 24px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); }
+    .quick b { display: grid; place-items: center; width: 32px; height: 32px; margin-bottom: 34px; border-radius: 9px; color: var(--violet-deep); background: var(--violet-soft); font-family: var(--mono); font-size: 12px; }
+    .quick strong { display: block; font-size: 15px; }
+    .quick span { display: block; margin-top: 7px; color: var(--muted); font-size: 12px; }
+
+    .roadmap { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; overflow: hidden; border: 1px solid var(--line); border-radius: var(--radius-lg); background: var(--line); }
+    .phase { padding: 30px; background: var(--surface); }
+    .phase .time { color: var(--violet); font-family: var(--mono); font-size: 11px; font-weight: 900; text-transform: uppercase; }
+    .phase h3 { margin-top: 12px; font-family: var(--serif); font-size: 25px; }
+    .phase ol { margin: 22px 0 0; padding-left: 18px; color: var(--muted); font-size: 13px; }
+    .phase li { margin: 10px 0; padding-left: 4px; }
+    .outcome { margin-top: 22px; padding-top: 18px; border-top: 1px solid var(--line); font-size: 12px; }
+    .outcome strong { color: #126d5e; }
+
+    .principles { display: grid; grid-template-columns: repeat(2, 1fr); gap: 12px; }
+    .principle { padding: 26px; border: 1px solid var(--line); border-radius: var(--radius-md); background: var(--surface); }
+    .principle strong { font-family: var(--serif); font-size: 21px; }
+    .principle p { margin: 8px 0 0; color: var(--muted); font-size: 13px; }
+
+    .references { padding-bottom: 110px; }
+    .references ol { margin: 0; padding-left: 20px; columns: 2; column-gap: 50px; }
+    .references li { break-inside: avoid; margin: 0 0 16px; padding-left: 6px; color: var(--muted); font-size: 13px; }
+    .references a { font-weight: 750; }
+
+    footer { padding: 28px 0 48px; color: var(--faint); font-size: 12px; }
+    footer .shell { display: flex; justify-content: space-between; gap: 20px; }
+
+    @media (max-width: 900px) {
+      .facts, .score-grid, .quick-grid { grid-template-columns: repeat(2, 1fr); }
+      .section-head { grid-template-columns: 1fr; gap: 14px; }
+      .diagnosis { grid-template-columns: 1fr; }
+      .rec { grid-template-columns: 42px minmax(0, 1fr); }
+      .rec aside { grid-column: 2; }
+      .mock-shell { grid-template-columns: 145px 1fr; }
+      .mock-toc { display: none; }
+      .roadmap { grid-template-columns: 1fr; }
+    }
+
+    @media (max-width: 620px) {
+      .shell { width: min(100% - 24px, 1240px); }
+      .masthead { padding: 48px 0 40px; }
+      h1 { font-size: 43px; }
+      section { padding: 58px 0; }
+      .facts, .score-grid, .quick-grid, .principles { grid-template-columns: 1fr; }
+      .comparison { display: block; overflow-x: auto; white-space: normal; }
+      .comparison table { min-width: 720px; }
+      .north-star { overflow-x: auto; }
+      .mock-shell { min-width: 730px; }
+      .rec { grid-template-columns: 1fr; padding: 22px; }
+      .rec aside { grid-column: 1; }
+      .references ol { columns: 1; }
+      footer .shell { display: block; }
+    }
+
+    @media print {
+      body { background: white; }
+      .nav-wrap { display: none; }
+      .shell { width: 100%; }
+      section { break-inside: avoid; padding: 38px 0; }
+      .rec, .score, .quick, .principle, .north-star { break-inside: avoid; box-shadow: none; }
+      .masthead { padding-top: 30px; }
+    }
+  </style>
+</head>
+<body>
+  <header class="masthead">
+    <div class="shell">
+      <div class="eyebrow">Tadoku UI · refinement audit · 7 August 2026</div>
+      <h1>From functional library to <em>confident system.</em></h1>
+      <p class="lede"><strong>Nothing is obviously broken—and that is why the gap is hard to name.</strong> The component set works, but the visual grammar and the documentation do not yet explain why it looks this way, when to use each choice, or what “correct” looks like across states.</p>
+      <div class="facts" aria-label="Audit evidence summary">
+        <div class="fact"><strong>18</strong><span>style-guide routes audited</span></div>
+        <div class="fact"><strong>4,299px</strong><span>Forms page height at 1280px</span></div>
+        <div class="fact"><strong>960px</strong><span>unframed preview width at desktop</span></div>
+        <div class="fact"><strong>4.15:1</strong><span>current violet on white</span></div>
+      </div>
+    </div>
+  </header>
+
+  <div class="nav-wrap">
+    <nav class="nav shell" aria-label="Report sections">
+      <a href="#diagnosis">Diagnosis</a>
+      <a href="#benchmark">Benchmark</a>
+      <a href="#north-star">North star</a>
+      <a href="#recommendations">Recommendations</a>
+      <a href="#quick-wins">Quick wins</a>
+      <a href="#roadmap">Roadmap</a>
+      <a href="#principles">Principles</a>
+    </nav>
+  </div>
+
+  <main>
+    <section id="diagnosis">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">01 / DIAGNOSIS</div>
+          <div>
+            <h2>The missing layer is intentionality.</h2>
+            <p class="section-intro">The site currently proves that components exist. A refined design system also communicates the decisions around them: hierarchy, behavior, boundaries, accessibility, and maturity.</p>
+          </div>
+        </div>
+
+        <div class="diagnosis">
+          <div class="verdict">
+            <span class="label">Core finding</span>
+            <h3>The library is presented as a kitchen sink, not as a decision-making tool.</h3>
+            <p>That creates the feeling of “something missing”: pages are technically complete, but they do not create confidence, teach judgment, or express a distinct Tadoku point of view.</p>
+          </div>
+          <div>
+            <ul>
+              <li><div><strong>Examples lack a frame</strong><span>White previews sit directly on a near-white page, with no canvas controls, boundary, density, or state context.</span></div></li>
+              <li><div><strong>Visual rules are implicit</strong><span>Square controls, two-pixel bottom borders, shadows, spacing, and typography are individual styles rather than a named visual grammar.</span></div></li>
+              <li><div><strong>Guidance is sparse</strong><span>Most entries are only a title, preview, and source. Users still have to infer when, why, and how.</span></div></li>
+              <li><div><strong>Foundations are underspecified</strong><span>Seven utility colors and three type examples cannot carry a growing product system.</span></div></li>
+            </ul>
+          </div>
+        </div>
+
+        <div class="score-grid" aria-label="Heuristic scorecard">
+          <div class="score" style="--score: 72%"><div class="score-top"><span>Component coverage</span><span>7.2</span></div><div class="meter"><i></i></div><p>A useful set of real product components and flows already exists.</p></div>
+          <div class="score" style="--score: 50%"><div class="score-top"><span>Visual coherence</span><span>5.0</span></div><div class="meter"><i></i></div><p>Consistent in broad strokes, but shape, depth, density, and state treatment are not systematic.</p></div>
+          <div class="score" style="--score: 34%"><div class="score-top"><span>Documentation</span><span>3.4</span></div><div class="meter"><i></i></div><p>Code is visible; decision guidance, props, anatomy, and behavior are mostly absent.</p></div>
+          <div class="score" style="--score: 40%"><div class="score-top"><span>Accessibility</span><span>4.0</span></div><div class="meter"><i></i></div><p>Good use of Headless UI, but the system lacks a documented and tested accessibility contract.</p></div>
+          <div class="score" style="--score: 30%"><div class="score-top"><span>Foundations</span><span>3.0</span></div><div class="meter"><i></i></div><p>Brand colors and fonts exist; semantic tokens and a complete type/spacing system do not.</p></div>
+          <div class="score" style="--score: 24%"><div class="score-top"><span>Governance</span><span>2.4</span></div><div class="meter"><i></i></div><p>No visible status, owner, changelog, deprecation, or contribution path.</p></div>
+        </div>
+        <p class="note">Scores are directional heuristics, not compliance grades. They are intended to prioritize the next investment.</p>
+      </div>
+    </section>
+
+    <section id="benchmark">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">02 / BENCHMARK</div>
+          <div>
+            <h2>What mature systems add.</h2>
+            <p class="section-intro">Strong systems combine a component workshop with a reference manual. Storybook calls each rendered state a “story”; USWDS separates components, patterns, and tokens; VA pages add usage, alternatives, content, and accessibility guidance.</p>
+          </div>
+        </div>
+
+        <div style="overflow-x:auto">
+          <table class="comparison">
+            <thead><tr><th>Today</th><th>Mature pattern</th><th>Best fit for Tadoku</th></tr></thead>
+            <tbody>
+              <tr><td>Preview ↔ Code toggle</td><td>Purpose, anatomy, variants, states, API, accessibility, content guidance</td><td>Keep the lightweight custom site, but give every component the same documentation schema.</td></tr>
+              <tr><td>Seven utility colors</td><td>Primitive palette → semantic role → component token</td><td>Expose CSS variables for role-based colors; let Tailwind utilities implement rather than define the system.</td></tr>
+              <tr><td>One long page per category</td><td>One component per route, search, local table of contents, deep links</td><td>Split Forms and Navigation first; add an indexed component home with maturity labels.</td></tr>
+              <tr><td>Default examples</td><td>Every meaningful state, interactive controls, viewport and theme switching</td><td>Add a reusable preview canvas and a compact state matrix before adopting more tooling.</td></tr>
+              <tr><td>Examples mixed with product prototypes</td><td>Foundations, components, patterns, and experimental work clearly separated</td><td>Move Logging flows to Patterns and label v2 as experimental.</td></tr>
+              <tr><td>No visible lifecycle</td><td>Status, owner, version, last update, changelog, migration notes</td><td>Start with “stable / beta / deprecated” metadata and a source link on every page.</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </section>
+
+    <section id="north-star">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">03 / NORTH STAR</div>
+          <div>
+            <h2>Make every page answer the same questions.</h2>
+            <p class="section-intro">A developer should learn the API. A designer or product engineer should learn the decision. Both should be able to verify behavior without reading the source first.</p>
+          </div>
+        </div>
+
+        <div class="north-star" role="img" aria-label="Conceptual layout for a refined Tadoku Button documentation page">
+          <div class="browser-bar"><i></i><i></i><i></i></div>
+          <div class="mock-shell">
+            <aside class="mock-side">
+              <div class="mock-brand">tadoku/ui</div>
+              <small>Foundations</small><span>Overview</span><span>Color</span><span>Typography</span>
+              <small>Actions</small><span class="active">Button</span><span>Action menu</span><span>Pagination</span>
+              <small>Forms</small><span>Input</span><span>Select</span><span>Autocomplete</span>
+            </aside>
+            <article class="mock-main">
+              <div class="crumb">Components / Actions</div>
+              <div class="mock-title-row"><h3>Button</h3><span class="badge">● Stable</span></div>
+              <p class="mock-lede">Triggers an immediate action. Choose a hierarchy that matches the importance and risk of that action.</p>
+              <div class="mini-tabs"><span class="active">Preview</span><span>Code</span><span>Props</span><span>Accessibility</span></div>
+              <div class="canvas"><div class="button-row"><span class="demo-button">Primary action</span><span class="demo-button secondary">Secondary</span><span class="demo-button danger">Delete log</span></div></div>
+              <div class="mock-grid">
+                <div class="mock-card"><strong>Use when</strong><p>The user is ready to commit a clear, immediate action.</p></div>
+                <div class="mock-card"><strong>Avoid when</strong><p>Navigation is the intent; use a Link with the correct semantics.</p></div>
+                <div class="mock-card"><strong>Behavior</strong><p>Supports keyboard, loading, disabled, icon, and full-width states.</p></div>
+                <div class="mock-card"><strong>Content</strong><p>Start with a specific verb. Prefer “Save log” over “Submit”.</p></div>
+              </div>
+            </article>
+            <aside class="mock-toc"><strong>On this page</strong><span class="active">Overview</span><span>Examples</span><span>Variants</span><span>States</span><span>Usage</span><span>Accessibility</span><span>API</span><span>Changelog</span></aside>
+          </div>
+        </div>
+        <div class="caption"><span><strong>The key change:</strong> the component is no longer the whole page; the decision model is.</span><span>Concept, not a final visual spec.</span></div>
+      </div>
+    </section>
+
+    <section id="recommendations">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">04 / RECOMMENDATIONS</div>
+          <div>
+            <h2>Fourteen improvements, in order.</h2>
+            <p class="section-intro">Start with the shared language and the documentation shell. Those changes improve every existing component before a large visual redesign is attempted.</p>
+          </div>
+        </div>
+
+        <div class="rec-groups">
+          <div>
+            <div class="group-head"><span class="priority">P0 · NOW</span><h3>Build confidence and coherence</h3></div>
+            <div class="rec-list">
+              <article class="rec">
+                <div><h4>Introduce semantic design tokens</h4><p>The current palette names implementation colors (<code>slate-500</code>, <code>lime-700</code>) rather than user-interface roles. Add a stable layer for surface, text, border, action, focus, and status so product code does not choose raw hues.</p><ul><li>Keep a primitive palette, but document it as an implementation detail.</li><li>Add light/dark aliases now even if dark mode ships later.</li><li>Give chart colors their own accessible categorical sequence.</li></ul><pre class="token-code">--color-action-bg: #5f5ff5;
+--color-action-hover: #5555e6;
+--color-action-text: #ffffff;
+--color-text-default: #202128;
+--color-text-muted: #60636f;
+--color-surface-canvas: #f6f6f8;
+--color-border-subtle: #e2e3e9;</pre></div>
+                <aside><span>Impact <strong>Very high</strong></span><span>Effort <strong>Medium</strong></span><span>Evidence <strong>Color page</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Define Tadoku’s visual grammar</h4><p>The system feels unfinished because shape and depth are nearly absent: controls, previews, tables, and cards are predominantly square; buttons and inputs rely on a two-pixel bottom border. Decide and name the rules.</p><ul><li>Suggested starting point: 6px controls, 10–12px cards/popovers, 16px modals.</li><li>Use one-pixel borders plus restrained elevation; reserve stronger shadows for overlays.</li><li>Keep Merriweather and violet as signature elements—the goal is refinement, not generic softness.</li><li>Define density, icon sizes, motion duration, and focus ring as tokens too.</li></ul></div>
+                <aside><span>Impact <strong>Very high</strong></span><span>Effort <strong>Medium</strong></span><span>Risk <strong>Needs review</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Replace Showcase with a real documentation shell</h4><p>The current <code>Showcase</code> offers a title and a binary Preview/Code toggle. Expand it into a consistent page anatomy: summary, status, examples, variants, states, usage, content, accessibility, API, and source.</p><ul><li>Frame previews with a border, radius, neutral canvas, and compact toolbar.</li><li>Put Preview / Code / Props in tabs so changing one example does not move the page.</li><li>Add copy-code, deep-link, canvas theme, and viewport controls.</li><li>Keep prose outside the canvas so examples remain focused.</li></ul></div>
+                <aside><span>Impact <strong>Very high</strong></span><span>Effort <strong>Medium</strong></span><span>Start with <strong>Button</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Make accessibility a component contract</h4><p>Do a focused WCAG 2.2 sweep and document keyboard/screen-reader behavior alongside each component. Concrete issues already visible in source should become regression tests.</p><ul><li><code>#6969FF</code> is 4.15:1 on white, below the 4.5:1 threshold for normal text—including current button labels. A darker interactive violet such as <code>#5F5FF5</code> reaches roughly 4.73:1.</li><li>Connect form hints/errors with <code>aria-describedby</code> and set <code>aria-invalid</code>; ensure every select/input has a matching id.</li><li>Use <code>aria-current="page"</code> for active breadcrumbs/navigation; Pagination currently labels its nav as “breadcrumb”.</li><li>Standardize visible <code>:focus-visible</code>, reduced-motion behavior, target size, and high-contrast support.</li></ul></div>
+                <aside><span>Impact <strong>Critical</strong></span><span>Effort <strong>Medium</strong></span><span>Automate <strong>axe + tests</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Add a typed Button and LinkButton API</h4><p>The documentation explicitly says buttons are CSS classes, so invalid combinations and missing states are easy. A component API makes hierarchy discoverable and provides one place for loading, icons, disabled behavior, and accessible semantics.</p><ul><li>Use variants: <code>primary</code>, <code>secondary</code>, <code>danger</code>, <code>ghost</code>.</li><li>Use sizes and intent props rather than free-form class combinations.</li><li>Keep escape hatches for layout, but make the correct path the easy path.</li><li>Separate action buttons from navigation links while sharing visual recipes.</li></ul></div>
+                <aside><span>Impact <strong>High</strong></span><span>Effort <strong>Medium</strong></span><span>Migration <strong>Codemodable</strong></span></aside>
+              </article>
+            </div>
+          </div>
+
+          <div>
+            <div class="group-head"><span class="priority next">P1 · NEXT</span><h3>Turn the site into a reference tool</h3></div>
+            <div class="rec-list">
+              <article class="rec">
+                <div><h4>Use one route per component, with search</h4><p>Forms is over 4,200px tall and mixes six unrelated examples. Split it into Input, Select, Checkbox, Radio, Autocomplete, Tags, Textarea, and composed-form pages. Add keyboard-first search and a local page outline.</p><ul><li>Provide a component index with category, description, and status.</li><li>Keep Foundation / Components / Patterns, but group components by job: Actions, Forms, Navigation, Feedback, Data display, Overlays.</li><li>Use stable anchor links for every example and guidance section.</li></ul></div>
+                <aside><span>Impact <strong>High</strong></span><span>Effort <strong>Medium</strong></span><span>First split <strong>Forms</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Show the whole state matrix</h4><p>A default render rarely exposes the problems that make a system feel inconsistent. Document default, hover, pressed, focus, disabled, loading, error, empty, overflow, and long-copy states at a glance.</p><ul><li>Use static state grids for visual review and interactive examples for behavior.</li><li>Include icon-leading, icon-only, long-label, and full-width cases.</li><li>Render at phone, tablet, and desktop widths—especially navigation and data tables.</li></ul></div>
+                <aside><span>Impact <strong>High</strong></span><span>Effort <strong>Medium</strong></span><span>Benefit <strong>Fewer surprises</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Rebuild the foundation pages</h4><p>The Color page should show values, aliases, usage, contrast, pairings, and copy actions. Typography needs a full ramp—not only title, subtitle, and text link. Add spacing, radius, elevation, motion, iconography, and layout pages.</p><ul><li>Give every token a name, value, example, purpose, and “do not use for”.</li><li>Separate body typography from display/editorial typography.</li><li>Document a reading column (about 65–75 characters) and a wider demo/data column.</li><li>Load fonts with document links/preload rather than a CSS <code>@import</code>.</li></ul></div>
+                <aside><span>Impact <strong>High</strong></span><span>Effort <strong>Medium</strong></span><span>Owner <strong>Design + FE</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Co-locate examples, metadata, and tests</h4><p>The current custom guide can remain. Borrow Storybook’s best idea: each meaningful component state should be a reusable, named example near the component. Generate navigation, props tables, and status from that metadata.</p><ul><li>Do not migrate tooling first; establish the documentation schema first.</li><li>Consider Storybook only if controls, autodocs, and visual testing save more maintenance than a custom renderer costs.</li><li>Reuse the same examples in docs, unit tests, and visual snapshots.</li></ul></div>
+                <aside><span>Impact <strong>High</strong></span><span>Effort <strong>High</strong></span><span>Decision <strong>After pilot</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Add automated quality gates</h4><p>A design system needs stronger checks than a product page because regressions multiply across consumers. Add visual diffs, accessibility scans, interaction tests, and token linting to the component workflow.</p><ul><li>Start with Button, Input, Modal, ActionMenu, Navbar, and Pagination.</li><li>Snapshot all documented states and two responsive widths.</li><li>Fail changes that introduce raw color values outside the token layer.</li></ul></div>
+                <aside><span>Impact <strong>High</strong></span><span>Effort <strong>Medium</strong></span><span>Coverage <strong>Top 6 first</strong></span></aside>
+              </article>
+            </div>
+          </div>
+
+          <div>
+            <div class="group-head"><span class="priority later">P2 · SCALE</span><h3>Make the system durable</h3></div>
+            <div class="rec-list">
+              <article class="rec">
+                <div><h4>Separate components, patterns, and experiments</h4><p>“Logs overview” and “Logging flow v2” are valuable product patterns, but they currently sit beside production components without status. Create a Patterns section and mark exploratory work as experimental.</p><ul><li>Components are reusable parts; patterns are recommended compositions; experiments are proposals.</li><li>Show which components a pattern uses and which product problem it solves.</li></ul></div>
+                <aside><span>Impact <strong>Medium</strong></span><span>Effort <strong>Low</strong></span><span>Clarity <strong>Immediate</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Add lifecycle and governance</h4><p>Every page should show maturity, owner, last meaningful update, package version, and source. Publish contribution criteria and a lightweight review checklist.</p><ul><li>Use three statuses: Experimental, Stable, Deprecated.</li><li>Require docs, accessibility notes, tests, and migration guidance before Stable.</li><li>Add “replaced by” links and removal dates for deprecations.</li></ul></div>
+                <aside><span>Impact <strong>Medium</strong></span><span>Effort <strong>Low</strong></span><span>Prevents <strong>Silent drift</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Design for themes and user preferences</h4><p>Even if Tadoku remains light-first, tokens should support dark surfaces, forced colors, reduced motion, zoom, and future brand modes. The preview canvas is the right place to expose those constraints early.</p><ul><li>Test at 200% text zoom and narrow reflow widths.</li><li>Respect <code>prefers-reduced-motion</code> for modal, menu, toast, and loading animations.</li><li>Check charts and status colors without relying on hue alone.</li></ul></div>
+                <aside><span>Impact <strong>Medium</strong></span><span>Effort <strong>Medium</strong></span><span>Timing <strong>Token phase</strong></span></aside>
+              </article>
+
+              <article class="rec">
+                <div><h4>Tighten the package boundary</h4><p>Global element selectors and raw Tailwind utilities make it hard to know what is guaranteed by the design system. Define the supported public surface and make styles consumable without leaking accidental defaults.</p><ul><li>Export tokens and a shared Tailwind preset; document global prerequisites explicitly.</li><li>Prefer component recipes over broad selectors for tables, links, form controls, and headings.</li><li>Audit package exports for duplicates, stale paths, and undocumented components such as Loading and VerticalTabbar.</li></ul></div>
+                <aside><span>Impact <strong>Medium</strong></span><span>Effort <strong>High</strong></span><span>Risk <strong>Stage migration</strong></span></aside>
+              </article>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="quick-wins">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">05 / QUICK WINS</div>
+          <div>
+            <h2>Four changes that will be felt immediately.</h2>
+            <p class="section-intro">These can land before the token and component refactors are complete.</p>
+          </div>
+        </div>
+        <div class="quick-grid">
+          <div class="quick"><b>01</b><strong>Frame every preview</strong><span>Add a one-pixel border, 10px radius, neutral canvas, and 24–32px padding.</span></div>
+          <div class="quick"><b>02</b><strong>Constrain readable content</strong><span>Use a 720–780px prose column; let demos and data opt into the wider column.</span></div>
+          <div class="quick"><b>03</b><strong>Darken interactive violet</strong><span>Move text/button usage from #6969FF toward #5F5FF5; keep the brighter violet for decorative branding.</span></div>
+          <div class="quick"><b>04</b><strong>Add the “why”</strong><span>Put a one-sentence purpose plus “Use when / Avoid when” above every existing example.</span></div>
+        </div>
+      </div>
+    </section>
+
+    <section id="roadmap">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">06 / ROADMAP</div>
+          <div>
+            <h2>A practical sequence.</h2>
+            <p class="section-intro">Avoid a big-bang redesign. Build one polished vertical slice, validate the visual direction and documentation model, then scale it.</p>
+          </div>
+        </div>
+        <div class="roadmap">
+          <article class="phase"><span class="time">Week 1</span><h3>Set the language</h3><ol><li>Inventory current colors, type, spacing, radii, shadows, and states.</li><li>Draft semantic tokens and contrast-safe interactive colors.</li><li>Agree on the component page schema and maturity statuses.</li></ol><div class="outcome"><strong>Outcome:</strong> one shared vocabulary and fewer subjective reviews.</div></article>
+          <article class="phase"><span class="time">Weeks 2–3</span><h3>Build the pilot</h3><ol><li>Redesign Showcase and the page shell.</li><li>Create typed Button/LinkButton APIs.</li><li>Document Button, Input, Modal, and ActionMenu completely.</li><li>Add accessibility and visual tests for their states.</li></ol><div class="outcome"><strong>Outcome:</strong> a believable end-to-end example of the future system.</div></article>
+          <article class="phase"><span class="time">Weeks 4–8</span><h3>Scale deliberately</h3><ol><li>Split Forms and Navigation routes; add search and page outlines.</li><li>Rebuild foundation pages from token data.</li><li>Cover the remaining components by usage frequency.</li><li>Add governance, changelogs, and migration notes.</li></ol><div class="outcome"><strong>Outcome:</strong> a reference that can guide product work without tribal knowledge.</div></article>
+        </div>
+      </div>
+    </section>
+
+    <section id="principles">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">07 / GUARDRAILS</div>
+          <div>
+            <h2>What to preserve.</h2>
+            <p class="section-intro">Refinement should sharpen Tadoku’s identity, not sand it into a generic SaaS library.</p>
+          </div>
+        </div>
+        <div class="principles">
+          <div class="principle"><strong>Keep the editorial voice.</strong><p>Merriweather gives headings a reading-focused character that fits Tadoku. Build a better scale around it rather than replacing it reflexively.</p></div>
+          <div class="principle"><strong>Keep examples grounded in the product.</strong><p>The logging examples are a strength. Reclassify them as patterns and add decisions; do not replace them with abstract lorem ipsum.</p></div>
+          <div class="principle"><strong>Prefer fewer, clearer variants.</strong><p>Refinement comes from stronger defaults and explicit hierarchy—not from adding a new knob for every edge case.</p></div>
+          <div class="principle"><strong>Tooling follows the model.</strong><p>Storybook can accelerate controls and generated docs, but it will not supply missing design decisions. Pilot the content structure first.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="references" id="references">
+      <div class="shell">
+        <div class="section-head">
+          <div class="section-number">08 / REFERENCES</div>
+          <div><h2>Reference patterns used in this audit.</h2></div>
+        </div>
+        <ol>
+          <li><a href="https://ui.tadoku.app/">Tadoku Design System</a> — live site audited alongside the local <code>ui</code> package and style-guide source.</li>
+          <li><a href="https://storybook.js.org/docs/writing-docs">Storybook: How to document components</a> — generated docs, prose, and reusable doc blocks.</li>
+          <li><a href="https://storybook.js.org/docs/get-started/whats-a-story">Storybook: What’s a story?</a> — named rendered states as reusable development and regression fixtures.</li>
+          <li><a href="https://designsystem.digital.gov/">U.S. Web Design System</a> — clear separation of components, patterns, design tokens, and utilities.</li>
+          <li><a href="https://design.va.gov/components/details/">VA Design System: Details</a> — purpose, examples, when to use, alternatives, behavior, placement, and accessibility in one entry.</li>
+          <li><a href="https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html">W3C: Contrast minimum</a> — 4.5:1 for normal text and threshold calculation guidance.</li>
+          <li><a href="https://www.w3.org/WAI/ARIA/apg/patterns/breadcrumb/examples/breadcrumb/">WAI-ARIA breadcrumb example</a> — <code>aria-current="page"</code> on the current breadcrumb.</li>
+        </ol>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    <div class="shell"><span>Prepared for Tadoku · design-system refinement audit</span><span>Scope: live style guide + local <code>frontend/packages/ui</code> and <code>frontend/apps/styleguide</code></span></div>
+  </footer>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/design-system-type-icon-baseline-v10.html
+++ b/docs/wip/tadoku-paper/artifacts/design-system-type-icon-baseline-v10.html
@@ -1,0 +1,311 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku — Typography, Icon Grammar, and Regression Baseline</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;family=Open+Sans:wght@400;600;700&amp;display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --accent: #5747b8;
+      --accent-soft: #e8e4fa;
+      --danger: #a33333;
+      --success: #3f7048;
+      --action: #5747b8;
+      --action-hover: #49399f;
+      --action-lower: #35277f;
+      --shadow: 3px 3px 0 rgba(33, 26, 29, .16);
+      --font-serif: Merriweather, Georgia, "Times New Roman", serif;
+      --font-sans: "Open Sans", Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --accent: #9a8bea;
+      --accent-soft: #332d52;
+      --danger: #e08a8a;
+      --success: #87bd91;
+      --action: #6150bc;
+      --action-hover: #6d5cc7;
+      --action-lower: #40318c;
+      --shadow: 3px 3px 0 rgba(0, 0, 0, .48);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--canvas); color: var(--text); font-family: var(--font-sans); line-height: 1.5; }
+    button { font: inherit; color: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    .page { width: min(1180px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 50px; }
+    .heading-lockup { display: grid; grid-template-columns: 58px 1fr; gap: 17px; align-items: start; }
+    .brand-mark { width: 58px; height: 58px; color: var(--text); }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 700; letter-spacing: .14em; line-height: 16px; text-transform: uppercase; }
+    h1 { max-width: 900px; margin-bottom: 16px; font: 700 clamp(38px, 6vw, 64px)/1 var(--font-serif); letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font: 700 clamp(26px, 3vw, 36px)/1.1 var(--font-serif); letter-spacing: -.02em; }
+    h3 { margin-bottom: 7px; font-size: 18px; line-height: 24px; }
+    p { color: var(--muted); }
+    .lede, .section-intro { max-width: 800px; }
+    .lede { font-size: 18px; }
+    .section { margin-top: 56px; }
+    .section-intro { margin-bottom: 22px; }
+    .btn { display: inline-flex; min-height: 44px; align-items: center; justify-content: center; gap: 8px; padding: 9px 15px 8px; border: 1px solid var(--rule); border-bottom: 2px solid var(--rule-strong); border-radius: 0; background: var(--surface); cursor: pointer; font-weight: 700; }
+    .btn:hover { background: var(--surface-soft); }
+    .btn.primary { border-color: var(--action); border-bottom-color: var(--action-lower); background: var(--action); color: #fffefa; }
+    .btn.primary:hover { border-color: var(--action-hover); background: var(--action-hover); }
+    .btn.compact { min-height: 36px; padding: 6px 11px 5px; font-size: 14px; }
+    .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .theme-toggle { flex: none; }
+
+    .decisions { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); box-shadow: var(--shadow); }
+    .decision { padding: 18px; background: var(--surface); }
+    .decision strong { display: block; margin-bottom: 5px; }
+    .decision p { margin: 0; font-size: 13px; }
+
+    .type-system { border: 1px solid var(--rule-strong); background: var(--surface); }
+    .type-row { display: grid; grid-template-columns: 145px 155px 1fr; align-items: baseline; gap: 20px; min-height: 92px; padding: 18px 20px; }
+    .type-row + .type-row { border-top: 1px solid var(--rule); }
+    .type-token { color: var(--accent); font: 700 11px/16px var(--font-sans); letter-spacing: .08em; text-transform: uppercase; }
+    .type-spec { color: var(--muted); font: 12px/18px ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .display-sample { font: 700 48px/52px var(--font-serif); letter-spacing: -.025em; }
+    .page-sample { font: 700 32px/38px var(--font-serif); letter-spacing: -.015em; }
+    .section-sample { font: 700 24px/30px var(--font-serif); }
+    .component-sample { font: 600 18px/24px var(--font-sans); }
+    .body-sample { max-width: 650px; font: 400 16px/26px var(--font-sans); }
+    .compact-sample { max-width: 650px; font: 400 14px/22px var(--font-sans); }
+    .label-sample { font: 700 12px/16px var(--font-sans); letter-spacing: .1em; text-transform: uppercase; }
+    .meta-sample { font: 400 12px/18px var(--font-sans); color: var(--muted); }
+    .numeric { font-variant-numeric: tabular-nums; }
+
+    .type-rules { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; margin-top: 16px; }
+    .rule-card { padding: 19px; border: 1px solid var(--rule); background: var(--surface); }
+    .rule-card strong { display: block; margin-bottom: 5px; }
+    .rule-card p { margin: 0; font-size: 13px; }
+
+    .icon-grid { display: grid; grid-template-columns: .9fr 1.1fr; gap: 18px; }
+    .icon-panel { border: 1px solid var(--rule); background: var(--surface); }
+    .panel-head { padding: 17px 19px; border-bottom: 1px solid var(--rule); }
+    .panel-head h3 { margin-bottom: 3px; }
+    .panel-head p { margin: 0; font-size: 13px; }
+    .icon-rows { padding: 4px 19px; }
+    .icon-row { display: grid; grid-template-columns: 88px 1fr; align-items: center; min-height: 74px; }
+    .icon-row + .icon-row { border-top: 1px solid var(--rule); }
+    .icon-row strong { font-size: 13px; }
+    .icon-demo { display: flex; align-items: center; gap: 18px; }
+    .icon { display: block; flex: none; }
+    .i16 { width: 16px; height: 16px; }
+    .i20 { width: 20px; height: 20px; }
+    .i24 { width: 24px; height: 24px; }
+    .i48 { width: 48px; height: 48px; }
+    .outline-icon { fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+    .solid-icon { fill: currentColor; }
+    .success { color: var(--success); }
+    .danger { color: var(--danger); }
+    .component-demos { display: grid; gap: 13px; padding: 19px; }
+    .demo-row { display: flex; flex-wrap: wrap; gap: 10px; align-items: center; }
+    .icon-button { width: 44px; padding-inline: 0; }
+    .status-line { display: flex; align-items: center; gap: 8px; min-height: 42px; padding: 9px 12px; border: 1px solid var(--rule); background: var(--canvas); font-size: 14px; }
+    .icon-rule { padding: 13px 15px; border-left: 4px solid var(--accent); background: var(--surface-soft); color: var(--muted); font-size: 13px; }
+
+    .api-recommendation { display: grid; grid-template-columns: .8fr 1.2fr; border: 1px solid var(--rule-strong); background: var(--surface); box-shadow: var(--shadow); }
+    .api-copy { padding: 22px; border-right: 1px solid var(--rule); }
+    .api-copy p:last-child { margin-bottom: 0; }
+    pre { margin: 0; padding: 22px; overflow-x: auto; background: var(--surface-soft); color: var(--text); font: 13px/1.65 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .code-comment { color: var(--muted); }
+
+    .baseline { overflow: hidden; border: 1px solid var(--rule-strong); background: var(--surface); }
+    .baseline-row { display: grid; grid-template-columns: 155px 1.15fr 1fr; gap: 18px; padding: 17px 19px; }
+    .baseline-row + .baseline-row { border-top: 1px solid var(--rule); }
+    .baseline-row.header { background: var(--surface-soft); font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    .baseline-row strong { font-size: 14px; }
+    .baseline-row span { color: var(--muted); font-size: 13px; }
+    .baseline-note { margin-top: 16px; padding: 18px 20px 18px 26px; border-top: 1px solid var(--rule); border-right: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: var(--surface); position: relative; }
+    .baseline-note::before { content: ""; position: absolute; top: -1px; bottom: -1px; left: 0; width: 6px; background: var(--accent); }
+    .baseline-note p { margin: 0; font-size: 14px; }
+
+    .rollout { display: grid; grid-template-columns: repeat(5, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); }
+    .rollout-step { padding: 18px; background: var(--surface); }
+    .rollout-step b { display: block; margin-bottom: 5px; color: var(--accent); font-size: 11px; letter-spacing: .08em; text-transform: uppercase; }
+    .rollout-step strong { display: block; margin-bottom: 4px; }
+    .rollout-step span { color: var(--muted); font-size: 12px; }
+
+    @media (max-width: 980px) {
+      .decisions, .rollout { grid-template-columns: repeat(2, 1fr); }
+      .icon-grid, .api-recommendation { grid-template-columns: 1fr; }
+      .api-copy { border-right: 0; border-bottom: 1px solid var(--rule); }
+      .type-row { grid-template-columns: 130px 1fr; }
+      .type-row > :last-child { grid-column: 1 / -1; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1180px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .heading-lockup { grid-template-columns: 42px 1fr; }
+      .brand-mark { width: 42px; height: 42px; }
+      .decisions, .type-rules, .rollout { grid-template-columns: 1fr; }
+      .type-row, .baseline-row { grid-template-columns: 1fr; gap: 5px; }
+      .type-row > :last-child { grid-column: auto; }
+      .display-sample { font-size: 38px; line-height: 44px; }
+      .baseline-row.header { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div class="heading-lockup">
+        <svg class="brand-mark" viewBox="0 0 64 64" role="img" aria-label="Tadoku Cut Meter mark">
+          <defs><mask id="brand-cut"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="7"/></mask></defs>
+          <path fill="currentColor" mask="url(#brand-cut)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+        </svg>
+        <div>
+          <p class="eyebrow">Tadoku design discussion · P0.2 · Study 10</p>
+          <h1>Typography gives the system its voice.</h1>
+          <p class="lede">A complete type hierarchy, an intentional icon grammar, a class-first styling API, and a concrete explanation of the regression baseline.</p>
+        </div>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section>
+      <div class="decisions">
+        <article class="decision"><strong>Two densities</strong><p>Comfortable 44px and compact 36px are approved.</p></article>
+        <article class="decision"><strong>Compact mark</strong><p>Use the original square-diagonal Cut Meter for now.</p></article>
+        <article class="decision"><strong>Framework direction</strong><p>UI v2 must not depend on Next.js.</p></article>
+        <article class="decision"><strong>Rollout</strong><p>Style guide → admin → auth → webv2.</p></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">01 · Typography proposal</p>
+        <h2>Serif for editorial hierarchy; sans for work</h2>
+        <p>Keep Merriweather and Open Sans, but stop making every heading serif. Large navigational hierarchy gets the bookish voice; components and dense interfaces stay crisp and practical.</p>
+      </div>
+      <div class="type-system">
+        <div class="type-row"><div class="type-token">Display</div><div class="type-spec">48 / 52 · Serif 700</div><div class="display-sample">Read widely.</div></div>
+        <div class="type-row"><div class="type-token">Page title</div><div class="type-spec">32 / 38 · Serif 700</div><div class="page-sample">August Tadoku</div></div>
+        <div class="type-row"><div class="type-token">Section title</div><div class="type-spec">24 / 30 · Serif 700</div><div class="section-sample">Your reading activity</div></div>
+        <div class="type-row"><div class="type-token">Component title</div><div class="type-spec">18 / 24 · Sans 600</div><div class="component-sample">Recent updates</div></div>
+        <div class="type-row"><div class="type-token">Body comfortable</div><div class="type-spec">16 / 26 · Sans 400</div><div class="body-sample">Build understanding by reading and listening to material that interests you. The generous line height suits public, authentication, and editorial pages.</div></div>
+        <div class="type-row"><div class="type-token">Body compact</div><div class="type-spec">14 / 22 · Sans 400</div><div class="compact-sample">Admin tables and dense tools use a smaller role without changing the font family or inventing arbitrary sizes.</div></div>
+        <div class="type-row"><div class="type-token">Label / eyebrow</div><div class="type-spec">12 / 16 · Sans 700</div><div class="label-sample">Listening minutes</div></div>
+        <div class="type-row"><div class="type-token">Metadata</div><div class="type-spec">12 / 18 · Sans 400</div><div class="meta-sample numeric">Japanese · 07 Aug 2026 · 1,248 pages</div></div>
+      </div>
+      <div class="type-rules">
+        <article class="rule-card"><strong>Load real weights</strong><p>Open Sans 700 is currently missing even though `font-bold` is used. UI v2 should ship or document actual 400, 600, and 700 files—never synthetic bold.</p></article>
+        <article class="rule-card"><strong>Framework-independent fonts</strong><p>Use optional self-hosted WOFF2 assets and CSS variables. Do not depend on `next/font` or a runtime Google Fonts `@import`.</p></article>
+        <article class="rule-card"><strong>Respect multilingual text</strong><p>User-entered Japanese and other scripts stay in the sans/system fallback stack. Serif is reserved for controlled interface headings.</p></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Icon grammar proposal</p>
+        <h2>One family, two intentional modes</h2>
+        <p>Continue with Heroicons initially, but stop choosing solid versus outline ad hoc. Soft stroke endings aid recognition and do not require rounded component containers.</p>
+      </div>
+      <div class="icon-grid">
+        <article class="icon-panel">
+          <div class="panel-head"><h3>Size roles</h3><p>Three normal sizes and one illustration exception.</p></div>
+          <div class="icon-rows">
+            <div class="icon-row"><strong>16px</strong><div class="icon-demo"><svg class="icon i16 outline-icon" viewBox="0 0 24 24"><path d="M5 12h14M13 6l6 6-6 6"/></svg><span>Compact rows and inline metadata</span></div></div>
+            <div class="icon-row"><strong>20px</strong><div class="icon-demo"><svg class="icon i20 outline-icon" viewBox="0 0 24 24"><path d="M4 19.5V6.75A2.75 2.75 0 0 1 6.75 4H20v15.5H6.75A2.75 2.75 0 0 0 4 22.25M7 8h9M7 12h7"/></svg><span>Default buttons, fields, menus, and navigation</span></div></div>
+            <div class="icon-row"><strong>24px</strong><div class="icon-demo"><svg class="icon i24 outline-icon" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14"/></svg><span>Icon-only controls and prominent actions</span></div></div>
+            <div class="icon-row"><strong>48px</strong><div class="icon-demo"><svg class="icon i48 outline-icon" viewBox="0 0 24 24"><path d="M4 19.5V6.75A2.75 2.75 0 0 1 6.75 4H20v15.5H6.75A2.75 2.75 0 0 0 4 22.25M7 8h9M7 12h7"/></svg><span>Empty states only—not ordinary UI</span></div></div>
+          </div>
+        </article>
+        <article class="icon-panel">
+          <div class="panel-head"><h3>Semantic modes</h3><p>Outline describes actions; solid confirms state.</p></div>
+          <div class="component-demos">
+            <div class="demo-row">
+              <button class="btn primary" type="button"><svg class="icon i20 outline-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 5v14M5 12h14"/></svg>Add reading</button>
+              <button class="btn compact" type="button"><svg class="icon i16 outline-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M4 20h4l11-11-4-4L4 16zM13.5 6.5l4 4"/></svg>Edit</button>
+              <button class="btn icon-button" type="button" aria-label="More actions"><svg class="icon i24 outline-icon" viewBox="0 0 24 24" aria-hidden="true"><circle cx="5" cy="12" r="1"/><circle cx="12" cy="12" r="1"/><circle cx="19" cy="12" r="1"/></svg></button>
+            </div>
+            <div class="status-line"><svg class="icon i20 solid-icon success" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 2.5a9.5 9.5 0 1 0 0 19 9.5 9.5 0 0 0 0-19zm4.4 7.2-5.2 5.5a1 1 0 0 1-1.45 0L7.3 12.8l1.4-1.4 1.75 1.75L15 8.35z"/></svg><span><strong>Recorded.</strong> Your update was added.</span></div>
+            <div class="status-line"><svg class="icon i20 solid-icon danger" viewBox="0 0 24 24" aria-hidden="true"><path d="M11 3.5 2.5 19h19L13 3.5a1.14 1.14 0 0 0-2 0zM11 9h2v5h-2zm0 6.5h2v2h-2z"/></svg><span><strong>Could not save.</strong> Check the highlighted fields.</span></div>
+            <div class="icon-rule"><strong>Accessibility:</strong> labeled icons are decorative and hidden from assistive technology. Icon-only controls require an accessible name. Color never carries status alone.</div>
+          </div>
+        </article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">03 · Button API recommendation</p>
+        <h2>Classes are the primitive; React is optional</h2>
+        <p>A mandatory Button import would make simple markup less convenient and would couple navigation links to one framework. The class recipe should be the stable cross-framework contract.</p>
+      </div>
+      <div class="api-recommendation">
+        <div class="api-copy">
+          <h3>Hybrid, with a class-first bias</h3>
+          <p>`ui-v2/styles.css` owns `.btn`, variants, density, focus, disabled, and icon sizing. A Tailwind preset can expose the same tokens. Optional framework adapters add behavior without becoming the only way to obtain the styles.</p>
+          <p>This means plain HTML, React, another router, or a future non-Next application can all use the same visual contract.</p>
+        </div>
+        <pre><span class="code-comment">// No component import required</span>
+&lt;button className="btn primary"&gt;Save&lt;/button&gt;
+&lt;a className="btn" href="/contests"&gt;Contests&lt;/a&gt;
+
+<span class="code-comment">// Optional behavior adapter</span>
+&lt;Button loading icon={SaveIcon}&gt;Save&lt;/Button&gt;</pre>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">04 · Regression baseline, concretely</p>
+        <h2>Named fixtures plus behavior checks</h2>
+        <p>A baseline is the smallest representative set of UI v2 examples that must continue to render and behave correctly. It does not freeze the old design and it does not initially require screenshots.</p>
+      </div>
+      <div class="baseline">
+        <div class="baseline-row header"><span>Component</span><span>Shared style-guide fixtures</span><span>Immediate automated checks</span></div>
+        <div class="baseline-row"><strong>Buttons and links</strong><span>Primary, secondary, danger, disabled, loading, icon-only</span><span>Correct element, accessible name, disabled behavior, keyboard activation</span></div>
+        <div class="baseline-row"><strong>Form controls</strong><span>Empty, filled, error, disabled, help text</span><span>Label association, `aria-invalid`, described error, keyboard interaction</span></div>
+        <div class="baseline-row"><strong>Overlays</strong><span>Menu and modal open/closed states</span><span>Focus enters, Escape closes, focus returns to trigger</span></div>
+        <div class="baseline-row"><strong>Navigation</strong><span>Desktop, mobile closed, mobile open</span><span>Landmarks, toggle name/state, keyboard navigation</span></div>
+      </div>
+      <div class="baseline-note"><p><strong>How reuse works:</strong> the style guide imports a named fixture such as `PrimaryButtonDisabled`; the Vitest/Testing Library suite imports that same fixture and checks its semantics. The later visual-regression issue can screenshot the same fixture without inventing a second catalogue.</p></div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">05 · Additive rollout</p>
+        <h2>A separate, framework-independent UI v2</h2>
+      </div>
+      <div class="rollout">
+        <div class="rollout-step"><b>Foundation</b><strong>Create `ui-v2`</strong><span>Tokens, fonts, CSS recipes, Tailwind preset; no Next dependency.</span></div>
+        <div class="rollout-step"><b>First</b><strong>Style guide</strong><span>Document the complete v2 system and its shared fixtures.</span></div>
+        <div class="rollout-step"><b>Second</b><strong>Admin</strong><span>Exercise compact density and dense component states.</span></div>
+        <div class="rollout-step"><b>Third</b><strong>Auth</strong><span>Exercise comfortable forms and isolated flows.</span></div>
+        <div class="rollout-step"><b>Fourth</b><strong>webv2</strong><span>Migrate route-by-route while old `ui` remains available.</span></div>
+      </div>
+    </section>
+  </main>
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/artifacts/tadoku-paper-button-grammar-v11.html
+++ b/docs/wip/tadoku-paper/artifacts/tadoku-paper-button-grammar-v11.html
@@ -1,0 +1,319 @@
+<!doctype html>
+<!-- Archived Tadoku Paper planning artifact. See ../README.md. -->
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Tadoku Paper — Button Grammar and Package Direction</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Merriweather:wght@700&amp;family=Open+Sans:wght@400;600;700&amp;display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light;
+      --canvas: #f2efe8;
+      --surface: #fffefa;
+      --surface-soft: #e9e5dc;
+      --text: #211a1d;
+      --muted: #686064;
+      --rule: #c7c0b5;
+      --rule-strong: #393235;
+      --control-lower: #aba398;
+      --accent: #5747b8;
+      --accent-hover: #49399f;
+      --accent-lower: #35277f;
+      --accent-soft: #e8e4fa;
+      --danger: #a33333;
+      --danger-hover: #892828;
+      --danger-soft: #f4e2df;
+      --danger-action: #a33333;
+      --danger-action-hover: #892828;
+      --danger-action-lower: #651b1b;
+      --shadow: 3px 3px 0 rgba(33, 26, 29, .16);
+      --font-serif: Merriweather, Georgia, serif;
+      --font-sans: "Open Sans", ui-sans-serif, system-ui, sans-serif;
+    }
+    [data-theme="dark"] {
+      color-scheme: dark;
+      --canvas: #171517;
+      --surface: #222022;
+      --surface-soft: #2d292c;
+      --text: #f2eee8;
+      --muted: #b8afb3;
+      --rule: #4e484b;
+      --rule-strong: #81777c;
+      --control-lower: #696166;
+      --accent: #9a8bea;
+      --accent-hover: #6d5cc7;
+      --accent-lower: #40318c;
+      --accent-soft: #332d52;
+      --danger: #d77171;
+      --danger-hover: #b94f4f;
+      --danger-soft: #472729;
+      --danger-action: #9f3d3d;
+      --danger-action-hover: #b14a4a;
+      --danger-action-lower: #6f2424;
+      --shadow: 3px 3px 0 rgba(0, 0, 0, .48);
+    }
+    * { box-sizing: border-box; }
+    body { margin: 0; background: var(--canvas); color: var(--text); font-family: var(--font-sans); line-height: 1.5; }
+    button { font: inherit; color: inherit; }
+    h1, h2, h3, p { margin-top: 0; }
+    h1, h2 { font-family: var(--font-serif); }
+    h1 { max-width: 890px; margin-bottom: 16px; font-size: clamp(38px, 6vw, 64px); line-height: 1; letter-spacing: -.035em; }
+    h2 { margin-bottom: 9px; font-size: clamp(26px, 3vw, 36px); line-height: 1.1; letter-spacing: -.02em; }
+    h3 { margin-bottom: 7px; font-size: 18px; line-height: 24px; }
+    p { color: var(--muted); }
+    code { font-family: ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .page { width: min(1160px, calc(100% - 32px)); margin: 0 auto; padding: 44px 0 72px; }
+    .topbar { display: flex; align-items: start; justify-content: space-between; gap: 24px; margin-bottom: 50px; }
+    .heading-lockup { display: grid; grid-template-columns: 58px 1fr; gap: 17px; align-items: start; }
+    .brand-mark { width: 58px; height: 58px; color: var(--text); }
+    .eyebrow { margin: 0 0 10px; color: var(--accent); font-size: 12px; font-weight: 700; letter-spacing: .14em; line-height: 16px; text-transform: uppercase; }
+    .lede, .section-intro { max-width: 800px; }
+    .lede { font-size: 18px; }
+    .section { margin-top: 56px; }
+    .section-intro { margin-bottom: 22px; }
+
+    .btn {
+      display: inline-flex;
+      min-height: 44px;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      padding: 9px 15px 8px;
+      border: 1px solid var(--rule);
+      border-bottom: 2px solid var(--control-lower);
+      border-radius: 0;
+      background: var(--surface);
+      color: var(--text);
+      cursor: pointer;
+      font-weight: 700;
+      transition: background-color 140ms ease, border-color 140ms ease, color 140ms ease;
+    }
+    .btn:hover { border-color: var(--rule-strong); border-bottom-color: var(--control-lower); background: var(--surface-soft); }
+    .btn.primary { border-color: var(--accent); border-bottom-color: var(--accent-lower); background: var(--accent); color: #fffefa; }
+    .btn.primary:hover { border-color: var(--accent-hover); border-bottom-color: var(--accent-lower); background: var(--accent-hover); }
+    [data-theme="dark"] .btn.primary { border-color: #6150bc; background: #6150bc; }
+    [data-theme="dark"] .btn.primary:hover { border-color: var(--accent-hover); background: var(--accent-hover); }
+    .btn.ghost { border-color: transparent; border-bottom-color: transparent; background: transparent; }
+    .btn.ghost:hover { border-color: transparent; background: var(--surface-soft); }
+    .btn.danger { border-color: var(--danger); border-bottom-color: var(--danger); color: var(--danger); }
+    .btn.danger:hover { background: var(--danger-soft); }
+    .btn.primary.danger { border-color: var(--danger-action); border-bottom-color: var(--danger-action-lower); background: var(--danger-action); color: #fffefa; }
+    .btn.primary.danger:hover { border-color: var(--danger-action-hover); background: var(--danger-action-hover); }
+    .btn.ghost.danger { border-color: transparent; border-bottom-color: transparent; }
+    .btn.compact { min-height: 36px; padding: 6px 11px 5px; font-size: 14px; }
+    .btn.icon-only { width: 44px; padding-inline: 0; }
+    .btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .btn:disabled { cursor: not-allowed; opacity: .55; }
+    .btn.loading::before,
+    .btn[aria-busy="true"]::before {
+      content: "";
+      width: 14px;
+      height: 14px;
+      border: 2px solid currentColor;
+      border-right-color: transparent;
+      border-radius: 50%;
+      animation: spin 700ms linear infinite;
+    }
+    @keyframes spin { to { transform: rotate(360deg); } }
+    @media (prefers-reduced-motion: reduce) { .btn.loading::before, .btn[aria-busy="true"]::before { animation: none; } }
+    .theme-toggle { flex: none; }
+    .icon { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-width: 1.8; stroke-linecap: round; stroke-linejoin: round; }
+    .icon.close { width: 24px; height: 24px; }
+
+    .summary { display: grid; grid-template-columns: repeat(3, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); box-shadow: var(--shadow); }
+    .summary-item { padding: 18px; background: var(--surface); }
+    .summary-item strong { display: block; margin-bottom: 5px; }
+    .summary-item p { margin: 0; font-size: 13px; }
+
+    .button-grid { display: grid; grid-template-columns: repeat(3, 1fr); gap: 14px; }
+    .button-card { display: flex; min-height: 270px; flex-direction: column; padding: 20px; border: 1px solid var(--rule); background: var(--surface); }
+    .button-card p { font-size: 14px; }
+    .button-stage { display: flex; flex: 1; align-items: center; justify-content: center; padding: 25px 10px; background: var(--canvas); }
+    .button-code { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--rule); color: var(--muted); font-size: 12px; }
+    .tag { display: inline-block; align-self: flex-start; margin-bottom: 8px; padding: 3px 6px; background: var(--accent-soft); color: var(--accent); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+
+    .close-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 22px; }
+    .dialog { border: 1px solid var(--rule-strong); background: var(--surface); box-shadow: var(--shadow); }
+    .dialog-head { display: flex; align-items: center; justify-content: space-between; gap: 15px; padding: 14px 17px; border-bottom: 1px solid var(--rule); }
+    .dialog-head h3 { margin: 0; }
+    .dialog-body { min-height: 115px; padding: 18px; }
+    .dialog-actions { display: flex; justify-content: flex-end; gap: 10px; padding: 14px 17px; border-top: 1px solid var(--rule); }
+    .callout { padding: 20px 22px 20px 28px; border-top: 1px solid var(--rule); border-right: 1px solid var(--rule); border-bottom: 1px solid var(--rule); background: var(--surface); position: relative; }
+    .callout::before { content: ""; position: absolute; top: -1px; bottom: -1px; left: 0; width: 6px; background: var(--accent); }
+    .callout p:last-child { margin-bottom: 0; }
+
+    .tone-table { overflow: hidden; border: 1px solid var(--rule-strong); background: var(--surface); }
+    .tone-row { display: grid; grid-template-columns: 150px 1fr 1fr; align-items: center; gap: 18px; padding: 16px 18px; }
+    .tone-row + .tone-row { border-top: 1px solid var(--rule); }
+    .tone-row.header { background: var(--surface-soft); font-size: 11px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    .tone-row strong { font-size: 14px; }
+    .tone-row span { color: var(--muted); font-size: 13px; }
+
+    .parity { display: grid; grid-template-columns: 1fr 1fr; border: 1px solid var(--rule-strong); background: var(--surface); }
+    .code-panel { min-width: 0; }
+    .code-panel + .code-panel { border-left: 1px solid var(--rule); }
+    .code-head { padding: 12px 16px; border-bottom: 1px solid var(--rule); font-size: 12px; font-weight: 700; }
+    pre { margin: 0; padding: 18px; overflow-x: auto; background: var(--surface-soft); color: var(--text); font: 12px/1.7 ui-monospace, SFMono-Regular, Menlo, monospace; }
+    .architecture { display: grid; grid-template-columns: 1fr 1.2fr; gap: 22px; }
+    .package-card { padding: 22px; border: 1px solid var(--rule-strong); background: var(--surface); box-shadow: var(--shadow); }
+    .package-name { display: inline-block; margin: 6px 0 16px; padding: 8px 10px; background: var(--text); color: var(--surface); font: 700 16px/1 ui-monospace, monospace; }
+    .package-card ul { margin: 0; padding-left: 19px; color: var(--muted); font-size: 14px; }
+    .package-card li + li { margin-top: 7px; }
+    .migration { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1px; border: 1px solid var(--rule); background: var(--rule); }
+    .migration-step { padding: 18px; background: var(--surface); }
+    .migration-step b { display: block; margin-bottom: 5px; color: var(--accent); font-size: 10px; letter-spacing: .08em; text-transform: uppercase; }
+    .migration-step strong { display: block; margin-bottom: 4px; }
+    .migration-step span { color: var(--muted); font-size: 12px; }
+
+    @media (max-width: 900px) {
+      .button-grid { grid-template-columns: repeat(2, 1fr); }
+      .architecture { grid-template-columns: 1fr; }
+    }
+    @media (max-width: 650px) {
+      .page { width: min(100% - 20px, 1160px); padding-top: 26px; }
+      .topbar { display: block; }
+      .theme-toggle { margin-top: 20px; }
+      .heading-lockup { grid-template-columns: 42px 1fr; }
+      .brand-mark { width: 42px; height: 42px; }
+      .summary, .button-grid, .close-grid, .parity, .migration { grid-template-columns: 1fr; }
+      .code-panel + .code-panel { border-left: 0; border-top: 1px solid var(--rule); }
+      .tone-row { grid-template-columns: 1fr; gap: 5px; }
+      .tone-row.header { display: none; }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header class="topbar">
+      <div class="heading-lockup">
+        <svg class="brand-mark" viewBox="0 0 64 64" role="img" aria-label="Tadoku Cut Meter mark">
+          <defs><mask id="brand-cut"><rect width="64" height="64" fill="white"/><path d="M2 43L62 17" stroke="black" stroke-width="7"/></mask></defs>
+          <path fill="currentColor" mask="url(#brand-cut)" d="M7 38h13v18H7zM25 24h14v32H25zM44 8h13v48H44z"/>
+        </svg>
+        <div>
+          <p class="eyebrow">Tadoku Paper · Button grammar · Study 11</p>
+          <h1>Names should describe emphasis, not intent.</h1>
+          <p class="lede">Default, primary, and ghost describe visual hierarchy. Danger modifies tone. “Close” is an action label whose visual treatment depends on where it appears.</p>
+        </div>
+      </div>
+      <button class="btn theme-toggle" id="theme-toggle" type="button" aria-pressed="false">Switch to dark</button>
+    </header>
+
+    <section>
+      <div class="summary">
+        <article class="summary-item"><strong>Design system</strong><p>Human-facing name: Tadoku Paper.</p></article>
+        <article class="summary-item"><strong>Package</strong><p>React package: <code>paper-ui</code>; never Next-specific.</p></article>
+        <article class="summary-item"><strong>Migration</strong><p>One complete application at a time; no mixed v1/v2 UI inside an app.</p></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">01 · Visual hierarchy</p>
+        <h2>Three variants cover ordinary actions</h2>
+        <p>There is no separate secondary variant in this proposal. Default already fills that role, which keeps both the vocabulary and the visual hierarchy smaller.</p>
+      </div>
+      <div class="button-grid">
+        <article class="button-card"><span class="tag">Default</span><h3>Neutral action</h3><p>Routine, reversible, or lower-priority actions: Cancel, Close, Edit, Back.</p><div class="button-stage"><button class="btn" type="button">Close</button></div><div class="button-code"><code>class="btn"</code></div></article>
+        <article class="button-card"><span class="tag">Primary</span><h3>Preferred next action</h3><p>The single action the interface most wants completed: Save, Submit, Join.</p><div class="button-stage"><button class="btn primary" type="button">Save update</button></div><div class="button-code"><code>class="btn primary"</code></div></article>
+        <article class="button-card"><span class="tag">Ghost</span><h3>Interface chrome</h3><p>Low-emphasis controls, toolbars, back actions, and compact close buttons.</p><div class="button-stage"><button class="btn ghost" type="button"><svg class="icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M5 12h14M11 6l-6 6 6 6"/></svg>Back</button></div><div class="button-code"><code>class="btn ghost"</code></div></article>
+        <article class="button-card"><span class="tag">Loading state</span><h3>Composable state</h3><p>Loading combines with any hierarchy. The class draws it; attributes carry behavior and meaning.</p><div class="button-stage"><button class="btn primary loading" type="button" aria-busy="true" disabled>Saving</button></div><div class="button-code"><code>class="btn primary loading"</code></div></article>
+        <article class="button-card"><span class="tag">Danger tone</span><h3>Destructive, lower emphasis</h3><p>Use when deletion is available but not the dialog’s intended next step.</p><div class="button-stage"><button class="btn danger" type="button">Delete draft</button></div><div class="button-code"><code>class="btn danger"</code></div></article>
+        <article class="button-card"><span class="tag">Primary + danger</span><h3>Destructive confirmation</h3><p>Reserved for a dedicated confirmation flow where destruction is the explicit next action.</p><div class="button-stage"><button class="btn primary danger" type="button">Delete permanently</button></div><div class="button-code"><code>class="btn primary danger"</code></div></article>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">02 · Is default the close button?</p>
+        <h2>Sometimes. Placement decides.</h2>
+        <p>A footer button participates in the action hierarchy. A top-right × belongs to window chrome and should visually recede.</p>
+      </div>
+      <div class="close-grid">
+        <div class="dialog">
+          <div class="dialog-head"><h3>Edit reading</h3></div>
+          <div class="dialog-body"><p>The footer uses a default Cancel button beside the primary Save action.</p></div>
+          <div class="dialog-actions"><button class="btn" type="button">Cancel</button><button class="btn primary" type="button">Save update</button></div>
+        </div>
+        <div class="dialog">
+          <div class="dialog-head"><h3>Reading details</h3><button class="btn ghost icon-only" type="button" aria-label="Close dialog"><svg class="icon close" viewBox="0 0 24 24" aria-hidden="true"><path d="m6 6 12 12M18 6 6 18"/></svg></button></div>
+          <div class="dialog-body"><p>The top-right × is a ghost icon-only button with an accessible name.</p></div>
+          <div class="dialog-actions"><button class="btn" type="button">Close</button></div>
+        </div>
+      </div>
+      <div class="callout"><p><strong>Recommendation:</strong> do not create a `close` visual variant. “Close” is purpose; default or ghost is presentation. This prevents purpose-specific variants such as `save`, `edit`, or `back` from multiplying the API.</p></div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">03 · Variant versus tone</p>
+        <h2>Danger modifies the hierarchy</h2>
+        <p>Keeping danger independent lets the same destructive action appear quietly in a menu or strongly in its final confirmation.</p>
+      </div>
+      <div class="tone-table">
+        <div class="tone-row header"><span>Combination</span><span>Visual meaning</span><span>Typical use</span></div>
+        <div class="tone-row"><strong>Default</strong><span>Neutral bordered action</span><span>Cancel, Close, Edit</span></div>
+        <div class="tone-row"><strong>Primary</strong><span>Filled violet action</span><span>Save, Submit, Join</span></div>
+        <div class="tone-row"><strong>Ghost</strong><span>Borderless low emphasis</span><span>Toolbar, ×, Back</span></div>
+        <div class="tone-row"><strong>Default + danger</strong><span>Outlined destructive tone</span><span>Delete option before confirmation</span></div>
+        <div class="tone-row"><strong>Primary + danger</strong><span>Filled destructive tone</span><span>Final delete confirmation</span></div>
+        <div class="tone-row"><strong>Ghost + danger</strong><span>Quiet destructive tone</span><span>Menu or compact toolbar</span></div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">04 · Class and component parity</p>
+        <h2>Two APIs, one CSS implementation</h2>
+      </div>
+      <div class="parity">
+        <div class="code-panel"><div class="code-head">Class API · always supported</div><pre>&lt;button className="btn"&gt;Close&lt;/button&gt;
+&lt;button className="btn primary"&gt;Save&lt;/button&gt;
+&lt;button
+  className="btn primary loading"
+  aria-busy="true"
+  disabled
+&gt;Saving&lt;/button&gt;</pre></div>
+        <div class="code-panel"><div class="code-head">React API · optional convenience</div><pre>&lt;Button&gt;Close&lt;/Button&gt;
+&lt;Button variant="primary"&gt;Save&lt;/Button&gt;
+&lt;Button
+  variant="primary"
+  loading
+&gt;Saving&lt;/Button&gt;</pre></div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="section-intro">
+        <p class="eyebrow">05 · Paper architecture</p>
+        <h2>React, but never Next.js-specific</h2>
+      </div>
+      <div class="architecture">
+        <article class="package-card">
+          <p class="eyebrow">Package</p><h3>Tadoku Paper</h3><div class="package-name">paper-ui</div>
+          <ul><li>React and React DOM as peer dependencies.</li><li>No `next`, `next/image`, `next/link`, or `next/font` dependency.</li><li>Exports components, tokens, CSS recipes, font assets, icons, and an optional Tailwind preset.</li><li>Router-specific links use the public class API or a caller-supplied React element.</li></ul>
+        </article>
+        <div class="migration">
+          <div class="migration-step"><b>1 · Big bang</b><strong>Style guide</strong><span>Build the complete Tadoku Paper catalogue and fixtures.</span></div>
+          <div class="migration-step"><b>2 · Big bang</b><strong>Admin</strong><span>Switch the whole application to compact Paper components.</span></div>
+          <div class="migration-step"><b>3 · Big bang</b><strong>Auth</strong><span>Switch the whole application to comfortable Paper forms.</span></div>
+          <div class="migration-step"><b>4 · Big bang</b><strong>webv2</strong><span>Switch the final application after Paper is proven elsewhere.</span></div>
+        </div>
+      </div>
+    </section>
+  </main>
+  <script>
+    const root = document.documentElement;
+    const toggle = document.getElementById('theme-toggle');
+    toggle.addEventListener('click', () => {
+      const isDark = root.dataset.theme === 'dark';
+      root.dataset.theme = isDark ? '' : 'dark';
+      toggle.textContent = isDark ? 'Switch to dark' : 'Switch to light';
+      toggle.setAttribute('aria-pressed', String(!isDark));
+    });
+  </script>
+</body>
+</html>

--- a/docs/wip/tadoku-paper/decision-log.md
+++ b/docs/wip/tadoku-paper/decision-log.md
@@ -1,0 +1,383 @@
+# Tadoku Paper design-system decision log
+
+This is the permanent record of the Tadoku Paper planning discussion. The original audit remains preserved at [artifacts/design-system-refinement-audit.html](artifacts/design-system-refinement-audit.html) and [Presenter](https://presentr.lab/html/tadoku-design-system-refinement-audit).
+
+Last updated: 2026-08-07
+
+## Final decision snapshot
+
+### Identity and visual grammar
+
+- Human-facing design-system name: **Tadoku Paper**.
+- Compact brand mark: the original monochrome-first Cut Meter with three rising bars and a square diagonal negative-space cut.
+- Preserve the editorial book/library character with sharp geometry and no component border radius.
+- Use warm paper/canvas neutrals, dark ink structure, and restrained ink violet as the brand/action accent.
+- Use straight accent rails; a colored left rail replaces the neutral left hairline.
+- Static surfaces use quiet 1px neutral borders. Pale form controls use a subtle 2px lower edge. Filled actions retain a stronger 2px lower edge.
+- Ordinary surfaces remain flat. Floating overlays use a 3px hard-offset shadow; rare showcase surfaces may use 5px.
+- Dark mode uses a lifted structural violet and deeper filled-action violet with light action text.
+- Support comfortable 44px and compact 36px density modes.
+
+### Typography and iconography
+
+- Merriweather is reserved for display, page, and section hierarchy.
+- Open Sans is used for component titles, labels, body copy, and dense interfaces, with real 400/600/700 weights.
+- Font delivery must be self-hostable and framework-independent.
+- Heroicons remain the initial icon family: outline for navigation/actions and solid for status/confirmation.
+- Icon sizes are 16px compact, 20px default, 24px prominent/icon-only, and 48px only for empty-state illustration.
+
+### Package and APIs
+
+- Package name: **`paper-ui`**.
+- `paper-ui` assumes React but must not depend on Next.js or Next-specific link, image, routing, or font APIs.
+- Both class recipes and optional React components are first-class public APIs and share one CSS implementation.
+- Standard button hierarchy is default, primary, and ghost. Danger is a composable tone; loading is a composable state.
+- Every standard button state remains usable through classes without importing a component.
+- Loading visuals must be paired with `aria-busy="true"` and normally native disabled behavior.
+
+### Documentation, tests, and migration
+
+- Replace the current style-guide `Showcase` with a complete documentation shell.
+- Give each component a searchable route, complete state matrix, realistic Tadoku examples, co-located metadata/examples/tests, and lifecycle status.
+- Separate primitives/components, product patterns, and experiments.
+- Reuse named style-guide fixtures in Vitest, React Testing Library, `user-event`, and `jest-dom` behavior/accessibility tests.
+- Introduce `paper-ui` alongside legacy `ui` at the repository level, but never mix them inside one application.
+- Perform a complete migration per application in this order: style guide, admin, auth, webv2.
+- Remove legacy `ui` only after the final migration and a repository-wide consumer search.
+
+## Agreed scope
+
+### Implement in the upcoming plan
+
+- P0.1 — Introduce semantic design tokens.
+- P0.3 — Replace `Showcase` with a complete documentation shell.
+- P1.1 — Use one route per component, with search.
+- P1.2 — Show the full component state matrix.
+- P1.3 — Rebuild foundation pages.
+- P1.4 — Co-locate examples, metadata, and tests.
+- P2.1 — Separate components, patterns, and experiments.
+- P2.2 — Add lifecycle and governance metadata.
+
+### Discussed and ready for planning
+
+1. P0.2 — Define Tadoku's visual grammar. **Resolved.**
+2. P0.5 — Define the Button/class API. **Resolved enough for planning.**
+3. P2.4 — Tighten the package boundary. **Resolved.**
+
+### Deferred GitHub issues
+
+- P0.4 — Accessibility contract: https://github.com/tadoku/tadoku/issues/761
+- P1.5 — Automated component regression gates: https://github.com/tadoku/tadoku/issues/762
+- P2.3 — Themes and user preferences: https://github.com/tadoku/tadoku/issues/763
+
+## Cross-cutting constraints
+
+- The migration must cover `webv2`, `admin`, and `auth`, not only the style guide.
+- All four applications currently import the same unscoped `ui/styles/globals.css`.
+- Shared UI changes build and publish four application images independently.
+- Introduce `paper-ui` additively at the repository level while unmigrated applications continue using legacy `ui`.
+- Do not mix legacy `ui` and `paper-ui` inside an application; each application receives one complete migration.
+- Migrate in this order: style guide, admin, auth, webv2.
+- Keep the legacy package until repository searches show no remaining application consumers.
+- Preserve the existing audit report; do not overwrite its file or Presentr key.
+- Parallel sub-agents may implement independent work after the decisions and plan are locked.
+
+## Immediate testing baseline for the implementation plan
+
+- Add rendered component tests using Vitest, React Testing Library, `user-event`, and `jest-dom`.
+- Test new/refactored component contracts, roles, names, disabled/loading behavior, and keyboard interaction.
+- Reuse named examples between the documentation renderer and tests.
+- Continue using all four application builds as the compatibility matrix.
+- Keep full Playwright visual regression, axe scanning, and CI baseline management in issue #762.
+
+---
+
+## Discussion 1 — P0.2: Tadoku's visual grammar
+
+### Existing character to preserve
+
+- Violet as the main brand/action color.
+- Merriweather headings and Tadoku's editorial, reading-oriented identity.
+- Product-specific examples instead of generic component-library demos.
+
+### Visual preview
+
+- Bookplate and flat-archival comparison: https://presentr.lab/html/tadoku-bookplate-direction-preview
+- Archived source: [artifacts/design-system-bookplate-preview.html](artifacts/design-system-bookplate-preview.html)
+
+### Preview feedback
+
+- Bookplate is preferred over flat archival.
+- The first Bookplate preview uses too many unrelated border colors and weights.
+- Border treatment must be simplified into a consistent, deliberate grammar.
+- The current bright purple needs to be evaluated against the book/library direction.
+- The logo and its relationship to the refined visual grammar need exploration.
+
+### Refinement under review
+
+- One neutral border family rather than component-specific border colors.
+- Border roles limited to structural, component, interactive weight, and floating depth.
+- Status color appears as a small marker, never as a competing full outline.
+- Purple is treated like printed annotation ink and used sparingly.
+- Preserve the existing geometric wordmark unless a lockup study shows a clear improvement.
+
+### Refinement preview v2
+
+- Refined borders, accent comparison, and logo lockups: https://presentr.lab/html/tadoku-bookplate-refinement-v2
+- Archived source: [artifacts/design-system-bookplate-refinement-v2.html](artifacts/design-system-bookplate-refinement-v2.html)
+- Interactive accent choices: current violet, ink violet, and library plum.
+- Working recommendation in the preview: ink violet and the existing unboxed wordmark, with a catalog lockup as a secondary composition.
+
+### Refinement v2 feedback and decisions
+
+- **Decided:** use ink violet for the light theme; it retains Tadoku's purple brand while fitting the printed Bookplate direction.
+- When a component has a colored left accent, that accent replaces the neutral left hairline. Do not draw both.
+- Soften the interactive lower edge: keep a 1px border on every side and use only a darker 1px bottom color, not extra bottom thickness.
+- The v2 logo preview is invalid: the reusable SVG lost the original even-odd fill behavior and the accent fill did not reliably carry through the SVG `<use>` instance.
+- Correct subsequent logo studies before making any logo decision.
+- Dark mode requires a tonal mapping of the same ink-violet hue, not reuse of the light-theme hex.
+
+### Light/dark refinement preview v3
+
+- Corrected light/dark study: https://presentr.lab/html/tadoku-bookplate-dark-preview-v3
+- Archived source: [artifacts/design-system-bookplate-dark-preview-v3.html](artifacts/design-system-bookplate-dark-preview-v3.html)
+- Light accent: ink violet `#5747B8`.
+- Proposed dark counterpart: lifted ink violet `#9A8BEA` with dark foreground on filled actions.
+- Accent-edge rule and softened 1px interactive lower color are demonstrated in the product specimen.
+- Logo preview restores `fill-rule="evenodd"` and applies the accent wedge independently.
+
+### Refinement v3 feedback
+
+- The thick accent border creates triangular/mitered joins where it meets the 1px top and bottom borders.
+- **Direction:** replace the border join with a positioned accent rail that overlays the left ends of the neutral borders, producing one uninterrupted straight edge without extra wrapper nesting.
+- Try a 2px lower border on form controls and interactive components; the 1px color-only treatment is too subtle.
+- Explore five distinct compact logo-mark concepts that represent Tadoku rather than extracting the K wedge from the existing wordmark.
+
+### Refinement v4 preview
+
+- Presenter: `https://presentr.lab/html/tadoku-bookplate-border-logo-v4`
+- Archived source: [artifacts/design-system-bookplate-border-logo-v4.html](artifacts/design-system-bookplate-border-logo-v4.html)
+- The accent is now a positioned rectangular rail that overlays the top and bottom hairline endpoints; it has no mitered joins and requires no additional wrapper.
+- Interactive controls use 1px top/side rules with a 2px lower rule. Static containers retain a consistent 1px hairline.
+- Five schematic logo territories are included: Open Book T, Bookmark T, Library Shelf, Reading Loop, and Catalog Card.
+- Initial shortlist for discussion: Bookmark T for compact clarity; Reading Loop for distinctiveness.
+
+### Refinement v4 feedback
+
+- Keep the 2px lower edge, but make it lighter and more subtle on pale input fields.
+- Filled submit buttons can retain their stronger lower edge.
+- Add a visible hover state to primary submit buttons.
+- Reject all letter-driven logo concepts; the forced T does not feel natural and none of the first set reads correctly.
+- Explore abstract marks without hidden initials or elaborate letter construction.
+
+### Refinement v5 preview
+
+- Presenter: `https://presentr.lab/html/tadoku-bookplate-controls-logo-v5`
+- Archived source: [artifacts/design-system-bookplate-controls-logo-v5.html](artifacts/design-system-bookplate-controls-logo-v5.html)
+- Pale fields now use a separate soft-neutral 2px lower-edge token; filled primary actions retain the deeper ink-violet edge.
+- Primary actions transition to a lighter ink-violet fill on hover while retaining a stable lower edge.
+- The logo study has been reset with five non-letter territories: Page Turn, Open Passage, Accumulation, Reading Current, and Marginal Rhythm.
+- Logo guardrails: no hidden initials, one meaningful violet gesture, and a legible two-color silhouette at 16px.
+
+### Refinement v5 feedback
+
+- The quieter 2px lower edge on inputs is approved.
+- In dark mode, try light text on primary buttons.
+- Reject the second logo set; the abstract forms still read as generic or unusable interface icons.
+- New identity territories should engage more directly with listening, language learning, contests, friendly competition, and media consumption.
+
+### Refinement v6 preview
+
+- Presenter: `https://presentr.lab/html/tadoku-bookplate-brand-v6`
+- Archived source: [artifacts/design-system-bookplate-brand-v6.html](artifacts/design-system-bookplate-brand-v6.html)
+- Dark primary actions now use light text on a deeper action-specific violet; default and hover contrast are approximately 6.15:1 and 5.19:1.
+- Bright dark-mode ink violet remains reserved for rails, focus rings, and small structural accents.
+- Five new territories: Immersion Field, Living Signal, Language Weave, Friendly Pace, and Media Feed.
+- Every mark is shown with a neutral Tadoku wordmark and at 28px/16px.
+- Brand recommendation: keep the master mark centered on immersion/language; treat competition as social energy and potentially give contests a separate badge rather than making the master identity trophy-like.
+
+### Refinement v6 feedback
+
+- Add the hard-offset floating treatment from the Bookplate v2 study to the design language/system.
+- Language Weave is visually strongest in the third set, but still too busy and not viable as-is.
+- Use the Bookmeter logo as conceptual inspiration: a very simple growing bar chart with immediate recognition.
+- The Tadoku compact mark must stand out with few shapes and remain recognizable with no color.
+- Color is an optional accent only; it must not create or rescue the mark.
+
+### Refinement v7 preview
+
+- Presenter: `https://presentr.lab/html/tadoku-bookplate-meter-v7`
+- Archived source: [artifacts/design-system-bookplate-meter-v7.html](artifacts/design-system-bookplate-meter-v7.html)
+- **Approved direction:** add hard-edged elevation as named roles: `floating` uses a strong 1px border plus a 3px hard offset; rare `showcase` surfaces may use a 5px hard offset. Ordinary cards remain flat.
+- Logo exploration is narrowed to one meter family rather than five unrelated metaphors.
+- Five monochrome-first variations: Three Beat, Page Meter, Cut Meter, Signal Rise, and Stacked Measure.
+- Cut Meter reduces the directional movement of Language Weave to one negative-space diagonal across growing bars.
+- Every mark is shown in solid monochrome, reversed, optionally accented, and beside a wordmark.
+- Non-negotiable order: black first, reverse second, accent third.
+- Reference principle from Bookmeter: few shapes, one baseline, immediate growth rhythm. Do not copy its exact three-bar proportions or green treatment.
+
+### Refinement v7 feedback
+
+- Cut Meter is the first compact-mark direction approved as a solid foundation.
+- Explore variations without changing the three-bar silhouette.
+- Vary the negative-space cut shape, including a slightly rounded line.
+- Begin surfacing the remaining design-system questions while the mark is refined.
+
+### Refinement v8 preview
+
+- Presenter: `https://presentr.lab/html/tadoku-cut-meter-variations-v8`
+- Archived source: [artifacts/design-system-cut-meter-variations-v8.html](artifacts/design-system-cut-meter-variations-v8.html)
+- Six Cut Meter variations: square diagonal, soft diagonal, tapered passage, gentle wave, stepped cut, and separate notches.
+- Suggested refinement for initial review: soft diagonal. Only the cut endpoints are rounded; the bars and interface geometry remain square.
+- All variations use identical bar proportions and are tested at 28px, 16px, reversed, and in a wordmark lockup.
+- The study now surfaces the remaining question queue: density, typography/icon grammar, typed Button APIs, package boundary, application rollout order, and the immediate regression-test baseline.
+- Suggested discussion sequence: finish the Cut Meter choice, decide density to close P0.2, then discuss P0.5 Button APIs and P2.4 package boundaries before creating the implementation plan.
+
+### Refinement v8 feedback
+
+- The soft diagonal does not appear materially softer than the original.
+- Explore a few genuinely rounded versions of the negative-space cut.
+
+### Refinement v9 preview
+
+- Presenter: `https://presentr.lab/html/tadoku-cut-meter-soft-v9`
+- Archived source: [artifacts/design-system-cut-meter-soft-v9.html](artifacts/design-system-cut-meter-soft-v9.html)
+- Construction correction: the previous line's rounded endpoints sat outside the bars and were clipped away, so the visible intersections remained sharp.
+- Each new visible cut segment has its own rounded geometry inside the bar.
+- Four softness levels: restrained capsules, full capsules, bowed capsules, and circular passage.
+- All four retain the fixed three-bar silhouette and are tested at 28px, 16px, reversed, and in a wordmark lockup.
+
+### Decisions after v9
+
+- **Density approved:** use two named modes—comfortable 44px controls and compact 36px controls.
+- **Compact mark selected for now:** use the original Cut Meter with the square diagonal cut; do not continue with the rounded-cut variants.
+- Discuss typography and icon grammar next.
+- A mandatory imported Button component is not assumed. The existing class/Tailwind-style convenience is important and needs to remain available.
+- UI v2 must move away from Next.js-specific dependencies because the applications may move away from Next.js.
+- Create UI v2 additively so legacy `ui` remains usable throughout migration.
+- Confirmed application rollout order: style guide, admin, auth, then webv2.
+- Explain and discuss the immediate regression baseline before locking the implementation plan.
+
+### Typography, icon, API, and regression preview v10
+
+- Presenter: `https://presentr.lab/html/tadoku-type-icon-baseline-v10`
+- Archived source: [artifacts/design-system-type-icon-baseline-v10.html](artifacts/design-system-type-icon-baseline-v10.html)
+- Typography proposal: Merriweather for display/page/section hierarchy; Open Sans for component titles, labels, body copy, and dense interfaces.
+- Proposed text roles: display 48/52, page 32/38, section 24/30, component 18/24, comfortable body 16/26, compact body 14/22, label 12/16, metadata 12/18.
+- Fix the current synthetic-bold risk: Open Sans 700 is used by classes but is not currently loaded.
+- Framework-independent font direction: optional self-hosted WOFF2/CSS assets; no `next/font` and no runtime Google Fonts import in the implementation.
+- Icon proposal: keep Heroicons initially; outline icons for navigation/actions, solid icons for status/confirmation; 16px compact, 20px default, 24px prominent/icon-only, 48px empty-state exception.
+- Rounded icon stroke caps are allowed for recognition even though component containers stay square.
+- Button API recommendation: class recipes are the cross-framework primitive (`btn primary`); an optional thin React adapter adds behavior but is not required for styling.
+- Regression baseline clarified: named fixtures are shared by style-guide documentation and Vitest/Testing Library behavior/accessibility tests. It does not freeze old visuals or require screenshots. The later visual-regression issue can reuse the same fixtures.
+- Proposed first fixture groups: buttons/links, form controls, overlays, and navigation.
+
+### Decisions after v10
+
+- **Typography approved:** Merriweather for display/page/section hierarchy; Open Sans for component titles, labels, body text, and dense interfaces. Use the proposed named scale and load real 400/600/700 sans weights.
+- **Icon grammar approved:** outline for navigation/actions, solid for status/confirmation; 16px compact, 20px default, 24px prominent/icon-only, and 48px only for empty-state illustration.
+- Rounded icon stroke endings are allowed for legibility while component geometry remains sharp.
+- **Button direction:** keep class recipes as the primary cross-framework API. Loading may be expressed with `btn primary loading` and does not require a React component.
+- Loading styling must be paired with semantic/behavioral state: `aria-busy="true"` and normally `disabled` on a native button. Prefer the semantic attribute as the CSS source of truth, with `.loading` available as a convenience alias if desired.
+- Optional framework adapters remain permissible but are not required to obtain any standard visual state.
+- **Regression baseline approved:** reuse named style-guide fixtures in behavior/accessibility tests first; add screenshot comparisons through the deferred visual-regression issue.
+- **Button architecture approved:** UI v2 supports both the class API and optional Button components.
+- The class API remains a first-class, documented, and tested public contract—not a legacy fallback.
+- Button components must compose the same public classes and semantic attributes; they must not own a separate private styling implementation.
+- Every standard state and variant, including loading, must remain usable without importing a framework component.
+
+### Agreed direction
+
+- No border radius. Sharp edges are an intentional Tadoku design principle.
+- The square geometry supports the book, library, and slightly old-school character of the product.
+- Refinement should come from proportion, typography, color, borders, spacing, and interaction states—not rounded corners.
+
+### Remaining recommended direction
+
+- Border-led surfaces: subtle 1px borders as the default separator.
+- No shadow on ordinary inline surfaces; restrained elevation for raised cards and popovers; stronger elevation only for overlays.
+- Test a restrained 2px lower rule on interactive controls only; static surfaces remain 1px.
+- Two named densities:
+  - Comfortable: 44px controls for public and authentication experiences.
+  - Compact: 36px controls for admin and dense data interfaces.
+- Icon scale: 16px, 20px, and 24px.
+- One consistent 2px `:focus-visible` ring with a 2px offset.
+- Motion durations: 120ms, 180ms, and 240ms, with reduced-motion support deferred to issue #763.
+
+### Safe migration model
+
+1. Create the new React-based, Next-independent `paper-ui` package with Tadoku Paper tokens, CSS recipes, components, assets, and tests.
+2. Rebuild and completely migrate the style guide so it becomes the authoritative Paper catalogue and fixture host.
+3. Completely migrate admin, using compact density as the primary stress test.
+4. Completely migrate auth, using comfortable density and form flows as the primary stress test.
+5. Completely migrate webv2 after Paper has been proven in the other applications.
+6. Keep legacy `ui` available only for applications that have not yet reached their cutover; remove it after webv2 migration and a repository-wide consumer search.
+
+### Decision required
+
+- None blocking the implementation plan. Treat the original square-diagonal Cut Meter as the selected compact mark.
+
+### Decision
+
+- **Decided:** Tadoku components and surfaces retain sharp edges with no border radius.
+- **Rationale:** square geometry fits Tadoku's book/library identity and slightly old-school visual character.
+- **Decided:** ordinary surfaces are border-led and flat; floating/showcase roles use named hard-offset elevation.
+- **Decided:** comfortable 44px and compact 36px density modes.
+- **Decided:** the proposed typography hierarchy and icon grammar.
+
+---
+
+## Discussion 2 — P0.5: Typed Button and LinkButton APIs
+
+Status: resolved enough for implementation planning.
+
+Questions to resolve later:
+
+- **Decided:** imported React components are not mandatory.
+- **Decided:** preserve a framework-independent class recipe as a first-class API so buttons and links can share styling without imports.
+- **Decided:** loading is a supported class/attribute state and does not require a component; pair its visual state with `aria-busy` and native disabled behavior.
+- **Decided:** provide both class-based buttons and optional Button components.
+- **Decided:** optional components compose the same public classes and semantic attributes so the two APIs cannot visually drift.
+- **Decided:** name the unmodified hierarchy `default`.
+- **Working default:** model destructive styling as a composable danger tone across default, primary, and ghost hierarchy. This is not plan-blocking.
+- If adapters remain, prefer separate `Button` and link adapters over a Next-specific polymorphic API.
+
+### Button and package preview v11
+
+- Presenter: `https://presentr.lab/html/tadoku-paper-button-grammar-v11`
+- Archived source: [artifacts/tadoku-paper-button-grammar-v11.html](artifacts/tadoku-paper-button-grammar-v11.html)
+- User selected `default` as the base hierarchy name.
+- Proposal: ordinary hierarchy is limited to default, primary, and ghost; omit a separate secondary name because default already fills that role.
+- “Close” is an action, not a visual variant: footer Close/Cancel is normally default; a top-right × is normally a ghost icon-only button.
+- Proposal: danger is a composable tone, allowing default + danger, primary + danger, and ghost + danger.
+- Loading composes with any hierarchy through both classes and semantic attributes.
+- Class and React examples are shown side-by-side and share one CSS implementation.
+
+---
+
+## Discussion 3 — P2.4: Package boundary
+
+Status: resolved.
+
+Questions to resolve later:
+
+- **Direction supplied:** UI v2 must be framework-independent and must not depend on Next.js.
+- Decide whether the additive package is named `ui-v2`, split into core/adapters, or exposed through versioned entry points.
+- Establish canonical styles, tokens, Tailwind-preset, assets, and optional framework-adapter entry points.
+- Retain the compatibility global stylesheet until all application migrations are complete.
+
+### Supplied architecture decisions
+
+- Human-facing design-system name: **Tadoku Paper**.
+- New package name: **`paper-ui`**.
+- `paper-ui` may assume React, but must not depend on Next.js or Next-specific components and font systems.
+- One React package is sufficient; a framework-core/React package split is unnecessary.
+- Old `ui` and new `paper-ui` may coexist in the repository during rollout, but an individual application does not mix them.
+- Each application receives one complete/big-bang migration in this order: style guide, admin, auth, webv2.
+- Therefore selector-level v1/v2 coexistence inside the same application is not a design requirement.
+
+---
+
+## Plan status
+
+Ready to create the parallel implementation plan. No blocking design or architecture discussion remains.


### PR DESCRIPTION
## Summary

- archive the Tadoku Paper design-system audit and all eleven visual studies under `docs/wip/tadoku-paper`
- preserve the complete chronological decision log with a concise final-decision snapshot
- add an index linking the Git-tracked artifacts to their Presenter copies

## Why

The planning artifacts were previously available only as temporary root-level files and Presenter uploads. Keeping the full iteration in Git preserves the rationale behind the upcoming Tadoku Paper implementation plan, including rejected directions.

## Impact

Documentation only. This does not change application code, dependencies, builds, or runtime behavior.

## Validation

- `git diff --check origin/main...HEAD`
- verified all 12 expected HTML artifacts are archived
- verified local artifact links from the README and decision log resolve
