### PR TITLE
Harden Bazel CI and dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+  - package-ecosystem: bazel
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      bazel-rules:
+        patterns:
+          - "rules_*"
+          - gazelle
+        update-types:
+          - minor
+          - patch

--- a/.github/workflows/build-bazel.yaml
+++ b/.github/workflows/build-bazel.yaml
@@ -1,10 +1,24 @@
 name: build-bazel
+
 on:
   schedule:
     # monthly at 5th of every month
     - cron: "0 0 5 * *"
 
   workflow_dispatch:
+  pull_request:
+    paths:
+      - "services/**"
+      - "tools/ci/**"
+      - "BUILD.bazel"
+      - ".bazelversion"
+      - ".bazelrc"
+      - "MODULE.bazel"
+      - "MODULE.bazel.lock"
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/build-bazel.yaml"
+      - "!frontend/**"
   push:
     paths:
       - "services/**"
@@ -18,6 +32,14 @@ on:
       - "go.sum"
       - ".github/workflows/build-bazel.yaml"
       - "!frontend/**"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-bazel-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build Tadoku
@@ -26,37 +48,43 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup cache
-        uses: actions/cache@v4
+      # bazel-contrib/setup-bazel 0.19.0
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
         with:
-          path: "/home/runner/.cache/bazel"
-          key: bazel-v5-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'go.mod', 'go.sum') }}
+          bazelisk-cache: true
+          repository-cache: true
+          disk-cache: ${{ github.workflow }}
+          cache-save: ${{ github.event_name != 'pull_request' }}
+
+      - name: Verify frozen Bazel dependencies
+        run: bazel mod deps --lockfile_mode=error
 
       - name: Verify Gazelle
-        run: bazel run //:gazelle -- -mode=diff
+        run: bazel run --lockfile_mode=error //:gazelle -- -mode=diff
 
       - name: Build
-        run: bazel build //...
+        run: bazel build --lockfile_mode=error //...
 
       - name: Check push_images covers all production oci_push targets
         run: |
           diff \
-            <(bazel query 'attr(name, "^push$", kind("oci_push", //services/...))' | sort) \
-            <(bazel query 'kind("oci_push", labels(data, //:push_images))' | sort) \
+            <(bazel query --lockfile_mode=error 'attr(name, "^push$", kind("oci_push", //services/...))' | sort) \
+            <(bazel query --lockfile_mode=error 'kind("oci_push", labels(data, //:push_images))' | sort) \
           || { echo "//:push_images is out of sync with production oci_push targets named :push under //services/..." >&2; exit 1; }
 
       - name: Check load_images covers all production oci_load targets
         run: |
           diff \
-            <(bazel query 'filter("^//services/[^/]+:load$", attr(name, "^load$", kind("oci_load", //services/...)))' | sort) \
-            <(bazel query 'kind("oci_load", labels(data, //:load_images))' | sort) \
+            <(bazel query --lockfile_mode=error 'filter("^//services/[^/]+:load$", attr(name, "^load$", kind("oci_load", //services/...)))' | sort) \
+            <(bazel query --lockfile_mode=error 'kind("oci_load", labels(data, //:load_images))' | sort) \
           || { echo "//:load_images is out of sync with production oci_load targets named :load under //services/..." >&2; exit 1; }
 
       - name: Run tests
-        run: bazel test //...
+        run: bazel test --lockfile_mode=error //...
 
       - name: Load backend images for scanning
-        run: bazel run //:load_images
+        run: bazel run --lockfile_mode=error //:load_images
 
       - name: Install Trivy
         uses: aquasecurity/setup-trivy@81e514348e19b6112ce2a7e3ecbafe19c1e1f567 # v0.3.1
@@ -90,15 +118,23 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup cache
-        uses: actions/cache@v4
+      # bazel-contrib/setup-bazel 0.19.0
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@c5acdfb288317d0b5c0bbd7a396a3dc868bb0f86
         with:
