### PR TITLE
docs: add Tadoku Paper implementation plan

### DIFF
--- a/docs/wip/tadoku-paper/README.md
+++ b/docs/wip/tadoku-paper/README.md
@@ -7,7 +7,7 @@ The studies intentionally include rejected directions. They document why the fin
 ## Documents
 
 - [Decision log](decision-log.md)
-- [Implementation plan](implementation-plan.md)
+- [Implementation plan](implementation-plan.md) ([Presenter](https://presentr.lab/md/tadoku-paper-implementation-plan))
 - [Original design-system refinement audit](artifacts/design-system-refinement-audit.html)
 
 ## Visual studies

--- a/docs/wip/tadoku-paper/README.md
+++ b/docs/wip/tadoku-paper/README.md
@@ -25,6 +25,7 @@ The studies intentionally include rejected directions. They document why the fin
 | [Soft Cut Meter v9](artifacts/design-system-cut-meter-soft-v9.html) | Genuinely rounded cut constructions | [Open](https://presentr.lab/html/tadoku-cut-meter-soft-v9) |
 | [Typography and icons v10](artifacts/design-system-type-icon-baseline-v10.html) | Typography hierarchy, icon grammar, API direction, and regression baseline | [Open](https://presentr.lab/html/tadoku-type-icon-baseline-v10) |
 | [Button grammar v11](artifacts/tadoku-paper-button-grammar-v11.html) | Button variants, class/component parity, and `paper-ui` architecture | [Open](https://presentr.lab/html/tadoku-paper-button-grammar-v11) |
+| [Button API and primitive layer v12](artifacts/tadoku-paper-button-api-base-ui-v12.html) | Shadcn-inspired recipes, link/form semantics, and Base UI versus Headless UI | [Open](https://presentr.lab/html/tadoku-paper-button-api-base-ui-v12) |
 
 The original audit also remains published at [Presenter](https://presentr.lab/html/tadoku-design-system-refinement-audit).
 

--- a/docs/wip/tadoku-paper/README.md
+++ b/docs/wip/tadoku-paper/README.md
@@ -7,6 +7,7 @@ The studies intentionally include rejected directions. They document why the fin
 ## Documents
 
 - [Decision log](decision-log.md)
+- [Implementation plan](implementation-plan.md)
 - [Original design-system refinement audit](artifacts/design-system-refinement-audit.html)
 
 ## Visual studies
@@ -29,4 +30,4 @@ The original audit also remains published at [Presenter](https://presentr.lab/ht
 
 ## Status
 
-The discussion phase is complete enough to produce the implementation plan. The plan should be added to this directory without replacing the audit, studies, or decision log.
+The discussion and implementation-planning phases are complete. The audit, visual studies, and decision log remain the design history; the implementation plan defines the phased delivery and application migrations.

--- a/docs/wip/tadoku-paper/artifacts/tadoku-paper-button-api-base-ui-v12.html
+++ b/docs/wip/tadoku-paper/artifacts/tadoku-paper-button-api-base-ui-v12.html
@@ -1,0 +1,684 @@
+<!doctype html>
+<html lang="en" data-theme="light">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tadoku Paper — Button API and primitive layer study</title>
+    <meta
+      name="description"
+      content="An interactive study of shadcn button conventions, the proposed Tadoku Paper API, form actions, link semantics, and the Base UI migration boundary."
+    />
+    <style>
+      :root {
+        color-scheme: light;
+        --canvas: #efede6;
+        --paper: #fffefa;
+        --paper-raised: #f8f6ef;
+        --ink: #282428;
+        --muted: #6e686d;
+        --faint: #918a88;
+        --rule: #cec8bd;
+        --rule-strong: #8b847d;
+        --field-edge: #aaa49b;
+        --violet: #5747b8;
+        --violet-hover: #6858c7;
+        --violet-edge: #3e318a;
+        --violet-soft: #eeebff;
+        --danger: #a03232;
+        --danger-hover: #b53b3b;
+        --danger-edge: #6e2020;
+        --success: #2c694f;
+        --code: #211e24;
+        --code-ink: #f5f0fa;
+        --focus: #7564dc;
+        --shadow: #282428;
+        --serif: Merriweather, Georgia, "Times New Roman", serif;
+        --sans: "Open Sans", Inter, ui-sans-serif, system-ui, sans-serif;
+      }
+
+      html[data-theme="dark"] {
+        color-scheme: dark;
+        --canvas: #17151a;
+        --paper: #211f25;
+        --paper-raised: #29262d;
+        --ink: #f3eff5;
+        --muted: #c5bec8;
+        --faint: #99919d;
+        --rule: #4b4650;
+        --rule-strong: #77707d;
+        --field-edge: #655f69;
+        --violet: #9a8bea;
+        --violet-hover: #aa9cf2;
+        --violet-edge: #7163c6;
+        --violet-soft: #302b49;
+        --danger: #e27777;
+        --danger-hover: #ef8b8b;
+        --danger-edge: #9e4d4d;
+        --success: #7fc8a7;
+        --code: #100e12;
+        --code-ink: #f5f0fa;
+        --focus: #b1a4ff;
+        --shadow: #050407;
+      }
+
+      * { box-sizing: border-box; }
+      html { scroll-behavior: smooth; }
+      body {
+        margin: 0;
+        background: var(--canvas);
+        color: var(--ink);
+        font: 15px/1.65 var(--sans);
+      }
+      button, input { font: inherit; }
+      a { color: var(--violet); }
+      :focus-visible {
+        outline: 2px solid var(--focus);
+        outline-offset: 2px;
+      }
+
+      .topbar {
+        position: sticky;
+        top: 0;
+        z-index: 20;
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 18px;
+        min-height: 58px;
+        padding: 10px clamp(18px, 4vw, 56px);
+        background: color-mix(in srgb, var(--paper) 94%, transparent);
+        border-bottom: 1px solid var(--rule);
+        backdrop-filter: blur(10px);
+      }
+      .brand { display: flex; align-items: center; gap: 12px; }
+      .meter { display: inline-flex; align-items: flex-end; gap: 3px; width: 30px; height: 28px; }
+      .meter i { position: relative; display: block; width: 7px; background: var(--ink); }
+      .meter i:nth-child(1) { height: 11px; }
+      .meter i:nth-child(2) { height: 18px; }
+      .meter i:nth-child(3) { height: 25px; }
+      .meter::after {
+        content: "";
+        position: absolute;
+        width: 30px;
+        height: 4px;
+        background: var(--paper);
+        transform: translateY(-9px) rotate(-15deg);
+        transform-origin: center;
+      }
+      .brand strong { font-family: var(--serif); font-size: 16px; letter-spacing: .01em; }
+      .brand span { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .12em; }
+      .theme-button {
+        min-height: 36px;
+        padding: 0 12px;
+        color: var(--ink);
+        background: var(--paper);
+        border: 1px solid var(--rule-strong);
+        border-bottom-width: 2px;
+        cursor: pointer;
+      }
+
+      .layout {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 240px;
+        gap: clamp(30px, 5vw, 72px);
+        width: min(1240px, calc(100% - 36px));
+        margin: 0 auto;
+        padding: 54px 0 90px;
+      }
+      main { min-width: 0; }
+      .toc {
+        position: sticky;
+        top: 86px;
+        align-self: start;
+        padding-left: 18px;
+        border-left: 4px solid var(--violet);
+      }
+      .toc strong { display: block; margin-bottom: 8px; font-size: 12px; text-transform: uppercase; letter-spacing: .12em; }
+      .toc a { display: block; padding: 4px 0; color: var(--muted); text-decoration: none; }
+      .toc a:hover { color: var(--violet); }
+
+      .eyebrow {
+        margin: 0 0 10px;
+        color: var(--violet);
+        font-weight: 700;
+        font-size: 12px;
+        letter-spacing: .14em;
+        text-transform: uppercase;
+      }
+      h1, h2, h3 { font-family: var(--serif); line-height: 1.18; }
+      h1 { max-width: 850px; margin: 0; font-size: clamp(38px, 6vw, 68px); letter-spacing: -.025em; }
+      h2 { margin: 0 0 12px; font-size: clamp(25px, 3vw, 34px); }
+      h3 { margin: 0 0 8px; font-size: 19px; }
+      .lede { max-width: 760px; margin: 22px 0 0; color: var(--muted); font-size: 18px; }
+      .rule-callout {
+        position: relative;
+        max-width: 900px;
+        margin: 34px 0 0;
+        padding: 20px 24px 20px 28px;
+        background: var(--paper);
+        border: 1px solid var(--rule);
+      }
+      .rule-callout::before {
+        content: "";
+        position: absolute;
+        inset: -1px auto -1px -1px;
+        width: 6px;
+        background: var(--violet);
+      }
+      .rule-callout strong { display: block; font: 700 21px/1.35 var(--serif); }
+      .rule-callout span { color: var(--muted); }
+
+      section { margin-top: 70px; scroll-margin-top: 90px; }
+      .section-intro { max-width: 760px; margin: 0 0 24px; color: var(--muted); }
+      .grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 20px; }
+      .card {
+        min-width: 0;
+        padding: 22px;
+        background: var(--paper);
+        border: 1px solid var(--rule);
+      }
+      .card.floating { box-shadow: 3px 3px 0 var(--shadow); border-color: var(--rule-strong); }
+      .card p { margin: 0 0 16px; color: var(--muted); }
+      .label {
+        display: inline-block;
+        margin-bottom: 12px;
+        color: var(--violet);
+        font-size: 11px;
+        font-weight: 700;
+        letter-spacing: .12em;
+        text-transform: uppercase;
+      }
+      .specimen {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 12px;
+        min-height: 78px;
+        padding: 18px;
+        background: var(--paper-raised);
+        border: 1px solid var(--rule);
+      }
+
+      .btn,
+      .button-link {
+        --button-bg: var(--paper);
+        --button-fg: var(--ink);
+        --button-border: var(--rule-strong);
+        --button-edge: var(--rule-strong);
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        min-height: 44px;
+        padding: 0 16px;
+        color: var(--button-fg);
+        background: var(--button-bg);
+        border: 1px solid var(--button-border);
+        border-bottom: 2px solid var(--button-edge);
+        border-radius: 0;
+        font-weight: 700;
+        line-height: 1;
+        text-decoration: none;
+        cursor: pointer;
+        transition: background 120ms ease, color 120ms ease, transform 120ms ease;
+      }
+      .btn:hover, .button-link:hover { background: color-mix(in srgb, var(--button-bg) 88%, var(--violet) 12%); }
+      .btn:active, .button-link:active { transform: translateY(1px); border-bottom-width: 1px; margin-bottom: 1px; }
+      .btn.primary, .button-link.primary {
+        --button-bg: var(--violet);
+        --button-fg: #fff;
+        --button-border: var(--violet-edge);
+        --button-edge: var(--violet-edge);
+      }
+      .btn.primary:hover, .button-link.primary:hover { --button-bg: var(--violet-hover); }
+      .btn.ghost, .button-link.ghost {
+        --button-bg: transparent;
+        --button-border: transparent;
+        --button-edge: transparent;
+        color: var(--violet);
+      }
+      .btn.danger, .button-link.danger {
+        --button-bg: var(--danger);
+        --button-fg: #fff;
+        --button-border: var(--danger-edge);
+        --button-edge: var(--danger-edge);
+      }
+      .btn.danger:hover, .button-link.danger:hover { --button-bg: var(--danger-hover); }
+      .btn.text-link {
+        min-height: auto;
+        padding: 3px 1px;
+        color: var(--violet);
+        background: transparent;
+        border: 0;
+        text-decoration: underline;
+        text-underline-offset: 4px;
+      }
+      .btn:disabled, .btn[aria-busy="true"] { opacity: .62; cursor: not-allowed; }
+      .spinner {
+        width: 15px;
+        height: 15px;
+        border: 2px solid currentColor;
+        border-right-color: transparent;
+        border-radius: 50%;
+        animation: spin .8s linear infinite;
+      }
+      @keyframes spin { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) {
+        *, *::before, *::after { scroll-behavior: auto !important; animation-duration: .01ms !important; animation-iteration-count: 1 !important; transition-duration: .01ms !important; }
+      }
+
+      pre {
+        overflow: auto;
+        margin: 14px 0 0;
+        padding: 16px;
+        color: var(--code-ink);
+        background: var(--code);
+        border-left: 4px solid var(--violet);
+        font: 12.5px/1.65 ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+        tab-size: 2;
+      }
+      code { font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; }
+      .inline-code { padding: 2px 5px; background: var(--violet-soft); color: var(--ink); }
+
+      .semantic-table { width: 100%; border-collapse: collapse; background: var(--paper); border: 1px solid var(--rule); }
+      .semantic-table th, .semantic-table td { padding: 14px 16px; text-align: left; vertical-align: top; border-bottom: 1px solid var(--rule); }
+      .semantic-table th { font-size: 12px; letter-spacing: .08em; text-transform: uppercase; background: var(--paper-raised); }
+      .yes { color: var(--success); font-weight: 700; }
+      .no { color: var(--danger); font-weight: 700; }
+
+      .form-demo { display: grid; gap: 15px; }
+      .field { display: grid; gap: 6px; }
+      .field label { font-weight: 700; }
+      .field input {
+        min-height: 44px;
+        padding: 8px 11px;
+        color: var(--ink);
+        background: var(--paper);
+        border: 1px solid var(--rule);
+        border-bottom: 2px solid var(--field-edge);
+        border-radius: 0;
+      }
+      .form-actions { display: flex; flex-wrap: wrap; gap: 10px; padding-top: 4px; }
+      .form-status { min-height: 24px; margin: 0; color: var(--success); font-weight: 700; }
+
+      .architecture {
+        display: grid;
+        grid-template-columns: minmax(0, 1fr) 36px minmax(0, 1fr);
+        align-items: center;
+        gap: 14px;
+      }
+      .stack { padding: 18px; background: var(--paper); border: 1px solid var(--rule); }
+      .stack strong { display: block; padding: 10px 12px; border: 1px solid var(--rule); background: var(--paper-raised); }
+      .stack strong + strong { margin-top: 8px; }
+      .stack .accent { color: #fff; background: var(--violet); border-color: var(--violet-edge); }
+      .arrow { color: var(--violet); font-size: 26px; font-weight: 700; text-align: center; }
+      .note { padding: 16px 18px; color: var(--muted); background: var(--violet-soft); border-left: 4px solid var(--violet); }
+      .sources { margin-top: 70px; padding-top: 24px; border-top: 1px solid var(--rule); color: var(--muted); }
+      .sources li { margin: 5px 0; }
+
+      @media (max-width: 900px) {
+        .layout { grid-template-columns: 1fr; }
+        .toc { position: static; grid-row: 1; }
+        .grid { grid-template-columns: 1fr; }
+      }
+      @media (max-width: 620px) {
+        .topbar { align-items: flex-start; }
+        .brand span { display: none; }
+        .layout { width: min(100% - 24px, 1240px); padding-top: 34px; }
+        .architecture { grid-template-columns: 1fr; }
+        .arrow { transform: rotate(90deg); }
+        .semantic-table { display: block; overflow-x: auto; }
+      }
+    </style>
+  </head>
+  <body>
+    <header class="topbar">
+      <div class="brand">
+        <span class="meter" aria-hidden="true"><i></i><i></i><i></i></span>
+        <strong>Tadoku Paper</strong>
+        <span>API study · v12</span>
+      </div>
+      <button class="theme-button" type="button" id="theme-toggle" aria-pressed="false">Dark specimen</button>
+    </header>
+
+    <div class="layout">
+      <main>
+        <p class="eyebrow">Technical inspiration, not visual inheritance</p>
+        <h1>Buttons have appearance. Elements have meaning.</h1>
+        <p class="lede">
+          Shadcn’s strongest lesson is not a particular border radius or Tailwind class. It is the separation of a reusable variant recipe from the element that receives it. Paper can retain that idea while owning its class-first API and sharp Bookplate appearance.
+        </p>
+
+        <div class="rule-callout">
+          <strong>Navigation uses a link. An operation uses a button.</strong>
+          <span>Either element may share the same visual recipe, but styling must never overwrite its semantics.</span>
+        </div>
+
+        <section id="shadcn">
+          <p class="eyebrow">01 · Current convention</p>
+          <h2>How the shadcn Button API is shaped</h2>
+          <p class="section-intro">
+            Shadcn combines a React component with an exported variant recipe. The component handles button markup; the recipe can style another element without forcing button behavior onto it.
+          </p>
+
+          <div class="grid">
+            <article class="card floating">
+              <span class="label">React component</span>
+              <h3>Button variants</h3>
+              <p>Shadcn currently exposes visual variants through a typed prop.</p>
+              <div class="specimen">
+                <button type="button" class="btn primary">Default</button>
+                <button type="button" class="btn">Outline</button>
+                <button type="button" class="btn ghost">Ghost</button>
+                <button type="button" class="btn danger">Destructive</button>
+                <button type="button" class="btn text-link">Link style</button>
+              </div>
+              <pre><code>&lt;Button variant="default"&gt;Save&lt;/Button&gt;
+&lt;Button variant="outline"&gt;Cancel&lt;/Button&gt;
+&lt;Button variant="ghost"&gt;Close&lt;/Button&gt;
+&lt;Button variant="destructive"&gt;Delete&lt;/Button&gt;
+&lt;Button variant="link"&gt;Learn more&lt;/Button&gt;</code></pre>
+            </article>
+
+            <article class="card">
+              <span class="label">Important vocabulary difference</span>
+              <h3>Shadcn “default” is visually primary</h3>
+              <p>
+                Shadcn’s default variant is normally the filled emphasis. Paper has already assigned <span class="inline-code">default</span> to the neutral action and <span class="inline-code">primary</span> to the emphasized action. We should borrow the architecture, not its names blindly.
+              </p>
+              <table class="semantic-table">
+                <thead><tr><th>Intent</th><th>Shadcn</th><th>Paper</th></tr></thead>
+                <tbody>
+                  <tr><td>Main action</td><td><code>default</code></td><td><code>primary</code></td></tr>
+                  <tr><td>Neutral action</td><td><code>outline</code></td><td><code>default</code></td></tr>
+                  <tr><td>Quiet action</td><td><code>ghost</code></td><td><code>ghost</code></td></tr>
+                  <tr><td>Destructive meaning</td><td><code>destructive</code> variant</td><td><code>danger</code> tone</td></tr>
+                </tbody>
+              </table>
+            </article>
+          </div>
+        </section>
+
+        <section id="links">
+          <p class="eyebrow">02 · Link semantics</p>
+          <h2>Can a link be a button?</h2>
+          <p class="section-intro">
+            It can look like one. It should remain an anchor in the DOM. Base UI’s Button intentionally enforces button semantics, so shadcn’s Base UI implementation tells consumers to style the anchor with the exported recipe instead.
+          </p>
+
+          <div class="grid">
+            <article class="card">
+              <span class="label yes">Correct · navigation</span>
+              <h3>An anchor with button appearance</h3>
+              <div class="specimen">
+                <a class="button-link primary" href="#forms">Continue to forms →</a>
+              </div>
+              <pre><code>import { buttonVariants } from "@/components/ui/button"
+
+&lt;a
+  href="/contests"
+  className={buttonVariants({ variant: "default" })}
+&gt;
+  Browse contests
+&lt;/a&gt;</code></pre>
+            </article>
+
+            <article class="card">
+              <span class="label no">Incorrect · semantic disguise</span>
+              <h3>A Button forced to render an anchor</h3>
+              <div class="specimen" aria-hidden="true">
+                <span class="btn danger">Do not compose this</span>
+              </div>
+              <pre><code>// Avoid with the Base UI Button.
+// It applies role="button" and button keyboard behavior.
+&lt;Button render={&lt;a href="/contests" /&gt;} nativeButton={false}&gt;
+  Browse contests
+&lt;/Button&gt;</code></pre>
+            </article>
+          </div>
+
+          <div class="note" style="margin-top: 20px">
+            <strong>Paper direction:</strong> export one <code>buttonClassName()</code> recipe for buttons, anchors, and router links. An optional <code>LinkButton</code> may exist, but it must render a real anchor and must never wrap Base UI’s Button primitive.
+          </div>
+        </section>
+
+        <section id="forms">
+          <p class="eyebrow">03 · Forms</p>
+          <h2>Form buttons need explicit jobs</h2>
+          <p class="section-intro">
+            A submit button submits, a cancel button performs an ordinary action, and a React Hook Form reset should normally call <code>methods.reset()</code>. Their visual hierarchy follows intent rather than DOM order.
+          </p>
+
+          <div class="grid">
+            <article class="card floating">
+              <span class="label">Interactive form specimen</span>
+              <form id="demo-form" class="form-demo">
+                <div class="field">
+                  <label for="book-title">Book title</label>
+                  <input id="book-title" name="title" value="コンビニ人間" />
+                </div>
+                <div class="form-actions">
+                  <button class="btn primary" type="submit">Save log</button>
+                  <button class="btn" type="button" id="reset-action">Reset changes</button>
+                  <button class="btn ghost" type="button" id="cancel-action">Cancel</button>
+                </div>
+                <p class="form-status" id="form-status" role="status" aria-live="polite"></p>
+              </form>
+            </article>
+
+            <article class="card">
+              <span class="label">Paper React API</span>
+              <pre><code>&lt;form onSubmit={methods.handleSubmit(save)}&gt;
+  &lt;Button type="submit" variant="primary"&gt;
+    Save log
+  &lt;/Button&gt;
+
+  &lt;Button
+    type="button"
+    variant="default"
+    onClick={() =&gt; methods.reset()}
+  &gt;
+    Reset changes
+  &lt;/Button&gt;
+
+  &lt;Button type="button" variant="ghost" onClick={close}&gt;
+    Cancel
+  &lt;/Button&gt;
+&lt;/form&gt;</code></pre>
+              <p style="margin-top: 14px">
+                <strong>Rule:</strong> Paper’s Button defaults to <code>type="button"</code>. A form submission must say <code>type="submit"</code> explicitly, matching Base UI’s guidance and preventing accidental submissions.
+              </p>
+            </article>
+          </div>
+        </section>
+
+        <section id="loading">
+          <p class="eyebrow">04 · State composition</p>
+          <h2>Loading belongs to both APIs</h2>
+          <p class="section-intro">
+            The component API supplies safe behavior; the class API remains usable without an import. Neither API should make the visible label or accessible name disappear.
+          </p>
+          <div class="grid">
+            <article class="card">
+              <span class="label">React component</span>
+              <div class="specimen">
+                <button class="btn primary" type="button" aria-busy="true" disabled>
+                  <span class="spinner" aria-hidden="true"></span>
+                  Saving log
+                </button>
+              </div>
+              <pre><code>&lt;Button variant="primary" loading&gt;
+  Saving log
+&lt;/Button&gt;
+
+// Output includes:
+// class="btn primary loading"
+// aria-busy="true"
+// disabled</code></pre>
+            </article>
+            <article class="card">
+              <span class="label">Raw class recipe</span>
+              <div class="specimen">
+                <button class="btn primary" type="button" aria-busy="true" disabled>
+                  <span class="spinner" aria-hidden="true"></span>
+                  Saving log
+                </button>
+              </div>
+              <pre><code>&lt;button
+  type="button"
+  className="btn primary loading"
+  aria-busy="true"
+  disabled
+&gt;
+  Saving log
+&lt;/button&gt;</code></pre>
+            </article>
+          </div>
+        </section>
+
+        <section id="paper-api">
+          <p class="eyebrow">05 · Proposed Paper contract</p>
+          <h2>Borrow the recipe architecture</h2>
+          <p class="section-intro">
+            Paper should expose one typed recipe function, one public CSS vocabulary, and thin semantic React adapters. They are three entrances to the same implementation—not separate styling systems.
+          </p>
+
+          <table class="semantic-table">
+            <thead><tr><th>Use case</th><th>Recommended API</th><th>Rendered element</th></tr></thead>
+            <tbody>
+              <tr><td>Simple action without import</td><td><code>className="btn primary"</code></td><td><code>&lt;button&gt;</code></td></tr>
+              <tr><td>Action with loading convenience</td><td><code>&lt;Button loading&gt;</code></td><td><code>&lt;button&gt;</code></td></tr>
+              <tr><td>Plain navigation link styled as an action</td><td><code>buttonClassName(...)</code></td><td><code>&lt;a&gt;</code></td></tr>
+              <tr><td>Convenient ordinary anchor</td><td><code>&lt;LinkButton href="…"&gt;</code></td><td><code>&lt;a&gt;</code></td></tr>
+              <tr><td>Framework router link</td><td><code>buttonClassName(...)</code> on caller link</td><td>Router-owned anchor</td></tr>
+              <tr><td>Submit</td><td><code>&lt;Button type="submit" variant="primary"&gt;</code></td><td><code>&lt;button type="submit"&gt;</code></td></tr>
+            </tbody>
+          </table>
+
+          <div class="grid" style="margin-top: 20px">
+            <article class="card">
+              <span class="label">Classes</span>
+              <pre><code>&lt;button className="btn primary"&gt;Save&lt;/button&gt;
+&lt;button className="btn default danger"&gt;Delete&lt;/button&gt;
+&lt;button className="btn ghost" aria-label="Close"&gt;…&lt;/button&gt;</code></pre>
+            </article>
+            <article class="card">
+              <span class="label">Typed recipe</span>
+              <pre><code>buttonClassName({
+  variant: "primary",
+  tone: "neutral",
+  density: "comfortable",
+  loading: false,
+})</code></pre>
+            </article>
+          </div>
+        </section>
+
+        <section id="primitives">
+          <p class="eyebrow">06 · Primitive boundary</p>
+          <h2>Base UI replaces Headless UI; it does not wrap it</h2>
+          <p class="section-intro">
+            Both libraries solve the same underlying problem: unstyled accessible behavior. Layering them would duplicate roles, focus management, portals, hidden form inputs, and event handlers.
+          </p>
+
+          <div class="architecture">
+            <div class="stack">
+              <span class="label">Legacy applications</span>
+              <strong class="accent">Legacy ui API and styles</strong>
+              <strong>Headless UI behavior</strong>
+              <strong>React</strong>
+            </div>
+            <div class="arrow" aria-hidden="true">→</div>
+            <div class="stack">
+              <span class="label">Migrated applications</span>
+              <strong class="accent">Paper API, recipes, and tokens</strong>
+              <strong>Base UI behavior where needed</strong>
+              <strong>Native HTML where sufficient</strong>
+              <strong>React</strong>
+            </div>
+          </div>
+
+          <table class="semantic-table" style="margin-top: 22px">
+            <thead><tr><th>Question</th><th>Decision</th></tr></thead>
+            <tbody>
+              <tr><td>Can both packages exist in the repository?</td><td><span class="yes">Yes.</span> Legacy apps bring Headless UI through <code>ui</code>; Paper consumers bring Base UI through <code>paper-ui</code>.</td></tr>
+              <tr><td>Can one component use both?</td><td><span class="no">No.</span> Choose one behavior primitive and one owner for focus, state, and DOM semantics.</td></tr>
+              <tr><td>Should Paper expose Base UI directly?</td><td><span class="no">No.</span> Apps consume the Paper API so the primitive layer can evolve without an application rewrite.</td></tr>
+              <tr><td>Do simple Paper buttons need Base UI?</td><td>Usually no. Native <code>&lt;button&gt;</code> already supplies the correct semantics.</td></tr>
+              <tr><td>Where is Base UI valuable?</td><td>Dialog, menu, popover, combobox, autocomplete, custom select, tabs, tooltip, and other difficult interaction patterns.</td></tr>
+              <tr><td>When is Headless UI removed?</td><td>Per application at its Paper cutover, then from the repository after the last legacy consumer is gone.</td></tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="recommendation">
+          <p class="eyebrow">07 · Recommendation</p>
+          <h2>The part worth copying is the separation of concerns</h2>
+          <div class="rule-callout">
+            <strong>Paper owns meaning, styling, and API. Base UI owns difficult interaction behavior.</strong>
+            <span>Shadcn remains a source of technical patterns and comparative examples, not a generated foundation or public dependency.</span>
+          </div>
+          <ul>
+            <li>Use native HTML for Button, Link, Input, TextArea, and other straightforward controls.</li>
+            <li>Use Base UI directly inside Paper for complex primitives.</li>
+            <li>Export public recipes independently of React components.</li>
+            <li>Keep links as anchors even when they look like buttons.</li>
+            <li>Require explicit form button types.</li>
+            <li>Preserve loading semantics in both the class and component APIs.</li>
+            <li>Do not expose Base UI or Headless UI types as Paper’s public contract unless unavoidable.</li>
+          </ul>
+        </section>
+
+        <footer class="sources">
+          <strong>Primary references</strong>
+          <ul>
+            <li><a href="https://ui.shadcn.com/docs/components/base/button">Shadcn Button documentation</a></li>
+            <li><a href="https://ui.shadcn.com/docs/forms/react-hook-form">Shadcn React Hook Form documentation</a></li>
+            <li><a href="https://base-ui.com/react/components/button">Base UI Button documentation</a></li>
+            <li><a href="https://base-ui.com/react/overview/accessibility">Base UI accessibility overview</a></li>
+          </ul>
+        </footer>
+      </main>
+
+      <nav class="toc" aria-label="On this page">
+        <strong>On this page</strong>
+        <a href="#shadcn">Shadcn API</a>
+        <a href="#links">Links and buttons</a>
+        <a href="#forms">Form actions</a>
+        <a href="#loading">Loading state</a>
+        <a href="#paper-api">Paper contract</a>
+        <a href="#primitives">Base vs Headless</a>
+        <a href="#recommendation">Recommendation</a>
+      </nav>
+    </div>
+
+    <script>
+      const root = document.documentElement
+      const themeButton = document.getElementById('theme-toggle')
+      themeButton.addEventListener('click', () => {
+        const dark = root.dataset.theme !== 'dark'
+        root.dataset.theme = dark ? 'dark' : 'light'
+        themeButton.setAttribute('aria-pressed', String(dark))
+        themeButton.textContent = dark ? 'Light specimen' : 'Dark specimen'
+      })
+
+      const form = document.getElementById('demo-form')
+      const field = document.getElementById('book-title')
+      const status = document.getElementById('form-status')
+      const initialValue = field.value
+
+      form.addEventListener('submit', event => {
+        event.preventDefault()
+        status.textContent = `Saved “${field.value}”`
+      })
+      document.getElementById('reset-action').addEventListener('click', () => {
+        field.value = initialValue
+        status.textContent = 'Changes reset through form state'
+        field.focus()
+      })
+      document.getElementById('cancel-action').addEventListener('click', () => {
+        status.textContent = 'Cancelled without submitting'
+      })
+    </script>
+  </body>
+</html>

--- a/docs/wip/tadoku-paper/decision-log.md
+++ b/docs/wip/tadoku-paper/decision-log.md
@@ -2,7 +2,7 @@
 
 This is the permanent record of the Tadoku Paper planning discussion. The original audit remains preserved at [artifacts/design-system-refinement-audit.html](artifacts/design-system-refinement-audit.html) and [Presenter](https://presentr.lab/html/tadoku-design-system-refinement-audit).
 
-Last updated: 2026-08-07
+Last updated: 2026-08-08
 
 ## Final decision snapshot
 
@@ -31,18 +31,23 @@ Last updated: 2026-08-07
 - Package name: **`paper-ui`**.
 - `paper-ui` assumes React but must not depend on Next.js or Next-specific link, image, routing, or font APIs.
 - Both class recipes and optional React components are first-class public APIs and share one CSS implementation.
-- Standard button hierarchy is default, primary, and ghost. Danger is a composable tone; loading is a composable state.
+- Button variants use the shadcn vocabulary: default, outline, ghost, link, and destructive. The default variant is the emphasized violet action; outline is the neutral bordered action. Loading remains a composable state.
 - Every standard button state remains usable through classes without importing a component.
 - Loading visuals must be paired with `aria-busy="true"` and normally native disabled behavior.
+- A link never acquires button semantics: anchors may use the exported button recipe for button appearance, while `Button variant="link"` remains a button action with link-like appearance.
+- Base UI is the sole headless primitive layer for new Paper components. Native HTML remains preferred where it already supplies the correct behavior.
+- Headless UI remains only behind legacy `ui` during coexistence and is removed with each application cutover and ultimately from the repository.
 
 ### Documentation, tests, and migration
 
-- Replace the current style-guide `Showcase` with a complete documentation shell.
+- Build a new plain React + Vite application named `paper-styleguide`; do not migrate or mix Paper into the existing legacy styleguide.
+- Deploy the new catalogue at `paper.tadoku.app` throughout migration, then move it to `ui.tadoku.app` after the complete application migration.
+- Use temporary `t3-expose` URLs for live development review and the persistent Paper hostname for merged work.
 - Give each component a searchable route, complete state matrix, realistic Tadoku examples, co-located metadata/examples/tests, and lifecycle status.
 - Separate primitives/components, product patterns, and experiments.
 - Reuse named style-guide fixtures in Vitest, React Testing Library, `user-event`, and `jest-dom` behavior/accessibility tests.
 - Introduce `paper-ui` alongside legacy `ui` at the repository level, but never mix them inside one application.
-- Perform a complete migration per application in this order: style guide, admin, auth, webv2.
+- Build the Paper catalogue first, then perform complete application migrations in this order: admin, auth, webv2. The legacy styleguide remains at `ui.tadoku.app` until the final domain cutover.
 - Remove legacy `ui` only after the final migration and a repository-wide consumer search.
 
 ## Agreed scope
@@ -50,7 +55,7 @@ Last updated: 2026-08-07
 ### Implement in the upcoming plan
 
 - P0.1 — Introduce semantic design tokens.
-- P0.3 — Replace `Showcase` with a complete documentation shell.
+- P0.3 — Build a complete documentation shell in the new `paper-styleguide` application.
 - P1.1 — Use one route per component, with search.
 - P1.2 — Show the full component state matrix.
 - P1.3 — Rebuild foundation pages.
@@ -77,7 +82,8 @@ Last updated: 2026-08-07
 - Shared UI changes build and publish four application images independently.
 - Introduce `paper-ui` additively at the repository level while unmigrated applications continue using legacy `ui`.
 - Do not mix legacy `ui` and `paper-ui` inside an application; each application receives one complete migration.
-- Migrate in this order: style guide, admin, auth, webv2.
+- Do not mix Headless UI and Base UI within a Paper component. New Paper code uses Base UI or native HTML; legacy code retains Headless UI only until its application cutover.
+- Build and deploy `paper-styleguide` independently, then migrate admin, auth, and webv2 in that order. Move the Paper catalogue to `ui.tadoku.app` only after those migrations complete.
 - Keep the legacy package until repository searches show no remaining application consumers.
 - Preserve the existing audit report; do not overwrite its file or Presentr key.
 - Parallel sub-agents may implement independent work after the decisions and plan are locked.
@@ -380,4 +386,29 @@ Questions to resolve later:
 
 ## Plan status
 
-Ready to create the parallel implementation plan. No blocking design or architecture discussion remains.
+The implementation plan exists and is being updated as later architecture decisions are resolved.
+
+---
+
+## Discussion 4 — Paper styleguide, Button vocabulary, and primitive layer
+
+Status: resolved for implementation planning.
+
+### Button API and primitive preview v12
+
+- Presenter: `https://presentr.lab/html/tadoku-paper-button-api-base-ui-v12`
+- Archived source: [artifacts/tadoku-paper-button-api-base-ui-v12.html](artifacts/tadoku-paper-button-api-base-ui-v12.html)
+- The study compares shadcn's React Button and exported recipe architecture, link versus button semantics, explicit form button behavior, and Base UI versus Headless UI.
+
+### Decisions
+
+- **Button vocabulary:** adopt the shadcn-style variant names `default`, `outline`, `ghost`, `link`, and `destructive`.
+- **Visual mapping:** `default` is the filled emphasized action previously called primary; `outline` is the neutral bordered action previously called default.
+- **No required secondary variant:** only add a distinct secondary treatment later if a documented product hierarchy requires it.
+- **Loading:** loading remains a state that composes with any applicable variant through both the React and raw class APIs.
+- **Link semantics:** `Button variant="link"` renders a real button action with link-like presentation. Navigation renders a real anchor and receives button appearance through `buttonClassName()` or an anchor-specific `LinkButton` adapter.
+- **Forms:** Paper Button defaults to `type="button"`; submissions declare `type="submit"`. React Hook Form resets call `methods.reset()` rather than relying on implicit native reset behavior.
+- **Primitive layer:** use Base UI as Paper's headless behavior dependency. Do not use shadcn as the generated foundation; use its technical architecture and documentation patterns as reference.
+- **Headless UI:** do not introduce Headless UI into `paper-ui` or `paper-styleguide`. It remains an implementation detail of legacy `ui` until the relevant application migrates, after which the unused dependency is removed.
+- **Paper styleguide:** create `frontend/apps/paper-styleguide` from scratch with plain React and Vite. It consumes only `paper-ui`, is served as static assets in production, and does not use SSR.
+- **Preview and domains:** agents expose the Vite development server with `t3-expose` for temporary live review. Merged work deploys persistently to `paper.tadoku.app`; `ui.tadoku.app` continues serving the legacy guide until the full migration finishes, then switches atomically to Paper.

--- a/docs/wip/tadoku-paper/implementation-plan.md
+++ b/docs/wip/tadoku-paper/implementation-plan.md
@@ -149,6 +149,51 @@ The new catalogue is a static Vite application. During development, agents expos
 6. **Keep changes reviewable.** Use atomic commits and small package/component PRs before the per-application deployment PRs.
 7. **Preserve history.** The audit, visual studies, and decision log remain unchanged and are linked from the finished style guide.
 
+## Autonomous execution protocol
+
+The implementation should minimize synchronous user input. An execution request starts Phase 0 immediately; passing a phase gate starts the next phase automatically when the required actions remain within the authority granted at kickoff.
+
+Agents follow these rules:
+
+- Read this plan, the decision log, repository instructions, and relevant current source before acting.
+- Treat recorded decisions as authoritative; do not reopen them because an implementation offers another reasonable preference.
+- Resolve reversible technical choices through evidence, a small spike, and an architecture decision record rather than asking the user.
+- Record non-blocking uncertainties and continue with unaffected work.
+- Batch progress into phase/gate reports instead of requesting approval for routine commits or implementation details.
+- Ask the user only when a choice changes product behavior or visual direction beyond this plan, required authority or credentials are missing, an irreversible external action is not pre-authorized, or safe alternatives have been exhausted.
+- Keep deployments rollback-capable and report the exact image/commit before each production cutover.
+
+### One-time kickoff authority
+
+The user can eliminate repeated operational prompts by including the desired authority in the execution request. The useful scopes are:
+
+- create branches, commits, and pull requests;
+- merge PRs after required checks and phase gates pass;
+- deploy the persistent `paper.tadoku.app` preview after its gate;
+- deploy admin, auth, and webv2 cutovers after their individual gates;
+- switch `ui.tadoku.app` and remove legacy source after the final gate.
+
+Authority for one item does not imply the others. Without explicit deployment or merge authority, agents complete and verify the work, then stop only at that external-action boundary.
+
+## Phase 0 research packet
+
+Phase 0 produces durable evidence under `docs/wip/tadoku-paper/research/` so later phases and fresh agents do not repeat discovery.
+
+| Research stream | Questions answered | Durable output |
+| --- | --- | --- |
+| Repository surface | Which exports, deep imports, selectors, classes, examples, routes, and Headless UI primitives exist and who consumes them? | Component/consumer matrix and selector inventory. |
+| Dependency compatibility | Which Base UI, Vite, router, test, and package-build versions work with the repository's React, TypeScript, Node, and pnpm constraints? | Compatibility matrix, lockfile spike, and ADRs. |
+| Primitive behavior | Which controls use native HTML and which use Base UI; do Dialog, Menu, Combobox, and Button meet the required semantics and composition model? | Disposable vertical spike plus keyboard/focus findings. |
+| CSS and recipes | How will static public classes, typed variant recipes, optional Tailwind mappings, themes, and densities share one implementation? | Recipe API ADR and generated-selector contract. |
+| Documentation/content | What legacy knowledge is worth carrying over, what becomes a Pattern or Experiment, and which old routes need redirects? | Page/route migration matrix and content gap report. |
+| Testing | What deterministic fixtures and behavior assertions replace the source-text test; what CI jobs and path filters are missing? | Test inventory, initial fixture map, and CI proposal. |
+| Fonts/brand/assets | Where do licensed font files and canonical logo geometry come from, and which production asset formats are required? | Asset provenance/license record and export list. |
+| Deployment | Where do image, ingress, Kubernetes, DNS, Tilt, and workflow changes live; how are static routes, health, caching, and rollback handled? | Deployment topology, cross-repository touchpoint list, and rollback runbook. |
+| Resource usage | What does the static container consume at startup, idle, and during representative navigation? | Measured recommendation for requests and limits. |
+| Application risk | Which admin, auth, and webv2 flows are critical, implicit-CSS-dependent, responsive, router-aware, or difficult to roll back? | Per-application smoke and risk matrices. |
+
+Research spikes are not production implementations. Keep only reusable tests or scaffolding that already meets the plan's package and quality contracts; otherwise preserve the findings and discard the spike through normal reviewable changes.
+
 ## Target architecture
 
 ### Package layout
@@ -474,6 +519,16 @@ Goal: give every parallel lane stable boundaries before implementation starts.
 
 Checklist:
 
+- [ ] Sync with current `main` while preserving the planning history and record the starting commit.
+- [ ] Create `docs/wip/tadoku-paper/research/` with an index linking every research output and ADR.
+- [ ] Produce the complete legacy component/consumer, selector/class, example, route, and Headless UI inventory.
+- [ ] Run an isolated compatibility spike for Base UI, Vite, the chosen router, Vitest, React Testing Library, and the package build against the repository's pinned React, TypeScript, Node, and pnpm versions.
+- [ ] Prototype Button/link recipes plus Base UI Dialog, Menu, and Combobox; record DOM, keyboard, focus, form, styling, bundle, and typing findings.
+- [ ] Decide native-versus-Base UI ownership for each component category and record it in an ADR.
+- [ ] Decide the typed recipe helper, CSS output, optional Tailwind mapping, and selector contract through a reversible spike and ADR.
+- [ ] Verify font licenses/provenance, canonical Cut Meter geometry, favicon needs, and distributable asset formats.
+- [ ] Locate all repository and cross-repository deployment touchpoints for `paper.tadoku.app`, static serving, health, ingress, image publication, and final hostname cutover.
+- [ ] Produce the route/content migration matrix, initial deterministic fixture map, CI gap report, and per-application risk/smoke matrices.
 - [ ] Record the final Button vocabulary: default, outline, ghost, link, destructive, and loading state.
 - [ ] Specify that `Button variant="link"` is an action and that anchors receive button appearance from `buttonClassName()` or an anchor adapter.
 - [ ] Decide the exact Base UI import strategy and the Paper-owned wrapper boundary.
@@ -487,7 +542,7 @@ Checklist:
 
 Repository guards must reject `ui` in migrated applications, `paper-ui` in unmigrated applications, private `paper-ui/src/*` imports, Next or Headless UI imports in Paper, and duplicate Paper stylesheet imports.
 
-**Phase gate:** the reviewed contract, inventories, route map, deployment/rollback design, smoke matrices, ownership map, and automated boundary checks all exist. No component implementation begins before this gate passes.
+**Phase gate:** the indexed research packet, compatibility/primitive spikes, ADRs, reviewed contract, inventories, route map, deployment/rollback design, smoke matrices, ownership map, and automated boundary checks all exist; no unresolved finding requires a product decision. No production component implementation begins before this gate passes.
 
 ### Phase 1 — Build the Paper foundation
 

--- a/docs/wip/tadoku-paper/implementation-plan.md
+++ b/docs/wip/tadoku-paper/implementation-plan.md
@@ -1,26 +1,72 @@
 # Tadoku Paper implementation plan
 
-Status: ready for implementation  
-Last updated: 2026-08-07  
-Decision source: [decision-log.md](decision-log.md)  
+Status: ready for implementation
+
+Last updated: 2026-08-08
+
+Decision source: [decision-log.md](decision-log.md)
+
 Design history: [README.md](README.md)
 
 ## Outcome
 
-Deliver Tadoku Paper as a refined, tested, React-based design system in a new `paper-ui` package, make the style guide its authoritative catalogue, migrate every frontend application without mixing old and new systems inside an application, and finally retire legacy `ui`.
+Deliver Tadoku Paper as a refined, tested, React-based design system in a new `paper-ui` package; build a new static React + Vite catalogue at `paper.tadoku.app`; migrate every product application without mixing old and new systems inside an application; move the completed catalogue to `ui.tadoku.app`; and finally retire legacy `ui`, the legacy styleguide, and Headless UI.
 
 The finished work must provide:
 
 - the approved sharp, editorial Bookplate visual language;
 - a semantic token system with light and dark mappings;
 - public CSS recipes and optional React components backed by the same implementation;
-- a searchable, registry-driven style guide with one route per component;
+- a searchable, registry-driven `paper-styleguide` with one route per component;
 - deterministic fixtures shared between documentation and component tests;
 - a framework-independent package boundary with no Next.js dependency;
-- complete migrations of styleguide, admin, auth, and webv2;
+- an independent Paper catalogue followed by complete migrations of admin, auth, and webv2;
 - compatibility, rollout, rollback, and eventual legacy-package removal gates.
 
 This plan is the implementation companion to the decision log. If an early audit suggestion conflicts with a later recorded decision, the later decision wins. In particular, Tadoku Paper remains square rather than rounded, and buttons support both classes and React components rather than requiring a component everywhere.
+
+## Overview
+
+The work proceeds along two coordinated tracks. The first builds `paper-ui`, its catalogue schema, tests, and the new `paper-styleguide`. The second migrates admin, auth, and webv2 one complete application at a time after the Paper component surface is stable. The existing `ui` package and styleguide remain untouched enough to serve unmigrated applications and `ui.tadoku.app`; they never load into the new catalogue.
+
+The new catalogue is a static Vite application. During development, agents expose it temporarily through the `t3-expose-development-server` workflow. Merged work deploys persistently to `paper.tadoku.app`. After admin, auth, and webv2 have migrated, `ui.tadoku.app` switches atomically to the Paper deployment and the legacy application is retired.
+
+### Benefits
+
+- No transitional CSS collision or misleading mixed catalogue.
+- A Vite consumer proves `paper-ui` is not coupled to Next.js.
+- Static production serving uses materially less idle CPU and memory than a persistent Next.js runtime.
+- Base UI supplies difficult ARIA, keyboard, focus, portal, and positioning behavior while Paper retains its own API and visual identity.
+- A typed registry makes navigation, search, lifecycle, documentation completeness, fixtures, and tests one coherent contract.
+- Per-application image cutovers provide clear rollback boundaries.
+
+### Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Two catalogues drift during the migration | Freeze the legacy styleguide except critical corrections; it documents only legacy `ui`, while Paper work goes only to `paper-styleguide`. |
+| Base UI behavior leaks into Paper's public contract | Wrap primitives behind Paper components, avoid exporting Base UI types where possible, and add public API/boundary tests. |
+| Copied shadcn conventions dilute the Paper identity | Borrow recipe, registry, composition, and documentation patterns only; do not generate shadcn components or adopt its theme. |
+| Static SPA deep links return 404 | Configure the production server and ingress to fall back to `index.html`; test every canonical route directly. |
+| Accessibility is assumed rather than verified | Reuse deterministic fixtures in rendered keyboard/semantic tests and complete issue #761 after the baseline. |
+| Legacy global CSS hides migration work | Inventory selectors as an implicit API and require a zero-legacy-class audit per application. |
+| Headless UI and Base UI conflict | Never combine them in a Paper component or application. Headless UI remains only behind legacy `ui` until cutover. |
+| Parallel lanes conflict in shared files | Give one integrator ownership of tokens, public exports, catalogue aggregation, and migration markers. |
+| Rarely visited styleguide still reserves excess cluster resources | Serve a static build from a minimal container, start with small measured requests/limits, and avoid SSR or scale-to-zero infrastructure unless data shows it is worthwhile. |
+
+### Measurable success criteria
+
+- `paper-ui` has zero `next` and zero `@headlessui/react` source imports or dependencies.
+- `paper-styleguide` has zero `ui`, legacy stylesheet, Next.js, and Headless UI imports.
+- Every public Stable component has exactly one canonical route, required instructional sections, deterministic fixtures, semantic/behavior tests, ownership, and lifecycle metadata.
+- Catalogue navigation, search, routes, statuses, and test fixtures derive from one validated registry.
+- Direct requests to every Paper catalogue route return the application successfully at `paper.tadoku.app` and, after cutover, `ui.tadoku.app`.
+- Button classes, typed recipe output, and React component output use the same selectors for every documented variant and loading state.
+- All required keyboard and focus tests pass for Base UI-backed components.
+- Each migrated application has zero legacy `ui` imports, legacy global CSS, undocumented legacy-only classes, and unused Headless UI dependencies.
+- Admin, auth, and webv2 pass their lint, typecheck, production build, image build, and critical-flow smoke gates.
+- The static Paper catalogue operates within the resource requests/limits selected from observed idle and navigation usage.
+- Repository-wide searches show zero legacy consumers before `ui`, the old styleguide, and Headless UI are removed.
 
 ## Scope and non-goals
 
@@ -29,13 +75,13 @@ This plan is the implementation companion to the decision log. If an early audit
 - All P0, P1, and P2 audit recommendations, including work already represented by follow-up issues.
 - The complete current public surface of `ui`, including components that are poorly documented or available only through deep imports.
 - The implicit styling contract currently supplied by `ui/styles/globals.css`.
-- The style-guide information architecture, examples, navigation, search, governance, and contribution model.
+- The new Paper styleguide's information architecture, examples, navigation, search, governance, contribution model, deployment, and final domain cutover.
 - Component semantics, keyboard behavior, test fixtures, fast rendered tests, package-boundary checks, and application build gates.
 - Additive repository-level coexistence followed by one complete cutover per application.
 
 ### Non-goals for the main migration
 
-- Rewriting any application away from Next.js. `paper-ui` must enable that future change, but application framework migration is separate work.
+- Rewriting admin, auth, or webv2 away from Next.js. `paper-ui` must enable that future change, while `paper-styleguide` deliberately uses Vite as the first non-Next consumer.
 - Consolidating or redesigning product behavior such as the two webv2 logging implementations.
 - Requiring Storybook before the custom catalogue has been proven insufficient.
 - Blocking the initial rollout on the complete Playwright screenshot system, exhaustive WCAG audit, or full user-preference matrix. Those remain tracked in issues #761–#763 and build on the foundation delivered here.
@@ -53,7 +99,7 @@ This plan is the implementation companion to the decision log. If an early audit
 - Pale form fields use a subtle neutral 2px lower edge.
 - Filled actions use a stronger 2px lower edge and a distinct hover state.
 - Ordinary surfaces stay flat; floating overlays use a 3px hard-offset shadow; rare showcase surfaces may use 5px.
-- Dark primary actions use a deeper violet with light text.
+- Dark default/emphasized actions use a deeper violet with light text.
 - Comfortable density is 44px; compact density is 36px.
 - Focus uses a consistent 2px `:focus-visible` ring with a 2px offset.
 - Motion roles are 120ms, 180ms, and 240ms.
@@ -73,14 +119,25 @@ This plan is the implementation companion to the decision log. If an early audit
 - Package name: `paper-ui`.
 - React is assumed; Next.js is not.
 - CSS class recipes and React components are equal public contracts.
-- Button hierarchy: `default`, `primary`, `ghost`.
-- `danger` is a composable tone and `loading` is a composable state.
-- A class-only loading button remains valid, for example `btn primary loading`, when paired with `aria-busy="true"` and normally `disabled`.
+- Button variants: `default`, `outline`, `ghost`, `link`, and `destructive`.
+- `default` is the filled emphasized violet action; `outline` is the neutral bordered action. `loading` is a composable state.
+- A class-only default button uses `btn`; additional variants compose as `btn outline`, `btn ghost`, `btn link`, or `btn destructive`. Loading composes as `btn loading` and must be paired with `aria-busy="true"` and normally disabled behavior.
 - React components compose the same public recipes; they do not own private duplicate styles.
-- `LinkButton` is a router-neutral React adapter over a native anchor or caller-supplied link element; router-specific code can always use the same public class recipe directly.
+- `Button variant="link"` remains a real button action with link-like appearance. Navigation remains a real anchor and receives button appearance from `buttonClassName()` or an anchor-specific `LinkButton` adapter.
+- Paper Button defaults to `type="button"`; form submissions declare `type="submit"`, and React Hook Form resets use `methods.reset()`.
 - Applications import the Paper stylesheet once, after which class recipes work without a component import at each call site.
-- Close is an action, not a variant: a footer Close action is usually default; a top-right X is ghost and icon-only.
+- Close is an action, not a variant: a footer Close action is usually outline; a top-right X is ghost and icon-only.
 - Navigation components receive link rendering and current-route data from consumers rather than importing router APIs.
+
+### Primitive policy
+
+- Use Base UI as the sole headless primitive dependency for Paper.
+- Wrap Base UI behind Paper-owned components and recipes; application code does not import Base UI for standard design-system components.
+- Prefer native HTML when it already provides correct semantics and behavior.
+- Use Base UI for complex Dialog, AlertDialog, Menu, Popover, Combobox, Autocomplete, custom Select, Tabs, Tooltip, and related interaction patterns.
+- Do not layer Base UI on Headless UI or expose both implementations through one component.
+- Headless UI remains only behind legacy `ui`; remove it from each application package when that application has no remaining direct or transitive use.
+- Continue to use React Hook Form as the form-state contract. Use `useController()` for Base UI-backed custom controls rather than substituting Base UI Form for application form state.
 
 ## Delivery principles
 
@@ -154,7 +211,36 @@ Button/
 | `paper-ui/tailwind-preset` | Immutable semantic Tailwind mappings |
 | `paper-ui/catalog` | Documentation metadata and named fixtures; excluded from production bundles unless explicitly imported |
 
-The package builds ESM, declarations, and CSS. React, React DOM, and React Hook Form are peer dependencies. Implementation libraries such as Headless UI and Heroicons can be direct dependencies. Package output must be consumable without Tailwind and without Next transpilation.
+The package builds ESM, declarations, and CSS. React, React DOM, and React Hook Form are peer dependencies. Base UI and Heroicons are direct implementation dependencies. Headless UI is prohibited. Package output must be consumable without Tailwind and without Next transpilation.
+
+### Paper styleguide application
+
+```text
+frontend/apps/paper-styleguide/
+├── index.html
+├── package.json
+├── vite.config.ts
+├── src/
+│   ├── app/
+│   │   ├── routes.tsx
+│   │   ├── DocsShell.tsx
+│   │   └── CatalogueSearch.tsx
+│   ├── documentation/
+│   │   ├── DocumentPage.tsx
+│   │   ├── ExampleCanvas.tsx
+│   │   ├── StateMatrix.tsx
+│   │   └── TableOfContents.tsx
+│   ├── styles/
+│   └── main.tsx
+└── tests/
+```
+
+- Plain React + Vite; no Next.js and no server rendering.
+- Imports `paper-ui/styles.css` once and consumes `paper-ui/catalog`.
+- Production output is static and served by a minimal container with SPA route fallback.
+- Merged builds deploy to `paper.tadoku.app` throughout migration.
+- Local live review uses `t3-expose run` with the Vite server honoring the supplied `HOST` and `PORT`; the returned URL is temporary and private-lab/tailnet scoped.
+- The existing `frontend/apps/styleguide` continues to consume only legacy `ui` and remains at `ui.tadoku.app` until final cutover.
 
 ### Token layers
 
@@ -223,7 +309,7 @@ Light aliases live on `:root` and `[data-theme="light"]`; dark aliases live on `
 └── changelog
 ```
 
-The style guide may remain a Next.js application during this work. Framework routing stays in a thin application adapter; `paper-ui`, its fixtures, and its catalogue remain framework-neutral.
+`paper-styleguide` uses React and Vite. Its routing is application-owned; `paper-ui`, fixtures, and catalogue metadata remain router- and bundler-neutral.
 
 ### Required page anatomy
 
@@ -243,7 +329,7 @@ Use exactly `Experimental`, `Stable`, and `Deprecated`. Category pages summarize
 
 ### Documentation shell
 
-Replace `Showcase` with:
+Build the new documentation shell with:
 
 - a responsive docs shell and mobile navigation;
 - keyboard-first search with `/` and Command/Ctrl-K;
@@ -260,6 +346,29 @@ Viewport previewing should create a real media-query environment, preferably an 
 ### Catalogue and fixture schema
 
 Each document entry requires a stable ID, route, name, category, aliases, summary, keywords, lifecycle, owner, review date, source path, package version, guidance, accessibility notes, API documentation, fixture IDs, dependencies, and migration details.
+
+### Required instructional sequence
+
+Every Stable component page presents information in this order:
+
+1. What the component is and the problem it solves.
+2. When to use it.
+3. When not to use it.
+4. How to choose between related components.
+5. Labeled anatomy and required parts.
+6. One recommended realistic Tadoku example with rationale.
+7. Supported variants and why each exists.
+8. Meaningful states, density, theme, viewport, long-copy, and overflow cases.
+9. Pointer, keyboard, focus, dismissal, validation, and loading behavior.
+10. Content guidance and common mistakes.
+11. Accessibility requirements and known constraints.
+12. Copyable implementation examples with complete imports and semantic attributes.
+13. React props, public types, class recipes, defaults, and invalid combinations.
+14. Related product patterns and composed primitives.
+15. Legacy migration notes.
+16. Lifecycle, ownership, source, version, last review, and changelog.
+
+The schema distinguishes required sections from optional component-specific sections. Registry validation prevents a component from becoming Stable when a required section is missing.
 
 Fixtures must be deterministic: no Faker randomness, `Math.random`, current dates, network calls, or application-router assumptions. A fixture contains stable metadata and a render function; assertions stay in tests.
 
@@ -337,17 +446,17 @@ The dependency spine is:
 ```text
 contracts
    ↓
-package foundations + catalogue/test schema
+paper-ui foundations + Vite catalogue shell
    ↓
 four-component vertical slice
    ↓
-full component catalogue + docs platform
-   ↓
-styleguide cutover
+complete component catalogue at paper.tadoku.app
    ↓
 admin → auth → webv2 cutovers
    ↓
-legacy ui removal and deferred hardening
+ui.tadoku.app domain cutover
+   ↓
+legacy ui, styleguide, Headless UI removal + deferred hardening
 ```
 
 Work beside the spine runs concurrently. Only shared contracts, the end-to-end pilot, and application deployment order are deliberately serial.
@@ -358,22 +467,27 @@ Goal: give every parallel lane stable boundaries before implementation starts.
 
 | Lane | Work |
 | --- | --- |
-| Architecture | Finalize export map, dependency policy, router/link contract, recipe/component parity, and built-output format. |
+| Architecture | Finalize export map, Base UI boundary, router/link contract, Button recipe/component parity, and built-output format. |
 | Catalogue | Freeze document, fixture, lifecycle, route, redirect, and registry schemas. |
-| Inventory | Map every legacy export, deep import, global selector, style-guide example, and consumer to its Paper destination. |
-| Delivery | Define per-app smoke lists, rollback evidence, CI matrix, owners, and PR boundaries. |
+| Inventory | Map every legacy export, deep import, global selector, Headless UI-backed component, styleguide example, and application consumer to its Paper destination. |
+| Delivery | Define `paper.tadoku.app` and final `ui.tadoku.app` routing, per-app smoke lists, rollback evidence, CI matrix, resource measurement, owners, and PR boundaries. |
 
-Add repository guards that reject:
+Checklist:
 
-- `ui` imports in an application marked migrated;
-- `paper-ui` imports in an application not yet marked migrated;
-- `paper-ui/src/*` private imports;
-- Next imports inside `paper-ui`;
-- duplicate application-level Paper stylesheet imports.
+- [ ] Record the final Button vocabulary: default, outline, ghost, link, destructive, and loading state.
+- [ ] Specify that `Button variant="link"` is an action and that anchors receive button appearance from `buttonClassName()` or an anchor adapter.
+- [ ] Decide the exact Base UI import strategy and the Paper-owned wrapper boundary.
+- [ ] Freeze package exports, token names, fixture/document schema, lifecycle values, route format, and old-route redirect map.
+- [ ] Inventory every legacy `ui` export, deep import, raw class, and global selector.
+- [ ] Inventory every Headless UI-backed legacy component and verify that applications do not need direct Headless UI APIs after Paper cutover.
+- [ ] Define migration markers and repository checks for allowed package use per application.
+- [ ] Define production image names, static-server fallback, `paper.tadoku.app` ingress, final domain switch, and immutable-image rollback procedure.
+- [ ] Define measurable resource collection for the static styleguide container.
+- [ ] Update coexistence contributor instructions without changing legacy application behavior.
 
-Update contributor instructions during coexistence to explain which package each application may use. Keep the existing design archive untouched.
+Repository guards must reject `ui` in migrated applications, `paper-ui` in unmigrated applications, private `paper-ui/src/*` imports, Next or Headless UI imports in Paper, and duplicate Paper stylesheet imports.
 
-**Exit gate:** approved contract document, complete migration inventory, route/redirect map, application smoke matrix, and enforcement scripts.
+**Phase gate:** the reviewed contract, inventories, route map, deployment/rollback design, smoke matrices, ownership map, and automated boundary checks all exist. No component implementation begins before this gate passes.
 
 ### Phase 1 — Build the Paper foundation
 
@@ -381,14 +495,29 @@ Run four lanes in parallel.
 
 | Lane | Deliverables |
 | --- | --- |
-| Package/build | Package scaffold, ESM/declaration build, export map, immutable Tailwind preset, root scripts, lockfile, package boundary checks, CI and Tilt triggers. |
+| Package/build | `paper-ui` scaffold, ESM/declaration build, export map, Base UI dependency, immutable Tailwind preset, root scripts, lockfile, package boundary checks, CI and Tilt triggers. |
 | Visual foundation | Semantic tokens, themes, density, typography/font assets, focus, motion, borders, accent rail, hard-offset elevation, chart palette, Cut Meter, wordmark, favicon sources. |
 | Test/catalogue | Vitest setup, RTL helpers, fixture and metadata schemas, registry validation, test utilities, catalogue export. |
-| Docs platform | Style-guide route resolver, registry stubs, shell primitives, isolated preview-canvas prototype, old-route redirect table. |
+| Paper styleguide | New React + Vite application, route resolver, registry stubs, shell primitives, isolated preview-canvas prototype, static container, and `paper.tadoku.app` deployment workflow. |
 
 One integrator owns root exports, registry aggregation, and shared token names. Lanes add modules without repeatedly editing those files.
 
-**Exit gate:** `paper-ui` builds, typechecks, tests, and server-renders outside Next; CSS works without Tailwind; both themes and densities render in a minimal harness; fonts and brand assets resolve; the stub catalogue drives navigation and search.
+Checklist:
+
+- [ ] Scaffold `frontend/packages/paper-ui` with explicit public exports, side-effect CSS, ESM, declarations, and package scripts.
+- [ ] Add Base UI and Heroicons; prohibit Next and Headless UI in source and dependency checks.
+- [ ] Implement semantic token layers, Paper base styles, public class recipes, theme/density attributes, and self-hosted fonts.
+- [ ] Add Cut Meter, wordmark, and derived favicon sources in monochrome, reversed, and accented forms.
+- [ ] Add Vitest, jsdom, Testing Library, `user-event`, jest-dom, deterministic cleanup, and server-render consumer smoke tests.
+- [ ] Define typed catalogue, document, fixture, lifecycle, and registry-validation contracts.
+- [ ] Scaffold `frontend/apps/paper-styleguide` with React, Vite, routing, Paper-only imports, and SPA deep-link fallback.
+- [ ] Build the responsive shell, registry navigation/search stubs, local outline, and isolated preview-canvas prototype.
+- [ ] Add a static production container and CI workflow watching `paper-ui` and `paper-styleguide`.
+- [ ] Add a `paper.tadoku.app` deployment target without changing `ui.tadoku.app`.
+- [ ] Document the live-review command using `t3-expose run`; verify Vite honors the helper's `HOST` and `PORT`.
+- [ ] Capture idle and basic-navigation CPU/memory observations from the static container and set initial requests/limits from evidence.
+
+**Phase gate:** `paper-ui` builds, typechecks, tests, packages, and server-renders without Next or Headless UI; CSS works without Tailwind; both themes and densities render; fonts/assets resolve; the Vite shell builds to static files, serves direct routes, drives stub navigation/search, passes Paper-only boundary checks, and is reachable at `paper.tadoku.app`.
 
 ### Phase 2 — Prove an end-to-end vertical slice
 
@@ -398,14 +527,27 @@ Parallel ownership:
 
 | Lane | Slice |
 | --- | --- |
-| Actions | Button and LinkButton recipes/components: default/primary/ghost, danger, loading, icon, full-width, both densities. |
+| Actions | Button, anchor styling, and optional LinkButton: default/outline/ghost/link/destructive, loading, icon, full-width, both densities. |
 | Forms | Input anatomy: label, hint, error, required, read-only, disabled, both densities and themes. |
-| Overlays | Modal and ActionMenu: focus, keyboard, close/return behavior, danger/disabled items, floating treatment. |
+| Overlays | Base UI-backed Modal and ActionMenu: focus, keyboard, close/return behavior, destructive/disabled items, floating treatment. |
 | Documentation/tests | Final page anatomy, state matrix, Preview/Code/API controls, fixture rendering, registry and behavior tests. |
 
 Show real hover and focus in browser documentation; do not introduce fake production state classes solely for jsdom.
 
-**Exit gate:** all four pages satisfy the final schema; raw classes and React APIs share styles; tests pass; desktop/mobile shell and all preview controls work; the team reviews visual coherence before scaling.
+Checklist:
+
+- [ ] Implement Button with one public recipe shared by raw classes and the React component.
+- [ ] Default Button to `type="button"`; document explicit submit behavior and React Hook Form reset behavior.
+- [ ] Prove that `Button variant="link"` remains a button and that anchors can use every appropriate button recipe without button roles.
+- [ ] Implement loading through class and component APIs with stable accessible names, `aria-busy`, and safe disabled behavior.
+- [ ] Implement Input through native HTML and React Hook Form context with deterministic label, hint, and error associations.
+- [ ] Implement Modal and ActionMenu on Base UI without exposing Base UI as the application API.
+- [ ] Add named deterministic fixtures for variants, states, themes, densities, long content, overflow, and narrow viewports.
+- [ ] Add rendered semantics, keyboard, pointer, focus containment/return, and class/component parity tests.
+- [ ] Build full Button, Input, Modal, and ActionMenu pages using the required 16-part instructional sequence.
+- [ ] Review the four pages through a temporary `t3-expose` URL before merging and verify the merged version at `paper.tadoku.app`.
+
+**Phase gate:** all four pages satisfy the validated instructional schema; raw classes, recipes, and React APIs share styles; Button/link semantics are correct; Base UI focus/keyboard tests pass; desktop/mobile shell and preview controls work; the reviewed build is live at `paper.tadoku.app`.
 
 ### Phase 3 — Complete `paper-ui` and the style-guide catalogue
 
@@ -415,29 +557,54 @@ With the pilot contracts frozen, run parallel component lanes in separate direct
 | --- | --- |
 | Actions/feedback | ButtonGroup, Flash, Loading, toasts, cards and elevation recipes. |
 | Forms | TextArea, Select, Checkbox, RadioSelect, RadioGroup, AmountWithUnit, autocomplete, multi-autocomplete, TagsInput, public option types; all use React Hook Form. |
-| Navigation/overlays | Navbar, Sidebar, Breadcrumb, Tabbar, VerticalTabbar, Pagination, Modal, ActionMenu, router-neutral link integration. |
+| Navigation/overlays | Base UI-backed or native Navbar, Sidebar, Breadcrumb, Tabbar, VerticalTabbar, Pagination, Modal, ActionMenu, and router-neutral link integration. |
 | Data/brand/layout | Tables, HeatmapChart, chart defaults/palette, layout recipes, Cut Meter and wordmark lockups. |
 | Docs foundations | Principles, color, typography, spacing/density, borders/shape, elevation, icons, motion, layout, brand. |
 | Docs governance | Component indexes, Patterns, Experimental logging-v2, contribution guide, lifecycle, deprecation policy, changelog. |
 
 Every lane ships its fixtures, metadata, tests, migration notes, and realistic Tadoku examples with the implementation. Explicitly document currently missed exports such as Loading, VerticalTabbar, and AmountWithUnit.
 
-**Exit gate:** the public export surface is complete; every Stable component has a searchable route and contract evidence; navigation/search/status derive from one registry; all routes and old-route redirects validate; foundation pages read canonical tokens instead of copied values.
+Checklist:
 
-### Phase 4 — Styleguide big-bang cutover
+- [ ] Complete Actions and Feedback components with fixtures, metadata, tests, and instructional pages.
+- [ ] Complete every React Hook Form control and Base UI-backed complex field with fixtures, metadata, tests, and instructional pages.
+- [ ] Complete Navigation and Overlay components with router-neutral APIs and keyboard/focus tests.
+- [ ] Complete data-display, table, chart, layout, brand, and icon APIs with non-color semantics prepared.
+- [ ] Build all Foundation pages from canonical Paper tokens and assets rather than copied values.
+- [ ] Build category indexes and searchable component routes from the registry.
+- [ ] Rebuild realistic logging examples as Patterns and keep logging-v2 visibly Experimental.
+- [ ] Add contribution, lifecycle, deprecation, ownership, review, migration, and changelog documentation.
+- [ ] Add “choose between,” common-mistake, rationale, content, and accessibility guidance to every Stable component.
+- [ ] Ensure copied code examples include complete imports, semantic attributes, and both class/component APIs where applicable.
+- [ ] Add old legacy-styleguide route mappings to the final-cutover redirect manifest without changing the legacy application yet.
 
-Prepare independent changes concurrently, then integrate them into one deployable application cutover.
+**Phase gate:** the public export surface is complete; every Stable component passes registry, fixture, behavior, accessibility-baseline, and documentation checks; every component is searchable; navigation/search/status derive from one registry; all Paper routes validate at `paper.tadoku.app`; foundation pages use canonical sources.
+
+### Phase 4 — Stabilize the Paper catalogue at `paper.tadoku.app`
+
+This phase makes the parallel catalogue authoritative for Paper while the original styleguide remains authoritative only for legacy `ui`.
 
 | Lane | Work |
 | --- | --- |
-| Shell | Replace `_app.tsx`, hard-coded sidebar, mobile navigation, `Showcase`, and old example helpers with the registry-driven docs shell. |
-| Content | Replace repeated category pages, split Forms and Navigation into canonical component routes, reclassify logging as Patterns and logging-v2 as Experimental. |
-| Build/assets | Switch package, CSS, Tailwind, Next config, document font preloads, brand/favicon assets, and remove obsolete raw-source loader support. |
-| Verification | Search/route tests, registry checks, keyboard/mobile docs-shell tests, link/redirect checks, production and container builds. |
+| Experience | Complete responsive shell, keyboard-first search, local outline, deep links, preview isolation, code copy, and theme/density/viewport controls. |
+| Content quality | Review the 16-part page contract, cross-component choice guidance, realistic examples, Patterns, Experiments, and design history. |
+| Static delivery | Harden direct-route fallback, caching, compression, font/assets, container health, resource limits, and `paper.tadoku.app` deployment. |
+| Verification | Route/registry tests, keyboard/mobile shell tests, package tests, visual human review, production/image builds, and telemetry checks. |
 
-Import `paper-ui/styles.css` exactly once. Preserve the audit, studies, and decision log and link them under Design history or Contributing.
+Checklist:
 
-**Cutover gate:** no legacy `ui` import, dependency, stylesheet, Tailwind inheritance, or config reference remains in styleguide; every shipped component is documented; search and deep links work keyboard-first; both themes, densities, and real narrow/desktop preview environments work; lint, typecheck, tests, application build, and image build pass.
+- [ ] Verify every public Paper component has one canonical page and every legacy route has a planned final redirect.
+- [ ] Verify every Stable page satisfies the complete instructional sequence and contains no placeholder or generic-only examples.
+- [ ] Verify Preview, Code, API/Props, and Accessibility views work without layout jumps.
+- [ ] Verify preview frames exercise real phone, tablet, and desktop media queries.
+- [ ] Verify search, navigation, status, metadata, and source links all derive from the registry.
+- [ ] Link the audit, all visual studies, decision log, and implementation plan under Design history.
+- [ ] Verify direct HTTP requests to nested SPA routes load successfully.
+- [ ] Measure static-container idle and navigation resources; tune requests and limits while retaining reliable startup.
+- [ ] Run lint, typecheck, Paper tests, styleguide tests, production build, container build, and deployment smoke tests.
+- [ ] Mark `paper.tadoku.app` as the authoritative Paper catalogue while keeping `ui.tadoku.app` unchanged.
+
+**Phase gate:** `paper.tadoku.app` is a complete, stable, keyboard-operable Paper catalogue with no legacy `ui`, Next, or Headless UI dependencies; all content and delivery checks pass; the original styleguide still serves legacy documentation independently.
 
 ### Phase 5 — Admin big-bang cutover
 
@@ -450,9 +617,22 @@ Admin is the compact-density stress test. Work in parallel on one integration br
 | Data/actions | Lists, tables, pagination, breadcrumbs, tabs, menus, dialogs, destructive actions, narrow layouts. |
 | Verification | Import/class audit, compact screenshots for human review, CRUD and role smoke suite, build matrix. |
 
-Review old `secondary` and `danger` combinations semantically; do not perform a blind class rename. Compact controls must not make icon-only targets inaccessible.
+Review old `primary`, `secondary`, and `danger` combinations semantically; do not perform a blind class rename. The emphasized action becomes default, neutral becomes outline, and destructive intent becomes destructive. Compact controls must not make icon-only targets inaccessible.
 
-**Cutover gate:** no legacy package or implicit legacy-only class remains; Paper CSS is loaded once and compact density is applied at the app root; dashboard/navigation, role/loading/access-denied, content CRUD and preview, announcements, languages, users, dialogs, and narrow layouts pass; lint, typecheck, production build, and image build pass.
+Checklist:
+
+- [ ] Migrate dashboard shell, Sidebar, branding, Loading, access-denied, and redirect states.
+- [ ] Migrate content, announcement, namespace, language, and user forms while retaining React Hook Form.
+- [ ] Migrate CodeMirror through `useController()` without making it a Paper primitive.
+- [ ] Migrate tables, pagination, breadcrumbs, tabs, menus, dialogs, and destructive actions.
+- [ ] Replace router behavior with admin-owned adapters.
+- [ ] Remove all admin `ui` imports, legacy stylesheet use, legacy-only classes, and unused Headless UI dependency.
+- [ ] Load Paper CSS once and apply compact density at the application root.
+- [ ] Add every newly discovered shared state to Paper fixtures, tests, and documentation before marking it Stable.
+- [ ] Run role, loading, access-denied, CRUD, preview, announcement, language/user, dialog, and narrow-layout smoke tests.
+- [ ] Record the deployed image, deploy only admin, verify telemetry, and retain the previous image for rollback.
+
+**Cutover gate:** admin contains only Paper, has no Headless UI dependency, passes its critical workflows at compact density, and passes lint, typecheck, production build, container build, deployment smoke, and rollback-readiness checks.
 
 ### Phase 6 — Auth big-bang cutover
 
@@ -462,10 +642,21 @@ Auth has few imports but high implicit-CSS and flow risk because Ory generates d
 | --- | --- |
 | Shell | Navigation, Cut Meter/wordmark, comfortable layout, feedback and loading. |
 | Ory fields | Node adapters, labels, hints, errors, checkbox/text/select semantics, WebAuthn/script preservation. |
-| Actions/flows | Explicit default/primary/ghost hierarchy, loading and double-submit prevention, removal of selector-order button hacks. |
+| Actions/flows | Explicit default/outline/ghost/link/destructive hierarchy, loading and double-submit prevention, removal of selector-order button hacks. |
 | Verification | Fixtures and production-like login, registration, recovery, verification, settings, OIDC/passkey/WebAuthn checks. |
 
-**Cutover gate:** no legacy import or broad legacy-form dependency; Paper CSS loaded once and comfortable density applied; server errors associate to controls; keyboard submission, `aria-busy`, disabled state, and dynamic Ory behavior work; lint, typecheck, production build, image build, and focused Ory smoke tests pass.
+Checklist:
+
+- [ ] Migrate the comfortable shell, navigation, brand, feedback, and loading states.
+- [ ] Map every Ory node type to Paper fields with correct labels, hints, errors, names, and values.
+- [ ] Preserve OIDC, passkey, WebAuthn, and required script behavior.
+- [ ] Assign button variants by semantic job and remove selector-order hacks.
+- [ ] Verify loading, `aria-busy`, disabled state, double-submit prevention, and keyboard submission.
+- [ ] Remove all auth `ui` imports, legacy global-form dependencies, duplicate stylesheet imports, and unused Headless UI dependency.
+- [ ] Test login, registration, recovery, verification, settings, configured identity methods, field errors, and global errors.
+- [ ] Record the deployed image, deploy only auth, verify production-like Ory flows and telemetry, and retain rollback.
+
+**Cutover gate:** auth contains only Paper, has no Headless UI dependency, preserves every configured identity flow and semantic error relationship, and passes lint, typecheck, production build, image build, focused Ory smoke, and rollback-readiness checks.
 
 ### Phase 7 — webv2 big-bang cutover
 
@@ -481,26 +672,47 @@ webv2 is last because it has the largest and broadest surface. Use four parallel
 
 Do not combine product refactors with the visual migration. App adapters provide routing data to Navbar, Breadcrumb, Tabs, and Pagination. Charts use semantic categorical tokens and prepare non-color cues for #763.
 
-**Cutover gate:** no legacy import or undocumented CSS dependency; Paper CSS loaded once; signed-in/out navigation, mobile navigation, logging create/edit/details/delete, contest creation/registration/leaderboards, profiles/statistics, blog/content, pagination/tabs, charts, and page counter pass; lint, typecheck, production build, image build, and the complete frontend build matrix pass.
+Checklist:
 
-### Phase 8 — Retire legacy `ui`
+- [ ] Migrate global Navigation, Footer, announcement, signed-in/out/admin/banned, and mobile states.
+- [ ] Migrate old/new/edit logging and contest create/register/submit flows without unrelated product consolidation.
+- [ ] Migrate leaderboards, profiles, lists, tables, pagination, tabs, menus, responsive behavior, and overflow.
+- [ ] Migrate blog, pages, manual, Page Counter exception, Chart.js palettes, heatmaps, and activity charts.
+- [ ] Supply routing and current-page data through webv2-owned adapters.
+- [ ] Remove all webv2 `ui` imports, legacy stylesheet use, legacy-only classes, and unused Headless UI dependency.
+- [ ] Add discovered shared states to Paper fixtures/tests/docs before Stable promotion.
+- [ ] Run signed-in/out/admin/banned, navigation, logging, contest, profile, content, pagination, tab, chart, and responsive smoke matrices.
+- [ ] Record the deployed image, deploy only webv2, verify telemetry, and retain rollback.
+- [ ] Run the complete frontend package/application and container-image matrix.
+
+**Cutover gate:** webv2 contains only Paper, has no Headless UI dependency, passes every representative role and product workflow, and passes lint, typecheck, production build, image build, whole-frontend compatibility, deployment smoke, and rollback-readiness checks.
+
+### Phase 8 — Move the catalogue and retire legacy code
 
 Only begin when a repository-wide search shows zero consumers:
 
 ```sh
-rg "from ['\"]ui|ui/styles|ui/components|\"ui\": \"workspace" frontend
+rg "from ['\"]ui|ui/styles|ui/components|\"ui\": \"workspace|@headlessui/react" frontend
 ```
 
-Then:
+Checklist:
 
-- remove `frontend/packages/ui`;
-- remove old dependencies, lockfile entries, transpilation entries, and Tailwind inheritance;
-- update all CI paths and `frontend/Tiltfile` to Paper only;
-- simplify contributor instructions from coexistence rules to Paper-only guidance;
-- run package tests and the complete frontend/application-image matrix;
-- record package retirement and final migration status in this directory and the style-guide changelog.
+- [ ] Confirm admin, auth, and webv2 production smoke windows have completed successfully.
+- [ ] Build and record the exact Paper styleguide image that will receive `ui.tadoku.app`.
+- [ ] Configure direct legacy route redirects and SPA fallback for the final hostname.
+- [ ] Switch `ui.tadoku.app` atomically from the legacy styleguide image to the Paper styleguide image.
+- [ ] Verify canonical routes, old bookmarks, search, assets, theme/density controls, and design-history links on `ui.tadoku.app`.
+- [ ] Keep `paper.tadoku.app` as a temporary alias or redirect according to the deployment policy, then remove it when no longer needed.
+- [ ] Retain the previous legacy styleguide image and verify the domain rollback procedure.
+- [ ] Remove `frontend/apps/styleguide` and its build workflow after the final smoke window.
+- [ ] Remove `frontend/packages/ui`, legacy dependencies, lockfile entries, transpilation entries, Tailwind inheritance, and old Tilt triggers.
+- [ ] Remove Headless UI from the workspace after repository search shows zero uses.
+- [ ] Update all CI paths, Tilt triggers, contributor instructions, documentation status, and styleguide changelog to Paper-only operation.
+- [ ] Run Paper tests and the complete frontend/application-image matrix from the clean repository.
 
 Previously deployed application images remain rollback-capable because their legacy dependencies are bundled.
+
+**Phase gate:** `ui.tadoku.app` serves the verified static Paper catalogue; old bookmarks work; the repository has zero `ui` and Headless UI consumers; the legacy package and application are removed; all builds and smoke tests pass; immutable rollback images remain recorded.
 
 ### Phase 9 — Finish the deferred hardening issues
 
@@ -512,16 +724,26 @@ These workstreams may begin earlier once their prerequisites exist, but close af
 | #762 Regression gates | Playwright fixture routes can start after the style-guide pilot; burn-in continues through app migrations. | Reviewed responsive baselines, failure artifacts, axe integration, and stable blocking CI complete. |
 | #763 Themes/preferences | Dark/reduced-motion/forced-color fixtures can start after tokens; app persistence waits for product rollout decisions. | Preference behavior and representative app/theme matrix complete. |
 
+Checklist:
+
+- [ ] Complete #761's component and application WCAG 2.2 contract, contrast, keyboard, zoom/reflow, forced-color, and exception tracking.
+- [ ] Complete #762's Playwright fixture routes, responsive screenshot baselines, real interaction states, axe scans, failure artifacts, and reviewed update workflow.
+- [ ] Complete #763's theme persistence, operating-system preferences, reduced motion, forced colors, dark-mode application validation, and non-color status/chart cues.
+- [ ] Run the resulting checks against `paper-ui`, `paper-styleguide`, admin, auth, and webv2.
+- [ ] Update component lifecycle and known-constraint metadata from the final findings.
+
+**Phase gate:** issues #761, #762, and #763 meet their full acceptance criteria; the resulting checks are documented, stable, and enforced at the agreed CI level.
+
 ## Parallel execution map
 
 At maximum useful concurrency, staff the program as follows:
 
 | Stream | Phases 0–2 | Phase 3 | Phase 4 | Phases 5–7 |
 | --- | --- | --- | --- | --- |
-| A | Package/build | Actions/feedback | Build/assets | Active app shell |
-| B | Visual foundations | Forms | Foundations/content | Active app forms/workflows |
+| A | Package/build | Actions/feedback | Static delivery/resources | Active app shell |
+| B | Visual foundations | Forms | Instructional content review | Active app forms/workflows |
 | C | Test/catalogue | Navigation/overlays | Shell/search/canvas | Active app data/navigation |
-| D | Docs platform | Data/brand/layout | Tests/governance | Verification plus next-app inventory |
+| D | Vite styleguide | Data/brand/layout | Tests/governance | Verification plus next-app inventory |
 
 While one application is in final integration and deployment, other streams may prepare the next application's inventory, fixtures, and smoke checklist or continue #761–#763. They must not introduce `paper-ui` into the next application until its coordinated cutover branch begins.
 
@@ -559,9 +781,10 @@ Each application follows the same protocol.
 
 - Replace component imports and deep imports.
 - Replace implicit global styling with components or named recipes.
-- Convert buttons by semantic hierarchy, tone, and state rather than text substitution.
+- Convert buttons by semantic job rather than text substitution: emphasized to default, neutral to outline, quiet action to ghost or link, destructive intent to destructive.
 - Load Paper styles once and set the application density.
 - Replace Next-aware shared behavior with application adapters.
+- Replace Headless UI-backed legacy components with their Paper/Base UI-backed equivalents without exposing Base UI to the application.
 - Update package, Tailwind, framework, image, CI, Tilt, and asset references as applicable.
 
 ### 4. Prove zero mixing
@@ -573,7 +796,8 @@ For the target application, repository checks must find no:
 - `ui/components/*` deep import;
 - `require('ui/tailwind.config.js')` or equivalent;
 - class that exists only through undocumented legacy globals;
-- duplicate `paper-ui/styles.css` import.
+- duplicate `paper-ui/styles.css` import;
+- direct or unused `@headlessui/react` dependency.
 
 ### 5. Verify and deploy
 
@@ -587,14 +811,15 @@ For the target application, repository checks must find no:
 
 Redeploy the recorded previous image. Do not attempt to fix a failed cutover by loading both stylesheets. Source rollback is a normal revert of the migration commits; no database or API rollback is involved.
 
-## Application migration matrix
+## Delivery and migration matrix
 
-| Order | Application | Default density | Primary risk | Required proof |
+| Order | Target | Default density | Primary risk | Required proof |
 | ---: | --- | --- | --- | --- |
-| 1 | styleguide | switchable | The new system documents and tests itself. | Every route, search, canvas, fixture, redirect, and registry contract works with zero legacy imports. |
-| 2 | admin | compact | Dense CRUD, tables, editors, menus, and modal flows. | Core administrative workflows and narrow layouts work at 36px density. |
-| 3 | auth | comfortable | Dynamic Ory nodes rely heavily on implicit global CSS. | Every configured identity flow, error state, keyboard path, and submit/loading state works. |
-| 4 | webv2 | comfortable | Largest surface and most router/data/chart combinations. | Representative user roles and core logging, contest, content, profile, navigation, and chart flows work. |
+| 0 | `paper-styleguide` at `paper.tadoku.app` | switchable | The new system must document and test itself without legacy assistance. | Every route, search, canvas, fixture, registry, instructional, static-delivery, and resource contract works with zero legacy/Headless imports. |
+| 1 | admin | compact | Dense CRUD, tables, editors, menus, and modal flows. | Core administrative workflows and narrow layouts work at 36px density with zero Headless UI. |
+| 2 | auth | comfortable | Dynamic Ory nodes rely heavily on implicit global CSS. | Every configured identity flow, error state, keyboard path, and submit/loading state works. |
+| 3 | webv2 | comfortable | Largest surface and most router/data/chart combinations. | Representative user roles and core logging, contest, content, profile, navigation, and chart flows work. |
+| 4 | `ui.tadoku.app` and cleanup | switchable | Domain continuity, legacy bookmarks, and irreversible source cleanup. | Paper serves both canonical and redirected routes; rollback image is recorded; repository has zero `ui` or Headless UI consumers. |
 
 ## Validation commands
 
@@ -605,9 +830,10 @@ cd frontend
 pnpm --filter paper-ui typecheck
 pnpm --filter paper-ui test
 pnpm --filter paper-ui build
-pnpm --filter styleguide lint
-pnpm --filter styleguide exec tsc --noEmit
-pnpm --filter styleguide build
+pnpm --filter paper-styleguide lint
+pnpm --filter paper-styleguide test
+pnpm --filter paper-styleguide exec tsc --noEmit
+pnpm --filter paper-styleguide build
 pnpm --filter admin lint
 pnpm --filter admin exec tsc --noEmit
 pnpm --filter admin build
@@ -627,14 +853,17 @@ Application and container-image workflow commands remain the final production co
 Tadoku Paper is complete when:
 
 - the approved visual grammar and brand assets are implemented only through semantic roles and documented exceptions;
-- `paper-ui` builds and is independently consumable by React without Next.js;
+- `paper-ui` builds and is independently consumable by React without Next.js or Headless UI;
 - class recipes and React components are documented and tested as one styling contract;
+- Button variants use the accepted default/outline/ghost/link/destructive vocabulary with correct button-versus-link semantics;
 - every public component has a canonical searchable page, deterministic fixtures, lifecycle metadata, ownership, tests, and migration guidance;
 - foundations, components, product patterns, and experiments are visibly separate;
-- styleguide, admin, auth, and webv2 each use only Paper and have passed their deployment smoke gates;
+- `paper-styleguide` is a static React + Vite application that uses only Paper and satisfies the full instructional page contract;
+- admin, auth, and webv2 each use only Paper and have passed their deployment smoke gates;
+- `paper.tadoku.app` supports the migration and `ui.tadoku.app` serves the final Paper catalogue with legacy-route redirects;
 - the original audit, all visual studies, and the decision log remain available;
 - repository and CI configuration watches and validates `paper-ui`;
-- legacy `ui` has zero consumers and is removed;
+- legacy `ui`, the old styleguide, and Headless UI have zero consumers and are removed;
 - issues #761–#763 meet their full accessibility, regression, and theme/preference acceptance criteria.
 
 ## Audit traceability
@@ -643,9 +872,9 @@ Tadoku Paper is complete when:
 | --- | --- |
 | P0.1 Semantic tokens | Phases 1 and 3 foundation work; token/package gates. |
 | P0.2 Visual grammar | Confirmed contract; Phases 1–3 implementation and documentation. |
-| P0.3 Complete docs shell | Phases 1–4. |
+| P0.3 Complete docs shell | New Vite catalogue in Phases 1–4; no in-place legacy shell migration. |
 | P0.4 Accessibility contract | Immediate semantic tests throughout; comprehensive completion in #761/Phase 9. |
-| P0.5 Typed Button/LinkButton | Hybrid class/component contract proven in Phase 2; router-neutral link recipes. |
+| P0.5 Typed Button/LinkButton | Shadcn-inspired default/outline/ghost/link/destructive recipe, class/component parity, and semantic anchor styling proven in Phase 2. |
 | P1.1 One route and search | Registry-driven docs in Phases 1, 3, and 4. |
 | P1.2 Full state matrix | Fixture schema and every component page, beginning in Phase 2. |
 | P1.3 Foundation pages | Phase 3. |
@@ -654,6 +883,17 @@ Tadoku Paper is complete when:
 | P2.1 Components/patterns/experiments | Information architecture and Phases 3–4. |
 | P2.2 Lifecycle/governance | Registry schema, Stable gate, contribution and deprecation policy in Phases 1–4. |
 | P2.3 Themes/preferences | Light/dark tokens and preview now; full preference behavior in #763/Phase 9. |
-| P2.4 Package boundary | `paper-ui` architecture, boundary tests, app adapters, and migration gates. |
+| P2.4 Package boundary | `paper-ui` architecture, Base UI wrapper boundary, Vite consumer proof, boundary tests, app adapters, and migration gates. |
 
 The early quick wins—framed previews, constrained prose, refined violet, and explicit use/avoid guidance—are incorporated into the documentation shell and visual contract rather than scheduled as throwaway work.
+
+## Follow-up opportunities unlocked by Paper
+
+- Publish a Paper registry or codemod that can add approved patterns without making generated shadcn source the canonical implementation.
+- Generate typed API tables and migration reports from TypeScript declarations and catalogue metadata.
+- Generate design-token packages for non-React surfaces and design tooling from the same semantic sources.
+- Move admin, auth, or webv2 away from Next.js independently now that their shared UI has no router/framework dependency.
+- Evaluate object-storage or CDN delivery for the static styleguide if eliminating its Kubernetes pod becomes more valuable than deployment consistency.
+- Add localized documentation and right-to-left specimens using the existing fixture and preview contracts.
+- Add automated component dependency graphs and “used by” views to help assess breaking changes.
+- Promote recurring product compositions into governed Patterns only after application migrations reveal real reuse.

--- a/docs/wip/tadoku-paper/implementation-plan.md
+++ b/docs/wip/tadoku-paper/implementation-plan.md
@@ -1,0 +1,659 @@
+# Tadoku Paper implementation plan
+
+Status: ready for implementation  
+Last updated: 2026-08-07  
+Decision source: [decision-log.md](decision-log.md)  
+Design history: [README.md](README.md)
+
+## Outcome
+
+Deliver Tadoku Paper as a refined, tested, React-based design system in a new `paper-ui` package, make the style guide its authoritative catalogue, migrate every frontend application without mixing old and new systems inside an application, and finally retire legacy `ui`.
+
+The finished work must provide:
+
+- the approved sharp, editorial Bookplate visual language;
+- a semantic token system with light and dark mappings;
+- public CSS recipes and optional React components backed by the same implementation;
+- a searchable, registry-driven style guide with one route per component;
+- deterministic fixtures shared between documentation and component tests;
+- a framework-independent package boundary with no Next.js dependency;
+- complete migrations of styleguide, admin, auth, and webv2;
+- compatibility, rollout, rollback, and eventual legacy-package removal gates.
+
+This plan is the implementation companion to the decision log. If an early audit suggestion conflicts with a later recorded decision, the later decision wins. In particular, Tadoku Paper remains square rather than rounded, and buttons support both classes and React components rather than requiring a component everywhere.
+
+## Scope and non-goals
+
+### In scope
+
+- All P0, P1, and P2 audit recommendations, including work already represented by follow-up issues.
+- The complete current public surface of `ui`, including components that are poorly documented or available only through deep imports.
+- The implicit styling contract currently supplied by `ui/styles/globals.css`.
+- The style-guide information architecture, examples, navigation, search, governance, and contribution model.
+- Component semantics, keyboard behavior, test fixtures, fast rendered tests, package-boundary checks, and application build gates.
+- Additive repository-level coexistence followed by one complete cutover per application.
+
+### Non-goals for the main migration
+
+- Rewriting any application away from Next.js. `paper-ui` must enable that future change, but application framework migration is separate work.
+- Consolidating or redesigning product behavior such as the two webv2 logging implementations.
+- Requiring Storybook before the custom catalogue has been proven insufficient.
+- Blocking the initial rollout on the complete Playwright screenshot system, exhaustive WCAG audit, or full user-preference matrix. Those remain tracked in issues #761–#763 and build on the foundation delivered here.
+- Mixing `ui` and `paper-ui` in one deployed application, even temporarily.
+
+## Confirmed design contract
+
+### Visual grammar
+
+- Sharp component geometry with no border radius.
+- Warm canvas and paper surfaces, dark ink structure, and restrained ink violet.
+- Light structural accent `#5747B8`; lifted dark structural accent `#9A8BEA`.
+- Static surfaces use quiet 1px neutral rules.
+- A colored left accent is a straight positioned rail that replaces the neutral left edge.
+- Pale form fields use a subtle neutral 2px lower edge.
+- Filled actions use a stronger 2px lower edge and a distinct hover state.
+- Ordinary surfaces stay flat; floating overlays use a 3px hard-offset shadow; rare showcase surfaces may use 5px.
+- Dark primary actions use a deeper violet with light text.
+- Comfortable density is 44px; compact density is 36px.
+- Focus uses a consistent 2px `:focus-visible` ring with a 2px offset.
+- Motion roles are 120ms, 180ms, and 240ms.
+
+### Type, icons, and brand
+
+- Merriweather: display, page, and section hierarchy.
+- Open Sans: component titles, labels, body copy, and dense UI, with real 400/600/700 font files.
+- Fonts are self-hosted and have no Google runtime import or `next/font` dependency.
+- Heroicons outline: actions and navigation; solid: status and confirmation.
+- Icon roles: 16px compact, 20px default, 24px prominent or icon-only, 48px only for empty-state illustration.
+- The compact brand mark is the monochrome-first square-cut Cut Meter with three rising bars.
+- Monochrome and reversed marks must work independently of the optional ink-violet accent.
+
+### Public API
+
+- Package name: `paper-ui`.
+- React is assumed; Next.js is not.
+- CSS class recipes and React components are equal public contracts.
+- Button hierarchy: `default`, `primary`, `ghost`.
+- `danger` is a composable tone and `loading` is a composable state.
+- A class-only loading button remains valid, for example `btn primary loading`, when paired with `aria-busy="true"` and normally `disabled`.
+- React components compose the same public recipes; they do not own private duplicate styles.
+- `LinkButton` is a router-neutral React adapter over a native anchor or caller-supplied link element; router-specific code can always use the same public class recipe directly.
+- Applications import the Paper stylesheet once, after which class recipes work without a component import at each call site.
+- Close is an action, not a variant: a footer Close action is usually default; a top-right X is ghost and icon-only.
+- Navigation components receive link rendering and current-route data from consumers rather than importing router APIs.
+
+## Delivery principles
+
+1. **One source of truth.** Tokens generate styles and foundation documentation; the catalogue registry generates routes, navigation, search, and status metadata; named fixtures feed both docs and tests.
+2. **Vertical slices before breadth.** Prove the package, fixture, component, documentation, and test contracts end to end with Button, Input, Modal, and ActionMenu before porting the full catalogue.
+3. **Parallelize by ownership.** Independent lanes own separate package or category directories. One integrator owns shared registries and export boundaries to reduce merge conflicts.
+4. **Promote by evidence.** A component becomes Stable only after its API, metadata, fixtures, semantics, behavior tests, migration notes, and ownership are present.
+5. **Cut over whole applications.** Repository packages coexist; styles within an application do not.
+6. **Keep changes reviewable.** Use atomic commits and small package/component PRs before the per-application deployment PRs.
+7. **Preserve history.** The audit, visual studies, and decision log remain unchanged and are linked from the finished style guide.
+
+## Target architecture
+
+### Package layout
+
+```text
+frontend/packages/paper-ui/
+├── package.json
+├── tsconfig.json
+├── vitest.config.ts
+├── src/
+│   ├── assets/
+│   │   ├── brand/
+│   │   └── fonts/
+│   ├── foundations/
+│   │   ├── tokens.css
+│   │   ├── fonts.css
+│   │   ├── base.css
+│   │   └── chart-palette.ts
+│   ├── components/
+│   │   ├── actions/
+│   │   ├── forms/
+│   │   ├── navigation/
+│   │   ├── feedback/
+│   │   ├── overlays/
+│   │   └── data-display/
+│   ├── catalog/
+│   │   ├── schema.ts
+│   │   └── registry.ts
+│   ├── icons/
+│   └── index.ts
+├── styles/
+│   ├── recipes.css
+│   ├── utilities.css
+│   └── index.css
+├── tailwind-preset.cjs
+└── tests/
+    └── setup.ts
+```
+
+Each component directory owns implementation, styles, fixtures, metadata, and tests:
+
+```text
+Button/
+├── Button.tsx
+├── button.css
+├── Button.fixtures.tsx
+├── Button.meta.ts
+└── Button.test.tsx
+```
+
+### Export contract
+
+| Export | Responsibility |
+| --- | --- |
+| `paper-ui` | React components, recipe helpers, and public types |
+| `paper-ui/styles.css` | Application-level Paper stylesheet |
+| `paper-ui/tokens.css` | Semantic light/dark variables when tokens are needed independently |
+| `paper-ui/fonts.css` | Self-hosted font faces |
+| `paper-ui/icons` | Curated icon exports and size helpers |
+| `paper-ui/tailwind-preset` | Immutable semantic Tailwind mappings |
+| `paper-ui/catalog` | Documentation metadata and named fixtures; excluded from production bundles unless explicitly imported |
+
+The package builds ESM, declarations, and CSS. React, React DOM, and React Hook Form are peer dependencies. Implementation libraries such as Headless UI and Heroicons can be direct dependencies. Package output must be consumable without Tailwind and without Next transpilation.
+
+### Token layers
+
+Keep primitives private and expose semantic roles:
+
+- surfaces: canvas, paper, raised, overlay;
+- text: ink, muted, inverse, link;
+- rules: subtle, default, strong, interactive lower edge;
+- actions: base, hover, active, text, danger;
+- status: information, success, warning, danger;
+- focus: ring and offset;
+- density: comfortable and compact;
+- motion: quick, standard, deliberate;
+- elevation: flat, floating, showcase;
+- typography: named display, page, section, component, body, label, and metadata roles;
+- charts: a separate categorical sequence with non-color cues.
+
+Light aliases live on `:root` and `[data-theme="light"]`; dark aliases live on `[data-theme="dark"]`. Density is set with `[data-density="comfortable|compact"]`. Theme previewing is part of the style guide now; operating-system preference and persistence remain in #763.
+
+### CSS boundary
+
+- `styles.css` includes tokens, fonts, a small documented base layer, and static class recipes.
+- Avoid broad form, table, heading, and link selectors that turn global CSS into an undocumented API.
+- Forms and tables receive Paper styling through components or named recipes.
+- Raw colors are allowed only in primitive token definitions, documented specimens, and an explicit chart-palette allow-list.
+- Keep convenient unprefixed recipes such as `.btn` because only one system is loaded per application.
+
+### Router boundary
+
+- No `next`, `next/link`, `next/router`, `next/image`, or `next/font` import or dependency in `paper-ui` or its catalogue.
+- Use inline SVG or ordinary image rendering for brand assets.
+- Expose a recipe helper for styling any router's link.
+- Navbar receives current state and a consumer-supplied link renderer.
+- Pagination receives page state plus `getHref` or `onPageChange`.
+- Breadcrumbs, tabs, sidebars, and grouped links use the same injected link contract.
+
+## Documentation model
+
+### Information architecture
+
+```text
+/
+├── foundations/
+│   ├── principles
+│   ├── color
+│   ├── typography
+│   ├── spacing-and-density
+│   ├── shape-and-borders
+│   ├── elevation
+│   ├── iconography
+│   ├── motion
+│   ├── layout
+│   └── brand
+├── components/
+│   ├── actions/
+│   ├── forms/
+│   ├── navigation/
+│   ├── feedback/
+│   ├── overlays/
+│   └── data-display/
+├── patterns/
+│   └── logging/
+├── experiments/
+│   └── logging-v2
+├── contributing
+└── changelog
+```
+
+The style guide may remain a Next.js application during this work. Framework routing stays in a thin application adapter; `paper-ui`, its fixtures, and its catalogue remain framework-neutral.
+
+### Required page anatomy
+
+Every component page contains:
+
+- name, summary, lifecycle status, owner, source, package version, and last meaningful review;
+- when to use and when to avoid;
+- content guidance;
+- accessibility and keyboard contract;
+- API and CSS-class contract;
+- realistic Tadoku examples;
+- meaningful variants, states, density, theme, viewport, long-copy, and overflow coverage;
+- migration guidance and changelog notes;
+- replacement and planned removal information when Deprecated.
+
+Use exactly `Experimental`, `Stable`, and `Deprecated`. Category pages summarize their children; every actual component gets one canonical searchable route. Old bookmarks redirect to the new route map.
+
+### Documentation shell
+
+Replace `Showcase` with:
+
+- a responsive docs shell and mobile navigation;
+- keyboard-first search with `/` and Command/Ctrl-K;
+- registry-driven navigation and component index;
+- a local table of contents with stable deep links;
+- a framed example canvas;
+- Preview, Code, API/Props, and Accessibility tabs as applicable;
+- code copy and fixture deep links;
+- theme, density, and real viewport controls;
+- status, metadata, usage, and accessibility panels.
+
+Viewport previewing should create a real media-query environment, preferably an isolated iframe document, not only a narrow wrapper. Reading prose should stay around 65–75 characters or 720–780px while examples and data specimens may use a wider column.
+
+### Catalogue and fixture schema
+
+Each document entry requires a stable ID, route, name, category, aliases, summary, keywords, lifecycle, owner, review date, source path, package version, guidance, accessibility notes, API documentation, fixture IDs, dependencies, and migration details.
+
+Fixtures must be deterministic: no Faker randomness, `Math.random`, current dates, network calls, or application-router assumptions. A fixture contains stable metadata and a render function; assertions stay in tests.
+
+Registry validation fails on:
+
+- duplicate IDs or slugs;
+- invalid category or lifecycle values;
+- missing Stable metadata, fixtures, behavior tests, or accessibility notes;
+- documentation references to nonexistent fixture IDs;
+- Deprecated entries without replacement and removal guidance.
+
+## Test and quality strategy
+
+### Immediate baseline
+
+Add Vitest with jsdom, React Testing Library, `user-event`, and jest-dom. Replace source-text assertions with rendered semantic and behavioral tests. Do not use an arbitrary coverage-percentage gate initially; gate the documented component contract instead.
+
+Initial tests cover:
+
+- roles and accessible names;
+- label, hint, and error relationships;
+- `aria-invalid`, `aria-describedby`, `aria-current`, and `aria-busy` behavior;
+- native disabled behavior and prevention of duplicate activation;
+- keyboard operation, focus entry/containment/return, and Escape behavior;
+- raw-class and React-component parity;
+- comfortable and compact fixture coverage;
+- deterministic fixture and registry validation;
+- public exports, CSS selectors, built assets, and server-render import smoke tests.
+
+The first required behavioral tranche is Button/LinkButton recipes, Input, Select, Checkbox, Modal, ActionMenu, Navbar, Breadcrumb, Tabs, Pagination, Loading, and form error plumbing. A component receives equivalent tests when promoted to Stable.
+
+### Package gates
+
+- No Next import, dependency, mock, or router assumption.
+- Public exports import and `renderToString` in a minimal React consumer.
+- Built output contains JS, declarations, CSS, tokens, fonts, icons, and brand assets.
+- `pnpm pack --dry-run` or equivalent validates the published file set.
+- Built CSS contains every documented raw class recipe and state selector.
+- Token lint rejects raw palette values outside approved definition files.
+- Font checks verify packaged Merriweather and Open Sans 400/600/700 assets.
+
+### CI
+
+Add a Paper quality workflow on pull requests and pushes to main for package, catalogue, style-guide, lockfile, and workflow changes. Its fast required job runs:
+
+```sh
+cd frontend
+pnpm install --frozen-lockfile
+pnpm --filter paper-ui typecheck
+pnpm --filter paper-ui test
+pnpm --filter paper-ui build
+```
+
+As each application migrates, its workflow must:
+
+- watch `frontend/packages/paper-ui/**`;
+- run application lint and typecheck before its production build;
+- retain production and container-image builds as compatibility checks;
+- join the Paper compatibility matrix.
+
+At completion, the repository gate is the complete frontend build plus all four application images.
+
+### Deferred comprehensive gates
+
+- #761: full WCAG 2.2 component contract, contrast, zoom/reflow, forced colors, and exception register.
+- #762: Playwright fixture routes, phone/desktop screenshots, real hover/focus, axe scans, traces/diffs, baseline approval workflow, and stability burn-in.
+- #763: preference detection and persistence, reduced motion, forced colors, exhaustive dark-theme validation, and non-color chart/status cues.
+
+The main plan establishes the catalogue, deterministic fixtures, semantics, dark token aliases, and CI hooks needed by these issues; the issues stay open until their complete acceptance criteria are met.
+
+## Phased execution
+
+The dependency spine is:
+
+```text
+contracts
+   ↓
+package foundations + catalogue/test schema
+   ↓
+four-component vertical slice
+   ↓
+full component catalogue + docs platform
+   ↓
+styleguide cutover
+   ↓
+admin → auth → webv2 cutovers
+   ↓
+legacy ui removal and deferred hardening
+```
+
+Work beside the spine runs concurrently. Only shared contracts, the end-to-end pilot, and application deployment order are deliberately serial.
+
+### Phase 0 — Lock contracts and migration guardrails
+
+Goal: give every parallel lane stable boundaries before implementation starts.
+
+| Lane | Work |
+| --- | --- |
+| Architecture | Finalize export map, dependency policy, router/link contract, recipe/component parity, and built-output format. |
+| Catalogue | Freeze document, fixture, lifecycle, route, redirect, and registry schemas. |
+| Inventory | Map every legacy export, deep import, global selector, style-guide example, and consumer to its Paper destination. |
+| Delivery | Define per-app smoke lists, rollback evidence, CI matrix, owners, and PR boundaries. |
+
+Add repository guards that reject:
+
+- `ui` imports in an application marked migrated;
+- `paper-ui` imports in an application not yet marked migrated;
+- `paper-ui/src/*` private imports;
+- Next imports inside `paper-ui`;
+- duplicate application-level Paper stylesheet imports.
+
+Update contributor instructions during coexistence to explain which package each application may use. Keep the existing design archive untouched.
+
+**Exit gate:** approved contract document, complete migration inventory, route/redirect map, application smoke matrix, and enforcement scripts.
+
+### Phase 1 — Build the Paper foundation
+
+Run four lanes in parallel.
+
+| Lane | Deliverables |
+| --- | --- |
+| Package/build | Package scaffold, ESM/declaration build, export map, immutable Tailwind preset, root scripts, lockfile, package boundary checks, CI and Tilt triggers. |
+| Visual foundation | Semantic tokens, themes, density, typography/font assets, focus, motion, borders, accent rail, hard-offset elevation, chart palette, Cut Meter, wordmark, favicon sources. |
+| Test/catalogue | Vitest setup, RTL helpers, fixture and metadata schemas, registry validation, test utilities, catalogue export. |
+| Docs platform | Style-guide route resolver, registry stubs, shell primitives, isolated preview-canvas prototype, old-route redirect table. |
+
+One integrator owns root exports, registry aggregation, and shared token names. Lanes add modules without repeatedly editing those files.
+
+**Exit gate:** `paper-ui` builds, typechecks, tests, and server-renders outside Next; CSS works without Tailwind; both themes and densities render in a minimal harness; fonts and brand assets resolve; the stub catalogue drives navigation and search.
+
+### Phase 2 — Prove an end-to-end vertical slice
+
+Implement Button, Input, Modal, and ActionMenu completely. These four jointly prove class/component parity, form anatomy, interactive edge treatment, floating elevation, overlay focus behavior, fixtures, metadata, documentation rendering, and tests.
+
+Parallel ownership:
+
+| Lane | Slice |
+| --- | --- |
+| Actions | Button and LinkButton recipes/components: default/primary/ghost, danger, loading, icon, full-width, both densities. |
+| Forms | Input anatomy: label, hint, error, required, read-only, disabled, both densities and themes. |
+| Overlays | Modal and ActionMenu: focus, keyboard, close/return behavior, danger/disabled items, floating treatment. |
+| Documentation/tests | Final page anatomy, state matrix, Preview/Code/API controls, fixture rendering, registry and behavior tests. |
+
+Show real hover and focus in browser documentation; do not introduce fake production state classes solely for jsdom.
+
+**Exit gate:** all four pages satisfy the final schema; raw classes and React APIs share styles; tests pass; desktop/mobile shell and all preview controls work; the team reviews visual coherence before scaling.
+
+### Phase 3 — Complete `paper-ui` and the style-guide catalogue
+
+With the pilot contracts frozen, run parallel component lanes in separate directories.
+
+| Lane | Components and docs |
+| --- | --- |
+| Actions/feedback | ButtonGroup, Flash, Loading, toasts, cards and elevation recipes. |
+| Forms | TextArea, Select, Checkbox, RadioSelect, RadioGroup, AmountWithUnit, autocomplete, multi-autocomplete, TagsInput, public option types; all use React Hook Form. |
+| Navigation/overlays | Navbar, Sidebar, Breadcrumb, Tabbar, VerticalTabbar, Pagination, Modal, ActionMenu, router-neutral link integration. |
+| Data/brand/layout | Tables, HeatmapChart, chart defaults/palette, layout recipes, Cut Meter and wordmark lockups. |
+| Docs foundations | Principles, color, typography, spacing/density, borders/shape, elevation, icons, motion, layout, brand. |
+| Docs governance | Component indexes, Patterns, Experimental logging-v2, contribution guide, lifecycle, deprecation policy, changelog. |
+
+Every lane ships its fixtures, metadata, tests, migration notes, and realistic Tadoku examples with the implementation. Explicitly document currently missed exports such as Loading, VerticalTabbar, and AmountWithUnit.
+
+**Exit gate:** the public export surface is complete; every Stable component has a searchable route and contract evidence; navigation/search/status derive from one registry; all routes and old-route redirects validate; foundation pages read canonical tokens instead of copied values.
+
+### Phase 4 — Styleguide big-bang cutover
+
+Prepare independent changes concurrently, then integrate them into one deployable application cutover.
+
+| Lane | Work |
+| --- | --- |
+| Shell | Replace `_app.tsx`, hard-coded sidebar, mobile navigation, `Showcase`, and old example helpers with the registry-driven docs shell. |
+| Content | Replace repeated category pages, split Forms and Navigation into canonical component routes, reclassify logging as Patterns and logging-v2 as Experimental. |
+| Build/assets | Switch package, CSS, Tailwind, Next config, document font preloads, brand/favicon assets, and remove obsolete raw-source loader support. |
+| Verification | Search/route tests, registry checks, keyboard/mobile docs-shell tests, link/redirect checks, production and container builds. |
+
+Import `paper-ui/styles.css` exactly once. Preserve the audit, studies, and decision log and link them under Design history or Contributing.
+
+**Cutover gate:** no legacy `ui` import, dependency, stylesheet, Tailwind inheritance, or config reference remains in styleguide; every shipped component is documented; search and deep links work keyboard-first; both themes, densities, and real narrow/desktop preview environments work; lint, typecheck, tests, application build, and image build pass.
+
+### Phase 5 — Admin big-bang cutover
+
+Admin is the compact-density stress test. Work in parallel on one integration branch or coordinated PR stack, then switch the application once.
+
+| Lane | Scope |
+| --- | --- |
+| Shell | Dashboard layout, Sidebar, branding, Loading, access-denied and redirect states. |
+| Editors/forms | Content and announcement editors, namespace forms, language/user editing, CodeMirror adapter using `useController`. |
+| Data/actions | Lists, tables, pagination, breadcrumbs, tabs, menus, dialogs, destructive actions, narrow layouts. |
+| Verification | Import/class audit, compact screenshots for human review, CRUD and role smoke suite, build matrix. |
+
+Review old `secondary` and `danger` combinations semantically; do not perform a blind class rename. Compact controls must not make icon-only targets inaccessible.
+
+**Cutover gate:** no legacy package or implicit legacy-only class remains; Paper CSS is loaded once and compact density is applied at the app root; dashboard/navigation, role/loading/access-denied, content CRUD and preview, announcements, languages, users, dialogs, and narrow layouts pass; lint, typecheck, production build, and image build pass.
+
+### Phase 6 — Auth big-bang cutover
+
+Auth has few imports but high implicit-CSS and flow risk because Ory generates dynamic form nodes.
+
+| Lane | Scope |
+| --- | --- |
+| Shell | Navigation, Cut Meter/wordmark, comfortable layout, feedback and loading. |
+| Ory fields | Node adapters, labels, hints, errors, checkbox/text/select semantics, WebAuthn/script preservation. |
+| Actions/flows | Explicit default/primary/ghost hierarchy, loading and double-submit prevention, removal of selector-order button hacks. |
+| Verification | Fixtures and production-like login, registration, recovery, verification, settings, OIDC/passkey/WebAuthn checks. |
+
+**Cutover gate:** no legacy import or broad legacy-form dependency; Paper CSS loaded once and comfortable density applied; server errors associate to controls; keyboard submission, `aria-busy`, disabled state, and dynamic Ory behavior work; lint, typecheck, production build, image build, and focused Ory smoke tests pass.
+
+### Phase 7 — webv2 big-bang cutover
+
+webv2 is last because it has the largest and broadest surface. Use four parallel workstreams while preserving the application as one cutover.
+
+| Lane | Scope |
+| --- | --- |
+| Global shell | Navigation, Footer, announcement banner, signed-in/out/admin/banned states, mobile disclosure. |
+| Logging/contest forms | New/old/edit log flows, contest create/register/submit flows, form validation and overlays. |
+| Browse/data | Leaderboards, profiles, lists, tables, pagination, tabs, menus, responsive and overflow behavior. |
+| Content/charts | Blog, pages, manual, Chart.js palettes, heatmaps, activity charts, page counter exception. |
+| Verification | Import/class audit, route and role smoke matrix, Paper tests, full frontend and container builds. |
+
+Do not combine product refactors with the visual migration. App adapters provide routing data to Navbar, Breadcrumb, Tabs, and Pagination. Charts use semantic categorical tokens and prepare non-color cues for #763.
+
+**Cutover gate:** no legacy import or undocumented CSS dependency; Paper CSS loaded once; signed-in/out navigation, mobile navigation, logging create/edit/details/delete, contest creation/registration/leaderboards, profiles/statistics, blog/content, pagination/tabs, charts, and page counter pass; lint, typecheck, production build, image build, and the complete frontend build matrix pass.
+
+### Phase 8 — Retire legacy `ui`
+
+Only begin when a repository-wide search shows zero consumers:
+
+```sh
+rg "from ['\"]ui|ui/styles|ui/components|\"ui\": \"workspace" frontend
+```
+
+Then:
+
+- remove `frontend/packages/ui`;
+- remove old dependencies, lockfile entries, transpilation entries, and Tailwind inheritance;
+- update all CI paths and `frontend/Tiltfile` to Paper only;
+- simplify contributor instructions from coexistence rules to Paper-only guidance;
+- run package tests and the complete frontend/application-image matrix;
+- record package retirement and final migration status in this directory and the style-guide changelog.
+
+Previously deployed application images remain rollback-capable because their legacy dependencies are bundled.
+
+### Phase 9 — Finish the deferred hardening issues
+
+These workstreams may begin earlier once their prerequisites exist, but close after the migrations only when their full acceptance criteria are satisfied.
+
+| Issue | Parallel work after prerequisites | Completion point |
+| --- | --- | --- |
+| #761 Accessibility contract | Component audits can start after Phase 2; product reflow checks start with each migrated app. | All documented controls, flows, contrast, keyboard, zoom/reflow, and exception tracking complete. |
+| #762 Regression gates | Playwright fixture routes can start after the style-guide pilot; burn-in continues through app migrations. | Reviewed responsive baselines, failure artifacts, axe integration, and stable blocking CI complete. |
+| #763 Themes/preferences | Dark/reduced-motion/forced-color fixtures can start after tokens; app persistence waits for product rollout decisions. | Preference behavior and representative app/theme matrix complete. |
+
+## Parallel execution map
+
+At maximum useful concurrency, staff the program as follows:
+
+| Stream | Phases 0–2 | Phase 3 | Phase 4 | Phases 5–7 |
+| --- | --- | --- | --- | --- |
+| A | Package/build | Actions/feedback | Build/assets | Active app shell |
+| B | Visual foundations | Forms | Foundations/content | Active app forms/workflows |
+| C | Test/catalogue | Navigation/overlays | Shell/search/canvas | Active app data/navigation |
+| D | Docs platform | Data/brand/layout | Tests/governance | Verification plus next-app inventory |
+
+While one application is in final integration and deployment, other streams may prepare the next application's inventory, fixtures, and smoke checklist or continue #761–#763. They must not introduce `paper-ui` into the next application until its coordinated cutover branch begins.
+
+Recommended integration discipline:
+
+- one owner for token names, public exports, and the catalogue registry;
+- directory ownership for parallel component lanes;
+- generated registry aggregation where possible;
+- small component/foundation PRs with their tests and docs;
+- one deployable migration PR per application, composed of atomic commits;
+- short-lived integration branches and daily main rebases during large cutovers;
+- no application deployment before the preceding application has passed its production smoke window.
+
+## Per-application migration protocol
+
+Each application follows the same protocol.
+
+### 1. Inventory
+
+- Direct imports and deep imports.
+- Legacy global selectors and raw classes.
+- Tailwind mutation, package, transpile, and stylesheet configuration.
+- Router-dependent behavior.
+- Brand/favicons and font loading.
+- Critical routes, roles, responsive states, form errors, and overlays.
+
+### 2. Prepare
+
+- Ensure every required Paper component is Stable or explicitly approved Experimental.
+- Add missing product states as deterministic fixtures and tests before migration.
+- Create application-owned router adapters and product patterns.
+- Record the currently deployed immutable image SHA/digest and verify the rollback command.
+
+### 3. Convert
+
+- Replace component imports and deep imports.
+- Replace implicit global styling with components or named recipes.
+- Convert buttons by semantic hierarchy, tone, and state rather than text substitution.
+- Load Paper styles once and set the application density.
+- Replace Next-aware shared behavior with application adapters.
+- Update package, Tailwind, framework, image, CI, Tilt, and asset references as applicable.
+
+### 4. Prove zero mixing
+
+For the target application, repository checks must find no:
+
+- `ui` dependency or import;
+- `ui/styles/globals.css` import;
+- `ui/components/*` deep import;
+- `require('ui/tailwind.config.js')` or equivalent;
+- class that exists only through undocumented legacy globals;
+- duplicate `paper-ui/styles.css` import.
+
+### 5. Verify and deploy
+
+- Run `paper-ui` typecheck, test, and build.
+- Run target-app lint, `tsc --noEmit`, production build, and image build.
+- Execute the app-specific smoke matrix on narrow and desktop layouts.
+- Deploy only the target application.
+- Re-run critical production smoke checks and observe frontend/error telemetry.
+
+### 6. Roll back if necessary
+
+Redeploy the recorded previous image. Do not attempt to fix a failed cutover by loading both stylesheets. Source rollback is a normal revert of the migration commits; no database or API rollback is involved.
+
+## Application migration matrix
+
+| Order | Application | Default density | Primary risk | Required proof |
+| ---: | --- | --- | --- | --- |
+| 1 | styleguide | switchable | The new system documents and tests itself. | Every route, search, canvas, fixture, redirect, and registry contract works with zero legacy imports. |
+| 2 | admin | compact | Dense CRUD, tables, editors, menus, and modal flows. | Core administrative workflows and narrow layouts work at 36px density. |
+| 3 | auth | comfortable | Dynamic Ory nodes rely heavily on implicit global CSS. | Every configured identity flow, error state, keyboard path, and submit/loading state works. |
+| 4 | webv2 | comfortable | Largest surface and most router/data/chart combinations. | Representative user roles and core logging, contest, content, profile, navigation, and chart flows work. |
+
+## Validation commands
+
+Exact package scripts will be added in Phase 1. The required command shape is:
+
+```sh
+cd frontend
+pnpm --filter paper-ui typecheck
+pnpm --filter paper-ui test
+pnpm --filter paper-ui build
+pnpm --filter styleguide lint
+pnpm --filter styleguide exec tsc --noEmit
+pnpm --filter styleguide build
+pnpm --filter admin lint
+pnpm --filter admin exec tsc --noEmit
+pnpm --filter admin build
+pnpm --filter auth lint
+pnpm --filter auth exec tsc --noEmit
+pnpm --filter auth build
+pnpm --filter webv2 lint
+pnpm --filter webv2 exec tsc --noEmit
+pnpm --filter webv2 build
+pnpm build
+```
+
+Application and container-image workflow commands remain the final production compatibility proof. Any new form implementation continues to use React Hook Form and Paper form components.
+
+## Definition of done
+
+Tadoku Paper is complete when:
+
+- the approved visual grammar and brand assets are implemented only through semantic roles and documented exceptions;
+- `paper-ui` builds and is independently consumable by React without Next.js;
+- class recipes and React components are documented and tested as one styling contract;
+- every public component has a canonical searchable page, deterministic fixtures, lifecycle metadata, ownership, tests, and migration guidance;
+- foundations, components, product patterns, and experiments are visibly separate;
+- styleguide, admin, auth, and webv2 each use only Paper and have passed their deployment smoke gates;
+- the original audit, all visual studies, and the decision log remain available;
+- repository and CI configuration watches and validates `paper-ui`;
+- legacy `ui` has zero consumers and is removed;
+- issues #761–#763 meet their full accessibility, regression, and theme/preference acceptance criteria.
+
+## Audit traceability
+
+| Original recommendation | Delivery |
+| --- | --- |
+| P0.1 Semantic tokens | Phases 1 and 3 foundation work; token/package gates. |
+| P0.2 Visual grammar | Confirmed contract; Phases 1–3 implementation and documentation. |
+| P0.3 Complete docs shell | Phases 1–4. |
+| P0.4 Accessibility contract | Immediate semantic tests throughout; comprehensive completion in #761/Phase 9. |
+| P0.5 Typed Button/LinkButton | Hybrid class/component contract proven in Phase 2; router-neutral link recipes. |
+| P1.1 One route and search | Registry-driven docs in Phases 1, 3, and 4. |
+| P1.2 Full state matrix | Fixture schema and every component page, beginning in Phase 2. |
+| P1.3 Foundation pages | Phase 3. |
+| P1.4 Co-located examples/metadata/tests | Package architecture and Phases 1–3. |
+| P1.5 Automated quality gates | Fast tests and CI now; comprehensive visual/axe system in #762/Phase 9. |
+| P2.1 Components/patterns/experiments | Information architecture and Phases 3–4. |
+| P2.2 Lifecycle/governance | Registry schema, Stable gate, contribution and deprecation policy in Phases 1–4. |
+| P2.3 Themes/preferences | Light/dark tokens and preview now; full preference behavior in #763/Phase 9. |
+| P2.4 Package boundary | `paper-ui` architecture, boundary tests, app adapters, and migration gates. |
+
+The early quick wins—framed previews, constrained prose, refined violet, and explicit use/avoid guidance—are incorporated into the documentation shell and visual contract rather than scheduled as throwaway work.


### PR DESCRIPTION
## Summary

- add the comprehensive, phased Tadoku Paper implementation and migration plan
- document the React + Vite `paper-styleguide`, Base UI primitive strategy, button API, testing gates, and application-by-application cutovers
- preserve and index the complete design exploration, decision log, audit, and button API preview
- add an autonomous research phase to reduce the input required before implementation begins

## Why

This turns the design-system audit and planning discussions into a durable execution contract. It keeps the current audit and legacy styleguide available while defining how Paper is built at `paper.tadoku.app`, validated, migrated through admin/auth/webv2, and ultimately moved to `ui.tadoku.app`.

## Impact

Documentation only. No application, package, deployment, or runtime behavior changes.

## Validation

- rebased onto current `main`
- `git diff --check origin/main...HEAD`
- verified 10 executable phases, 10 phase/cutover gates, and 108 checklist items
- verified the published Presenter plan at https://presentr.lab/md/tadoku-paper-implementation-plan