### PR TITLE
Reject sensitive paths from the Paper SPA fallback

### DIFF
--- a/frontend/apps/paper-styleguide/nginx.conf
+++ b/frontend/apps/paper-styleguide/nginx.conf
@@ -15,6 +15,14 @@ server {
     return 200 'ok\n';
   }
 
+  location ~ (^|/)\. {
+    return 404;
+  }
+
+  location ~* \.(?:env|bak|config|ini|log|sql)$ {
+    return 404;
+  }
+
   location /assets/ {
     try_files $uri =404;
     add_header Cache-Control "public, max-age=31536000, immutable";

--- a/frontend/scripts/smoke-paper-image.sh
+++ b/frontend/scripts/smoke-paper-image.sh
@@ -41,4 +41,9 @@ grep -qi '^cache-control: public, max-age=31536000, immutable' "$headers_file"
 missing_status="$(curl --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${port}/assets/not-a-real-paper-asset.js")"
 test "$missing_status" = "404"
 
+for sensitive_path in '/.env' '/.git/config' '/api/.env' '/config.env'; do
+  sensitive_status="$(curl --silent --output /dev/null --write-out '%{http_code}' "http://127.0.0.1:${port}${sensitive_path}")"
+  test "$sensitive_status" = "404"
+done
+
 echo "Paper static image smoke passed on port ${port}."


### PR DESCRIPTION
## Summary

- return explicit `404` responses for dotfiles and common sensitive file extensions instead of serving the harmless SPA index fallback
- extend the exact production-image smoke with `/.env`, `/.git/config`, `/api/.env`, and `/config.env` regression checks

## Evidence

- the new smoke failed against the currently deployed image before the nginx change
- the rebuilt production image passes health, root/deep fallback, gzip/cache behavior, missing assets, and every new sensitive-path assertion

No secret or repository content was exposed; the old response was the same 521-byte public `index.html`. This change removes misleading scanner 200s and narrows the static-server contract.