-          path: "/home/runner/.cache/bazel"
-          key: bazel-v5-${{ runner.os }}-${{ hashFiles('.bazelversion', '.bazelrc', 'MODULE.bazel', 'MODULE.bazel.lock', 'go.mod', 'go.sum') }}
+          bazelisk-cache: true
+          repository-cache: true
+          disk-cache: ${{ github.workflow }}
+
+      - name: Verify frozen Bazel dependencies
+        run: bazel mod deps --lockfile_mode=error
 
       - name: Push images
         run: |
@@ -108,4 +144,4 @@ jobs:
           cp /home/runner/.docker/config.json /tmp/docker/config.json
 
           # Push images
-          bazel run //:push_images
+          bazel run --lockfile_mode=error //:push_images

--- a/docs/wip/build-system-modernization/README.md
+++ b/docs/wip/build-system-modernization/README.md
@@ -25,7 +25,7 @@ statuses `Not started`, `In progress`, `Blocked`, and `Done`. A phase is not
 | 0. Capture the baseline | Done | [#765](https://github.com/tadoku/tadoku/pull/765) | — | Merged 2026-08-08 as `b6ba1845`; baseline evidence recorded below. |
 | 1. Make rules Bazel 9-ready on Bazel 8 | Done | [#766](https://github.com/tadoku/tadoku/pull/766) | Phase 0 | Merged 2026-08-08 as `be66af7e`; [full Bazel 8 CI passed](https://github.com/tadoku/tadoku/actions/runs/31237113928). |
 | 2. Upgrade Bazel to 9.2.0 | Done | [#767](https://github.com/tadoku/tadoku/pull/767) | Phase 1 merged | Merged 2026-08-08 as `42bba884`; [full Bazel 9 CI passed](https://github.com/tadoku/tadoku/actions/runs/31237357627). |
-| 3. Harden CI and dependency updates | In progress | Pending | Phase 2 merged | Local frozen-lock, build, test, OCI coverage/load, Trivy, Actionlint, and YAML-format gates passed; pull-request validation pending. |
+| 3. Harden CI and dependency updates | In progress | [#768](https://github.com/tadoku/tadoku/pull/768) | Phase 2 merged | Local frozen-lock, build, test, OCI coverage/load, Trivy, Actionlint, and YAML-format gates passed; pull-request validation pending. |
 | 4. Clean up latent Bazel debt | Not started | — | Phase 3 merged | — |
 | 5. Complete rollout and close migration | Not started | — | Phases 0–4 | — |
 
@@ -333,7 +333,7 @@ behavior explicit on GitHub-hosted runners.
 ### Steps
 
 - [x] Branch from `main` after Phase 2 is merged.
-- [x] Set Phase 3 to `In progress`; the pull request link remains pending.
+- [x] Set Phase 3 to `In progress` and link the pull request.
 - [x] Add `pull_request` to `.github/workflows/build-bazel.yaml` with the same
       relevant path filters as the push workflow.
 - [x] Add top-level `permissions: contents: read`.

--- a/docs/wip/build-system-modernization/README.md
+++ b/docs/wip/build-system-modernization/README.md
@@ -25,7 +25,7 @@ statuses `Not started`, `In progress`, `Blocked`, and `Done`. A phase is not
 | 0. Capture the baseline | Done | [#765](https://github.com/tadoku/tadoku/pull/765) | — | Merged 2026-08-08 as `b6ba1845`; baseline evidence recorded below. |
 | 1. Make rules Bazel 9-ready on Bazel 8 | Done | [#766](https://github.com/tadoku/tadoku/pull/766) | Phase 0 | Merged 2026-08-08 as `be66af7e`; [full Bazel 8 CI passed](https://github.com/tadoku/tadoku/actions/runs/31237113928). |
 | 2. Upgrade Bazel to 9.2.0 | Done | [#767](https://github.com/tadoku/tadoku/pull/767) | Phase 1 merged | Merged 2026-08-08 as `42bba884`; [full Bazel 9 CI passed](https://github.com/tadoku/tadoku/actions/runs/31237357627). |
-| 3. Harden CI and dependency updates | In progress | [#768](https://github.com/tadoku/tadoku/pull/768) | Phase 2 merged | Local frozen-lock, build, test, OCI coverage/load, Trivy, Actionlint, and YAML-format gates passed; pull-request validation pending. |
+| 3. Harden CI and dependency updates | In progress | [#768](https://github.com/tadoku/tadoku/pull/768) | Phase 2 merged | Local gates and the [full branch PR workflow](https://github.com/tadoku/tadoku/actions/runs/31237719680) passed; post-merge cache validation pending. |
 | 4. Clean up latent Bazel debt | Not started | — | Phase 3 merged | — |
 | 5. Complete rollout and close migration | Not started | — | Phases 0–4 | — |
 
@@ -363,7 +363,7 @@ behavior explicit on GitHub-hosted runners.
       reviewed once per update set.
 - [x] Do not configure Dependabot to combine Bazel updates with Go, pnpm, or
       GitHub Actions updates.
-- [ ] Validate the workflow on a pull request from a branch and, if practical,
+- [x] Validate the workflow on a pull request from a branch and, if practical,
       from a fork.
 - [ ] Merge and confirm the next scheduled or `main` run restores and saves
       the intended caches.

--- a/docs/wip/build-system-modernization/README.md
+++ b/docs/wip/build-system-modernization/README.md
@@ -24,8 +24,8 @@ statuses `Not started`, `In progress`, `Blocked`, and `Done`. A phase is not
 | --- | --- | --- | --- | --- |
 | 0. Capture the baseline | Done | [#765](https://github.com/tadoku/tadoku/pull/765) | — | Merged 2026-08-08 as `b6ba1845`; baseline evidence recorded below. |
 | 1. Make rules Bazel 9-ready on Bazel 8 | Done | [#766](https://github.com/tadoku/tadoku/pull/766) | Phase 0 | Merged 2026-08-08 as `be66af7e`; [full Bazel 8 CI passed](https://github.com/tadoku/tadoku/actions/runs/31237113928). |
-| 2. Upgrade Bazel to 9.2.0 | In progress | [#767](https://github.com/tadoku/tadoku/pull/767) | Phase 1 merged | Bazel 9 frozen dependencies, Gazelle, build, tests, OCI coverage/loading, and Trivy passed locally. |
-| 3. Harden CI and dependency updates | Not started | — | Phase 2 merged | — |
+| 2. Upgrade Bazel to 9.2.0 | Done | [#767](https://github.com/tadoku/tadoku/pull/767) | Phase 1 merged | Merged 2026-08-08 as `42bba884`; [full Bazel 9 CI passed](https://github.com/tadoku/tadoku/actions/runs/31237357627). |
+| 3. Harden CI and dependency updates | In progress | Pending | Phase 2 merged | Local frozen-lock, build, test, OCI coverage/load, Trivy, Actionlint, and YAML-format gates passed; pull-request validation pending. |
 | 4. Clean up latent Bazel debt | Not started | — | Phase 3 merged | — |
 | 5. Complete rollout and close migration | Not started | — | Phases 0–4 | — |
 
@@ -306,8 +306,8 @@ for externally loaded shell rules.
 - [x] Run the same Trivy scan performed by the Bazel GitHub Actions workflow.
 - [x] Confirm the pull request changes only Bazel configuration and generated
       dependency state.
-- [ ] Merge and verify the first `main` build completes with Bazel 9.2.0.
-- [ ] Record the merge commit and CI run, then mark Phase 2 `Done`.
+- [x] Merge and verify the first `main` build completes with Bazel 9.2.0.
+- [x] Record the merge commit and CI run, then mark Phase 2 `Done`.
 
 ### Exit criteria
 
@@ -332,36 +332,36 @@ behavior explicit on GitHub-hosted runners.
 
 ### Steps
 
-- [ ] Branch from `main` after Phase 2 is merged.
-- [ ] Set Phase 3 to `In progress` and link the pull request.
-- [ ] Add `pull_request` to `.github/workflows/build-bazel.yaml` with the same
+- [x] Branch from `main` after Phase 2 is merged.
+- [x] Set Phase 3 to `In progress`; the pull request link remains pending.
+- [x] Add `pull_request` to `.github/workflows/build-bazel.yaml` with the same
       relevant path filters as the push workflow.
-- [ ] Add top-level `permissions: contents: read`.
-- [ ] Grant `packages: write` only to the image publish job if it is required
+- [x] Add top-level `permissions: contents: read`.
+- [x] Grant `packages: write` only to the image publish job if it is required
       for GHCR publishing.
-- [ ] Add workflow concurrency so a newer commit cancels a superseded build
+- [x] Add workflow concurrency so a newer commit cancels a superseded build
       for the same branch or pull request.
-- [ ] Replace the manual `/home/runner/.cache/bazel` cache with
+- [x] Replace the manual `/home/runner/.cache/bazel` cache with
       `bazel-contrib/setup-bazel`.
-- [ ] Pin the setup action to a reviewed commit SHA, with its release version
+- [x] Pin the setup action to a reviewed commit SHA, with its release version
       documented in a comment.
-- [ ] Enable the Bazelisk download cache, repository cache, and per-workflow
+- [x] Enable the Bazelisk download cache, repository cache, and per-workflow
       disk cache.
-- [ ] Prevent pull requests from saving shared caches while still allowing
+- [x] Prevent pull requests from saving shared caches while still allowing
       cache restoration.
-- [ ] Add a dedicated frozen lockfile step before analysis:
+- [x] Add a dedicated frozen lockfile step before analysis:
 
   ```sh
   bazel mod deps --lockfile_mode=error
   ```
 
-- [ ] Pass `--lockfile_mode=error` to Gazelle, build, test, query, and image
+- [x] Pass `--lockfile_mode=error` to Gazelle, build, test, query, and image
       load invocations in CI where the command accepts it.
-- [ ] Add `.github/dependabot.yml` with a weekly `bazel` package ecosystem
+- [x] Add `.github/dependabot.yml` with a weekly `bazel` package ecosystem
       update at the repository root.
-- [ ] Group compatible Bazel rule updates so the regenerated lockfile is
+- [x] Group compatible Bazel rule updates so the regenerated lockfile is
       reviewed once per update set.
-- [ ] Do not configure Dependabot to combine Bazel updates with Go, pnpm, or
+- [x] Do not configure Dependabot to combine Bazel updates with Go, pnpm, or
       GitHub Actions updates.
 - [ ] Validate the workflow on a pull request from a branch and, if practical,
       from a fork.


### PR DESCRIPTION
## What

- run the full Bazel workflow for relevant pull requests
- enforce the Bzlmod lockfile in every CI Bazel command
- replace the broad manual cache with pinned `bazel-contrib/setup-bazel` caches
- restrict package write access to the main-branch publish job
- add weekly, grouped Bazel Dependabot updates
- record Phase 2 completion and Phase 3 progress

## Why

This is Phase 3 of the sequential Bazel modernization rollout. It makes lockfile drift fail immediately, validates changes before merge, and prevents pull requests from writing shared caches.

## Validation

- `actionlint .github/workflows/build-bazel.yaml`
- `pnpm --dir frontend exec prettier --check ../.github/dependabot.yml ../.github/workflows/build-bazel.yaml`
- `bazel mod deps --lockfile_mode=error`
- `bazel run --lockfile_mode=error //:gazelle -- -mode=diff`
- `bazel build --lockfile_mode=error //...` (142 targets)
- aggregate push/load image coverage queries
- `bazel test --lockfile_mode=error //...` (16 tests)
- `bazel run --lockfile_mode=error //:load_images`
- Trivy 0.72.0 high/critical scans for all six backend images