### PR TITLE
feat: prove the Paper component vertical slice

### DIFF
--- a/frontend/apps/paper-styleguide/src/documentation/ComponentWorkbench.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/ComponentWorkbench.tsx
@@ -1,0 +1,119 @@
+import { useRef, useState, type KeyboardEvent } from 'react'
+import type { CatalogDocument, CatalogFixture } from 'paper-ui/catalog'
+import { ExampleCanvas } from './ExampleCanvas'
+
+const VIEWS = ['preview', 'code', 'api', 'accessibility'] as const
+type View = (typeof VIEWS)[number]
+
+function label(view: View): string {
+  if (view === 'api') return 'API / Props'
+  return `${view.charAt(0).toUpperCase()}${view.slice(1)}`
+}
+
+function ApiList({ title, items }: { title: string; items: readonly string[] }) {
+  return (
+    <section>
+      <h4>{title}</h4>
+      {items.length ? (
+        <ul>{items.map((item) => <li key={item}><code>{item}</code></li>)}</ul>
+      ) : (
+        <p>None.</p>
+      )}
+    </section>
+  )
+}
+
+export function ComponentWorkbench({
+  document,
+  fixtures,
+}: {
+  document: CatalogDocument
+  fixtures: readonly CatalogFixture[]
+}) {
+  const [view, setView] = useState<View>('preview')
+  const [fixtureId, setFixtureId] = useState(fixtures[0]?.id ?? '')
+  const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
+  const fixture = fixtures.find((candidate) => candidate.id === fixtureId) ?? fixtures[0]
+
+  function moveTab(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    const nextIndex = event.key === 'Home'
+      ? 0
+      : event.key === 'End'
+        ? VIEWS.length - 1
+        : (index + (event.key === 'ArrowRight' ? 1 : -1) + VIEWS.length) % VIEWS.length
+    const nextView = VIEWS[nextIndex]
+    setView(nextView)
+    tabRefs.current[nextIndex]?.focus()
+  }
+
+  return (
+    <section className="component-workbench" aria-label={`${document.name} examples`}>
+      <div className="component-workbench__toolbar">
+        <div className="component-workbench__tabs" role="tablist" aria-label="Example views">
+          {VIEWS.map((candidate, index) => (
+            <button
+              key={candidate}
+              ref={(node) => { tabRefs.current[index] = node }}
+              id={`workbench-tab-${candidate}`}
+              type="button"
+              role="tab"
+              aria-selected={view === candidate}
+              aria-controls={`workbench-panel-${candidate}`}
+              tabIndex={view === candidate ? 0 : -1}
+              onKeyDown={(event) => moveTab(event, index)}
+              onClick={() => setView(candidate)}
+            >
+              {label(candidate)}
+            </button>
+          ))}
+        </div>
+        {fixtures.length > 1 ? (
+          <label className="component-workbench__fixture-select">
+            <span>Fixture</span>
+            <select value={fixture?.id} onChange={(event) => setFixtureId(event.target.value)}>
+              {fixtures.map((candidate) => (
+                <option key={candidate.id} value={candidate.id}>{candidate.name}</option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+      </div>
+
+      <div
+        id={`workbench-panel-${view}`}
+        role="tabpanel"
+        aria-labelledby={`workbench-tab-${view}`}
+        className="component-workbench__panel"
+      >
+        {view === 'preview' ? <ExampleCanvas fixture={fixture} /> : null}
+        {view === 'code' ? (
+          <div className="code-view">
+            <div>
+              <h3>{fixture?.name ?? 'Example'}</h3>
+              <p>{fixture?.description}</p>
+            </div>
+            <pre tabIndex={0}><code>{fixture?.code ?? 'No copyable example is registered.'}</code></pre>
+          </div>
+        ) : null}
+        {view === 'api' ? (
+          <div className="workbench-reference-grid">
+            <ApiList title="React" items={document.api.react} />
+            <ApiList title="CSS and recipes" items={document.api.cssClasses} />
+            <ApiList title="Public types" items={document.api.publicTypes} />
+            <ApiList title="Defaults" items={document.api.defaults} />
+            <ApiList title="Invalid combinations" items={document.api.invalidCombinations} />
+          </div>
+        ) : null}
+        {view === 'accessibility' ? (
+          <div className="workbench-reference-grid">
+            <ApiList title="Requirements" items={document.accessibility.requirements} />
+            <ApiList title="Keyboard" items={document.accessibility.keyboard} />
+            <ApiList title="Known constraints" items={document.accessibility.knownConstraints} />
+          </div>
+        ) : null}
+      </div>
+    </section>
+  )
+}

--- a/frontend/apps/paper-styleguide/src/documentation/DocumentPage.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/DocumentPage.tsx
@@ -1,8 +1,15 @@
-import type { CatalogDocument } from 'paper-ui/catalog'
+import {
+  REQUIRED_COMPONENT_SECTION_KEYS,
+  catalogRegistry,
+  type CatalogDocument,
+  type CatalogDocumentationSection,
+} from 'paper-ui/catalog'
+import { Fragment } from 'react'
+import { ComponentWorkbench } from './ComponentWorkbench'
 import { ExampleCanvas } from './ExampleCanvas'
 import { type OutlineItem, TableOfContents } from './TableOfContents'
 
-const OUTLINE: readonly OutlineItem[] = [
+const FOUNDATION_OUTLINE: readonly OutlineItem[] = [
   { id: 'overview', label: 'Overview' },
   { id: 'guidance', label: 'Guidance' },
   { id: 'accessibility', label: 'Accessibility' },
@@ -25,92 +32,125 @@ function SectionCopy({ value, fallback }: { value: unknown; fallback: string }) 
   return <p>{copy || fallback}</p>
 }
 
-export function DocumentPage({ document }: { document: CatalogDocument }) {
+function Metadata({ document }: { document: CatalogDocument }) {
+  return (
+    <dl className="metadata-list">
+      <div>
+        <dt>Canonical route</dt>
+        <dd><code>{document.route}</code></dd>
+      </div>
+      <div>
+        <dt>Source</dt>
+        <dd><code>{document.sourcePath}</code></dd>
+      </div>
+      <div>
+        <dt>Dependencies</dt>
+        <dd>{[...document.dependencies.documents, ...document.dependencies.packages].join(', ') || 'None'}</dd>
+      </div>
+    </dl>
+  )
+}
+
+function Hero({ document }: { document: CatalogDocument }) {
+  return (
+    <header className="document-hero paper-accent-rail">
+      <p className="eyebrow">{document.kind} · {document.category}</p>
+      <h1 className="paper-type-page">{document.name}</h1>
+      <p className="document-summary">{document.summary}</p>
+      <dl className="metadata-strip">
+        <div><dt>Status</dt><dd>{document.lifecycle}</dd></div>
+        <div><dt>Owner</dt><dd>{document.owner}</dd></div>
+        <div><dt>Version</dt><dd>{document.packageVersion}</dd></div>
+        <div><dt>Reviewed</dt><dd>{document.reviewDate}</dd></div>
+      </dl>
+    </header>
+  )
+}
+
+function ComponentSection({
+  id,
+  section,
+}: {
+  id: string
+  section: CatalogDocumentationSection
+}) {
+  return (
+    <section id={id} className="document-section">
+      <h2 className="paper-type-section">{section.heading}</h2>
+      {section.content.map((paragraph) => <p key={paragraph}>{paragraph}</p>)}
+    </section>
+  )
+}
+
+function ComponentDocumentPage({ document }: { document: CatalogDocument }) {
+  const fixtures = catalogRegistry.fixtures.filter((fixture) =>
+    document.fixtureIds.includes(fixture.id),
+  )
+  const sections = document.sections?.required ?? {}
+  const outline: OutlineItem[] = REQUIRED_COMPONENT_SECTION_KEYS.flatMap((key) => {
+    const section = sections[key]
+    return section ? [{ id: key, label: section.heading }] : []
+  })
+  outline.push({ id: 'metadata', label: 'Metadata' })
+
   return (
     <div className="document-layout">
       <article className="document-page">
-        <header id="overview" className="document-hero paper-accent-rail">
-          <p className="eyebrow">
-            {document.kind} · {document.category}
-          </p>
-          <h1 className="paper-type-page">{document.name}</h1>
-          <p className="document-summary">{document.summary}</p>
-          <dl className="metadata-strip">
-            <div>
-              <dt>Status</dt>
-              <dd>{document.lifecycle}</dd>
-            </div>
-            <div>
-              <dt>Owner</dt>
-              <dd>{document.owner}</dd>
-            </div>
-            <div>
-              <dt>Version</dt>
-              <dd>{document.packageVersion}</dd>
-            </div>
-            <div>
-              <dt>Reviewed</dt>
-              <dd>{document.reviewDate}</dd>
-            </div>
-          </dl>
-        </header>
-
-        <section id="guidance" className="document-section">
-          <h2 className="paper-type-section">Guidance</h2>
-          <SectionCopy
-            value={document.guidance}
-            fallback="Detailed usage guidance will arrive with this catalogue slice."
-          />
-        </section>
-
-        <section id="accessibility" className="document-section">
-          <h2 className="paper-type-section">Accessibility</h2>
-          <SectionCopy
-            value={document.accessibility}
-            fallback="Accessibility requirements are tracked in the catalogue registry."
-          />
-        </section>
-
-        <div id="preview" className="document-section document-section--wide">
-          <ExampleCanvas />
-        </div>
-
-        <section id="contract" className="document-section">
-          <h2 className="paper-type-section">Public contract</h2>
-          <SectionCopy
-            value={document.api}
-            fallback="This foundation does not expose a component API."
-          />
-        </section>
-
+        <Hero document={document} />
+        {REQUIRED_COMPONENT_SECTION_KEYS.map((key) => {
+          const section = sections[key]
+          if (!section) return null
+          return (
+            <Fragment key={key}>
+              <ComponentSection id={key} section={section} />
+              {key === 'recommendedExample' ? (
+                <div className="document-section--wide">
+                  <ComponentWorkbench document={document} fixtures={fixtures} />
+                </div>
+              ) : null}
+            </Fragment>
+          )
+        })}
         <section id="metadata" className="document-section">
           <h2 className="paper-type-section">Metadata</h2>
-          <dl className="metadata-list">
-            <div>
-              <dt>Canonical route</dt>
-              <dd>
-                <code>{document.route}</code>
-              </dd>
-            </div>
-            <div>
-              <dt>Source</dt>
-              <dd>
-                <code>{document.sourcePath}</code>
-              </dd>
-            </div>
-            <div>
-              <dt>Dependencies</dt>
-              <dd>
-                {[
-                  ...document.dependencies.documents,
-                  ...document.dependencies.packages,
-                ].join(', ') || 'None'}
-              </dd>
-            </div>
-          </dl>
+          <Metadata document={document} />
         </section>
       </article>
-      <TableOfContents items={OUTLINE} />
+      <TableOfContents items={outline} />
     </div>
   )
+}
+
+function GeneralDocumentPage({ document }: { document: CatalogDocument }) {
+  return (
+    <div className="document-layout">
+      <article className="document-page">
+        <div id="overview"><Hero document={document} /></div>
+        <section id="guidance" className="document-section">
+          <h2 className="paper-type-section">Guidance</h2>
+          <SectionCopy value={document.guidance} fallback="Detailed usage guidance will arrive with this catalogue slice." />
+        </section>
+        <section id="accessibility" className="document-section">
+          <h2 className="paper-type-section">Accessibility</h2>
+          <SectionCopy value={document.accessibility} fallback="Accessibility requirements are tracked in the catalogue registry." />
+        </section>
+        <div id="preview" className="document-section document-section--wide"><ExampleCanvas /></div>
+        <section id="contract" className="document-section">
+          <h2 className="paper-type-section">Public contract</h2>
+          <SectionCopy value={document.api} fallback="This foundation does not expose a component API." />
+        </section>
+        <section id="metadata" className="document-section">
+          <h2 className="paper-type-section">Metadata</h2>
+          <Metadata document={document} />
+        </section>
+      </article>
+      <TableOfContents items={FOUNDATION_OUTLINE} />
+    </div>
+  )
+}
+
+export function DocumentPage({ document }: { document: CatalogDocument }) {
+  return document.kind === 'component'
+    ? <ComponentDocumentPage document={document} />
+    : <GeneralDocumentPage document={document} />
 }

--- a/frontend/apps/paper-styleguide/src/documentation/ExampleCanvas.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/ExampleCanvas.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { createPortal } from 'react-dom'
+import type { CatalogFixture } from 'paper-ui/catalog'
 import type { PaperDensity, PaperTheme } from '../app/displayPreferences'
 
 const VIEWPORTS = [
@@ -32,7 +33,7 @@ function copyPaperStyles(target: Document) {
   }
 }
 
-export function ExampleCanvas() {
+export function ExampleCanvas({ fixture }: { fixture?: CatalogFixture }) {
   const [theme, setTheme] = useState<PaperTheme>('light')
   const [density, setDensity] = useState<PaperDensity>('comfortable')
   const [viewportId, setViewportId] = useState<(typeof VIEWPORTS)[number]['id']>(
@@ -126,7 +127,16 @@ export function ExampleCanvas() {
           }}
         />
       </div>
-      {previewRoot ? createPortal(<PreviewSpecimen />, previewRoot) : null}
+      {previewRoot
+        ? createPortal(
+            fixture ? (
+              <div className="paper-fixture-stage">{fixture.render()}</div>
+            ) : (
+              <PreviewSpecimen />
+            ),
+            previewRoot,
+          )
+        : null}
     </section>
   )
 }

--- a/frontend/apps/paper-styleguide/src/styles/shell.css
+++ b/frontend/apps/paper-styleguide/src/styles/shell.css
@@ -358,6 +358,120 @@
     background: var(--paper-color-surface-raised);
   }
 
+  .component-workbench {
+    border: 1px solid var(--paper-color-rule-default);
+    background: var(--paper-color-surface-paper);
+  }
+
+  .component-workbench__toolbar {
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 0.75rem;
+    border-block-end: 1px solid var(--paper-color-rule-subtle);
+  }
+
+  .component-workbench__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+  }
+
+  .component-workbench__tabs button {
+    min-block-size: var(--paper-control-height);
+    padding-inline: var(--paper-field-padding-inline);
+    border: 1px solid transparent;
+    border-block-end: 2px solid transparent;
+    color: var(--paper-color-text-muted);
+    background: transparent;
+  }
+
+  .component-workbench__tabs button:hover {
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-raised);
+  }
+
+  .component-workbench__tabs button[aria-selected='true'] {
+    color: var(--paper-color-text-ink);
+    border-block-end-color: var(--paper-color-action-default);
+    font-weight: var(--paper-type-label-weight);
+  }
+
+  .component-workbench__fixture-select {
+    display: grid;
+    gap: 0.2rem;
+    min-inline-size: 12rem;
+    color: var(--paper-color-text-muted);
+    font-size: var(--paper-type-metadata-size);
+  }
+
+  .component-workbench__fixture-select select {
+    padding-inline: var(--paper-field-padding-inline);
+    border: 1px solid var(--paper-color-rule-field-edge);
+    border-block-end: 2px solid var(--paper-color-rule-action-edge);
+    background: var(--paper-color-surface-paper);
+  }
+
+  .component-workbench__panel {
+    min-block-size: 28rem;
+  }
+
+  .code-view,
+  .workbench-reference-grid {
+    padding: 1.25rem;
+  }
+
+  .code-view h3,
+  .workbench-reference-grid h4 {
+    margin-block-start: 0;
+  }
+
+  .code-view pre {
+    max-block-size: 32rem;
+    overflow: auto;
+    margin-block-end: 0;
+    padding: 1rem;
+    border-inline-start: 3px solid var(--paper-color-action-default);
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-canvas);
+    font-family: var(--paper-font-monospace);
+    font-size: 0.875rem;
+    line-height: 1.6;
+    white-space: pre;
+  }
+
+  .workbench-reference-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr));
+    gap: 1.5rem;
+  }
+
+  .workbench-reference-grid section {
+    padding-inline-start: 1rem;
+    border-inline-start: 3px solid var(--paper-color-rule-default);
+  }
+
+  .paper-fixture-stage {
+    min-block-size: 100%;
+    padding: 2rem;
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-canvas);
+  }
+
+  .paper-fixture-row {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: var(--paper-inline-gap);
+  }
+
+  .paper-fixture-stack,
+  .paper-fixture-stage form {
+    display: grid;
+    gap: 1rem;
+  }
+
   .example-canvas__heading {
     display: flex;
     justify-content: space-between;
@@ -610,6 +724,15 @@
     .canvas-controls fieldset,
     .canvas-viewport-button {
       flex: 1;
+    }
+
+    .component-workbench__toolbar {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .component-workbench__fixture-select {
+      inline-size: 100%;
     }
   }
 

--- a/frontend/apps/paper-styleguide/tests/component-page.test.tsx
+++ b/frontend/apps/paper-styleguide/tests/component-page.test.tsx
@@ -1,0 +1,41 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { catalogRegistry, REQUIRED_COMPONENT_SECTION_KEYS } from 'paper-ui/catalog'
+import { describe, expect, it } from 'vitest'
+import { DocumentPage } from '../src/documentation/DocumentPage'
+
+const buttonDocument = catalogRegistry.documents.find(
+  (document) => document.id === 'component.button',
+)!
+
+describe('Stable component documentation', () => {
+  it('renders the complete instructional sequence from registry metadata', () => {
+    render(<DocumentPage document={buttonDocument} />)
+
+    for (const key of REQUIRED_COMPONENT_SECTION_KEYS) {
+      const section = buttonDocument.sections?.required[key]
+      expect(section).toBeDefined()
+      expect(screen.getByRole('heading', { name: section!.heading })).toBeInTheDocument()
+    }
+  })
+
+  it('switches Preview, Code, API, and Accessibility with arrow keys', async () => {
+    const user = userEvent.setup()
+    render(<DocumentPage document={buttonDocument} />)
+
+    const tabs = screen.getByRole('tablist', { name: 'Example views' })
+    const preview = within(tabs).getByRole('tab', { name: 'Preview' })
+    preview.focus()
+    await user.keyboard('{ArrowRight}')
+    expect(within(tabs).getByRole('tab', { name: 'Code' })).toHaveFocus()
+    expect(screen.getByText(/import \{ Button/u)).toBeInTheDocument()
+
+    await user.keyboard('{ArrowRight}')
+    expect(within(tabs).getByRole('tab', { name: 'API / Props' })).toHaveFocus()
+    expect(screen.getByRole('heading', { name: 'Public types' })).toBeInTheDocument()
+
+    await user.keyboard('{ArrowRight}')
+    expect(within(tabs).getByRole('tab', { name: 'Accessibility' })).toHaveFocus()
+    expect(screen.getByRole('heading', { name: 'Keyboard' })).toBeInTheDocument()
+  })
+})

--- a/frontend/packages/paper-ui/src/catalog/phase-two.tsx
+++ b/frontend/packages/paper-ui/src/catalog/phase-two.tsx
@@ -1,0 +1,570 @@
+import { useEffect } from "react";
+import { FormProvider, useForm } from "react-hook-form";
+import { ActionMenu } from "../components/overlays/ActionMenu";
+import { Button, buttonClassName } from "../components/actions/Button";
+import { Input } from "../components/forms/Input";
+import { Modal } from "../components/overlays/Modal";
+import {
+  defineCatalogDocument,
+  defineCatalogFixture,
+  type CatalogDocument,
+  type ComponentCategory,
+  type ComponentDocumentationSections,
+  type RequiredComponentSectionKey,
+} from "./schema";
+
+const REVIEW_DATE = "2026-08-08";
+const PACKAGE_VERSION = "0.1.0";
+const OWNER = "Tadoku design systems";
+const VIEWPORTS = [
+  { id: "phone", label: "Phone", width: 360, height: 720 },
+  { id: "tablet", label: "Tablet", width: 768, height: 800 },
+  { id: "desktop", label: "Desktop", width: 1280, height: 800 },
+] as const;
+
+function section(
+  heading: string,
+  ...content: readonly string[]
+): { readonly heading: string; readonly content: readonly string[] } {
+  return { heading, content };
+}
+
+function componentSections(
+  name: string,
+  details: Readonly<
+    Record<
+      RequiredComponentSectionKey,
+      { readonly heading: string; readonly content: readonly string[] }
+    >
+  >,
+): ComponentDocumentationSections {
+  void name;
+  return { required: details };
+}
+
+interface ComponentDocumentOptions {
+  readonly id: string;
+  readonly route: string;
+  readonly name: string;
+  readonly category: ComponentCategory;
+  readonly summary: string;
+  readonly keywords: readonly string[];
+  readonly sourcePath: string;
+  readonly fixtureIds: readonly string[];
+  readonly behaviorTestIds: readonly string[];
+  readonly guidance: CatalogDocument["guidance"];
+  readonly accessibility: CatalogDocument["accessibility"];
+  readonly api: CatalogDocument["api"];
+  readonly migration: CatalogDocument["migration"];
+  readonly sections: ComponentDocumentationSections;
+}
+
+function componentDocument(options: ComponentDocumentOptions): CatalogDocument {
+  return defineCatalogDocument({
+    ...options,
+    kind: "component",
+    aliases: [],
+    lifecycle: "Stable",
+    owner: OWNER,
+    reviewDate: REVIEW_DATE,
+    packageVersion: PACKAGE_VERSION,
+    dependencies: { documents: [], packages: ["paper-ui"] },
+    changelog: [
+      { date: REVIEW_DATE, note: "Published the Stable Phase 2 contract." },
+    ],
+  });
+}
+
+function InputRecommendedFixture() {
+  const methods = useForm<{ title: string }>({
+    defaultValues: { title: "August reading log" },
+  });
+  return (
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={methods.handleSubmit(() => undefined)}>
+        <Input
+          name="title"
+          label="Log title"
+          hint="Give this reading session a short, recognizable name."
+          rules={{ required: "Enter a log title." }}
+          required
+        />
+        <Button type="submit">Save log</Button>
+      </form>
+    </FormProvider>
+  );
+}
+
+function InputStatesFixture() {
+  const methods = useForm({
+    defaultValues: { readonly: "Japanese", disabled: "Archived" },
+  });
+  return (
+    <FormProvider {...methods}>
+      <div className="paper-fixture-stack">
+        <Input name="readonly" label="Language" readOnly />
+        <Input name="disabled" label="Status" disabled />
+      </div>
+    </FormProvider>
+  );
+}
+
+function InputErrorFixture() {
+  const methods = useForm<{ pages: string }>({ defaultValues: { pages: "" } });
+  useEffect(() => {
+    methods.setError("pages", { message: "Enter the number of pages read." });
+  }, [methods]);
+  return (
+    <FormProvider {...methods}>
+      <Input
+        name="pages"
+        label="Pages read"
+        hint="Use whole pages."
+        inputMode="numeric"
+        required
+      />
+    </FormProvider>
+  );
+}
+
+export const phaseTwoFixtures = [
+  defineCatalogFixture({
+    id: "button.variants",
+    name: "Button variants",
+    description: "The complete action hierarchy beside a semantic anchor.",
+    tags: ["button", "variants", "anchor"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Button, buttonClassName } from "paper-ui";
+
+<Button>Save log</Button>
+<Button variant="outline">Cancel</Button>
+<Button variant="ghost">More options</Button>
+<Button variant="link">Clear filters</Button>
+<Button variant="destructive">Delete log</Button>
+<a className={buttonClassName({ variant: "outline" })} href="/logs">
+  View logs
+</a>`,
+    render: () => (
+      <div className="paper-fixture-row">
+        <Button>Save log</Button>
+        <Button variant="outline">Cancel</Button>
+        <Button variant="ghost">More options</Button>
+        <Button variant="link">Clear filters</Button>
+        <Button variant="destructive">Delete log</Button>
+        <a className={buttonClassName({ variant: "outline" })} href="#logs">
+          View logs
+        </a>
+      </div>
+    ),
+  }),
+  defineCatalogFixture({
+    id: "button.loading",
+    name: "Loading action",
+    description: "A busy action keeps its visible and accessible name stable.",
+    tags: ["button", "loading", "disabled"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Button } from "paper-ui";
+
+<Button loading loadingLabel="Saving reading log">
+  Save log
+</Button>`,
+    render: () => (
+      <Button loading loadingLabel="Saving reading log">
+        Save log
+      </Button>
+    ),
+  }),
+  defineCatalogFixture({
+    id: "button.narrow",
+    name: "Long, full-width action",
+    description: "Long localized content at a narrow viewport.",
+    tags: ["button", "full width", "long content", "narrow"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Button } from "paper-ui";
+
+<Button fullWidth>Add this finished book to the August reading log</Button>`,
+    render: () => (
+      <Button fullWidth>Add this finished book to the August reading log</Button>
+    ),
+  }),
+  defineCatalogFixture({
+    id: "input.recommended",
+    name: "Reading-log title",
+    description: "Label, hint, required rule, value, and submission in one field.",
+    tags: ["input", "form", "required", "hint"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Button, Input } from "paper-ui";
+import { FormProvider, useForm } from "react-hook-form";
+
+const methods = useForm({ defaultValues: { title: "August reading log" } });
+<FormProvider {...methods}>
+  <form onSubmit={methods.handleSubmit(saveLog)}>
+    <Input
+      name="title"
+      label="Log title"
+      hint="Give this reading session a short, recognizable name."
+      rules={{ required: "Enter a log title." }}
+      required
+    />
+    <Button type="submit">Save log</Button>
+  </form>
+</FormProvider>`,
+    render: () => <InputRecommendedFixture />,
+  }),
+  defineCatalogFixture({
+    id: "input.states",
+    name: "Read-only and disabled",
+    description: "Two non-editable states with distinct native semantics.",
+    tags: ["input", "readonly", "disabled"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Input } from "paper-ui";
+
+<Input name="language" label="Language" readOnly />
+<Input name="status" label="Status" disabled />`,
+    render: () => <InputStatesFixture />,
+  }),
+  defineCatalogFixture({
+    id: "input.error",
+    name: "Validation error",
+    description: "Hint and error remain associated with the invalid input.",
+    tags: ["input", "error", "accessibility"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Input } from "paper-ui";
+
+<Input
+  name="pages"
+  label="Pages read"
+  hint="Use whole pages."
+  inputMode="numeric"
+  required
+/>`,
+    render: () => <InputErrorFixture />,
+  }),
+  defineCatalogFixture({
+    id: "modal.recommended",
+    name: "Confirm log deletion",
+    description: "A focused modal with explanatory copy and two close paths.",
+    tags: ["modal", "focus", "destructive"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Modal } from "paper-ui";
+
+<Modal
+  triggerLabel="Review deletion"
+  triggerVariant="destructive"
+  title="Delete this reading log?"
+  description="This removes the log from your history."
+  closeLabel="Keep log"
+  action={{ label: "Delete log", variant: "destructive", onAction: deleteLog }}
+>
+  <p>August Japanese reading · 1,240 pages</p>
+</Modal>`,
+    render: () => (
+      <Modal
+        triggerLabel="Review deletion"
+        triggerVariant="destructive"
+        title="Delete this reading log?"
+        description="This removes the log from your history."
+        closeLabel="Keep log"
+        action={{
+          label: "Delete log",
+          variant: "destructive",
+          onAction: () => undefined,
+        }}
+      >
+        <p>August Japanese reading · 1,240 pages</p>
+      </Modal>
+    ),
+  }),
+  defineCatalogFixture({
+    id: "modal.long-content",
+    name: "Long modal content",
+    description: "Overflow remains inside a viewport-bounded dialog.",
+    tags: ["modal", "overflow", "long content"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { Modal } from "paper-ui";
+
+<Modal triggerLabel="Review rules" title="August challenge rules">
+  <p>Read the complete challenge rules before joining.</p>
+</Modal>`,
+    render: () => (
+      <Modal triggerLabel="Review rules" title="August challenge rules">
+        <p>
+          Log pages or minutes only after reading. Choose the language you read,
+          keep notes concise, and correct accidental duplicates before the contest
+          closes. Moderators may review unusual entries to keep the challenge fair.
+        </p>
+      </Modal>
+    ),
+  }),
+  defineCatalogFixture({
+    id: "action-menu.recommended",
+    name: "Reading-log actions",
+    description: "Common, unavailable, and destructive actions in one menu.",
+    tags: ["action menu", "keyboard", "disabled", "destructive"],
+    themes: ["light", "dark"],
+    densities: ["comfortable", "compact"],
+    viewports: VIEWPORTS,
+    deterministic: true,
+    code: `import { ActionMenu } from "paper-ui";
+
+<ActionMenu
+  label="Log actions"
+  items={[
+    { id: "edit", label: "Edit log", onSelect: editLog },
+    { id: "duplicate", label: "Duplicate log", disabled: true, onSelect: duplicateLog },
+    { id: "delete", label: "Delete log", destructive: true, onSelect: deleteLog },
+  ]}
+/>`,
+    render: () => (
+      <ActionMenu
+        label="Log actions"
+        items={[
+          { id: "edit", label: "Edit log", onSelect: () => undefined },
+          {
+            id: "duplicate",
+            label: "Duplicate log",
+            disabled: true,
+            onSelect: () => undefined,
+          },
+          {
+            id: "delete",
+            label: "Delete log",
+            destructive: true,
+            onSelect: () => undefined,
+          },
+        ]}
+      />
+    ),
+  }),
+] as const;
+
+export const phaseTwoDocuments = [
+  componentDocument({
+    id: "component.button",
+    route: "/components/actions/button",
+    name: "Button",
+    category: "actions",
+    summary: "Triggers an immediate action with explicit hierarchy and safe defaults.",
+    keywords: ["button", "action", "loading", "anchor", "submit"],
+    sourcePath: "src/components/actions/Button/Button.tsx",
+    fixtureIds: ["button.variants", "button.loading", "button.narrow"],
+    behaviorTestIds: ["button.semantics", "button.recipe-parity", "button.loading"],
+    guidance: {
+      whenToUse: ["Trigger an immediate operation such as saving or deleting."],
+      whenNotToUse: ["Use an anchor for navigation to another resource."],
+      content: ["Start with a specific verb and keep labels stable while loading."],
+      commonMistakes: ["Do not use the link variant to turn navigation into a button."],
+    },
+    accessibility: {
+      requirements: ["Provide a stable accessible name and visible focus."],
+      keyboard: ["Enter and Space activate a button; anchors retain native Enter behavior."],
+      knownConstraints: ["Icon-only actions need an explicit aria-label."],
+    },
+    api: {
+      react: ["Button"],
+      cssClasses: ["paper-button", "buttonClassName()"],
+      publicTypes: ["ButtonProps", "ButtonVariant", "ButtonRecipeOptions"],
+      defaults: ["variant=default", "type=button", "loading=false"],
+      invalidCombinations: ["Do not put href on Button; style a real anchor with buttonClassName()."],
+    },
+    migration: {
+      legacy: ["ui Button", "btn primary", "btn secondary", "btn danger"],
+      notes: ["Map intent: primary to default, secondary to outline, danger to destructive."],
+    },
+    sections: componentSections("Button", {
+      overview: section("Overview", "Button expresses action hierarchy without changing native semantics."),
+      whenToUse: section("When to use", "Use it for immediate user-initiated operations."),
+      whenNotToUse: section("When not to use", "Use an anchor when activation navigates to a URL."),
+      choosingBetween: section("Choose between", "Default is the page's emphasized action; outline is neutral; ghost is low emphasis; link is an inline action; destructive is irreversible intent."),
+      anatomy: section("Anatomy", "A control contains an optional icon, a stable text label, and a lower interactive edge."),
+      recommendedExample: section("Recommended example", "Save log is specific, short, and defaults to type=button."),
+      variants: section("Variants", "Default, outline, ghost, link, and destructive form one vocabulary across React and raw classes."),
+      statesAndAdaptation: section("States and adaptation", "Loading disables activation, retains the label, exposes aria-busy, and respects both densities."),
+      behavior: section("Behavior", "Buttons activate on Enter or Space. Explicitly opt into type=submit inside a React Hook Form and use methods.reset() for reset workflows."),
+      contentGuidance: section("Content guidance", "Use a verb phrase such as Save log; avoid vague labels such as OK."),
+      accessibility: section("Accessibility", "Keep an accessible name, do not convey danger through color alone, and preserve native anchor roles for navigation."),
+      implementation: section("Implementation", "Button and buttonClassName() call the same recipe; load paper-ui/styles.css once at the application root."),
+      apiReference: section("API reference", "ButtonProps adds variant, loading, loadingLabel, icons, and fullWidth to native button attributes."),
+      relatedPatterns: section("Related patterns", "Use Modal for focused confirmation and ActionMenu when several contextual actions compete."),
+      migration: section("Migration", "Review old primary, secondary, and danger classes by semantic job instead of renaming mechanically."),
+      lifecycle: section("Lifecycle", "Stable in Paper 0.1.0; behavior and variant vocabulary are migration-ready."),
+    }),
+  }),
+  componentDocument({
+    id: "component.input",
+    route: "/components/forms/input",
+    name: "Input",
+    category: "forms",
+    summary: "Collects one line of text with complete field anatomy and form state.",
+    keywords: ["input", "field", "form", "error", "hint"],
+    sourcePath: "src/components/forms/Input/Input.tsx",
+    fixtureIds: ["input.recommended", "input.states", "input.error"],
+    behaviorTestIds: ["input.associations", "input.validation", "input.native-states"],
+    guidance: {
+      whenToUse: ["Collect a short, free-form value in a React Hook Form."],
+      whenNotToUse: ["Use a choice control when the set of valid values is known."],
+      content: ["Use a visible noun label and a hint only when it adds constraints or context."],
+      commonMistakes: ["Do not use placeholder text as the only label."],
+    },
+    accessibility: {
+      requirements: ["Associate label, hint, and error IDs with the native input."],
+      keyboard: ["The native input follows platform text-editing behavior."],
+      knownConstraints: ["Input requires a react-hook-form FormProvider."],
+    },
+    api: {
+      react: ["Input"],
+      cssClasses: ["paper-field", "paper-input"],
+      publicTypes: ["InputProps"],
+      defaults: ["Native text input behavior", "Errors come from react-hook-form state"],
+      invalidCombinations: ["Do not render Input outside FormProvider."],
+    },
+    migration: {
+      legacy: ["ui/components/Form Input"],
+      notes: ["Keep names and validation rules in react-hook-form; replace implicit global field styling."],
+    },
+    sections: componentSections("Input", {
+      overview: section("Overview", "Input owns the complete visible and semantic field relationship."),
+      whenToUse: section("When to use", "Use it for one-line values such as a reading-log title."),
+      whenNotToUse: section("When not to use", "Use TextArea for prose and Select or radio controls for constrained choices."),
+      choosingBetween: section("Choose between", "Read-only values remain focusable and selectable; disabled values are unavailable and omitted from submission."),
+      anatomy: section("Anatomy", "The field contains a persistent label, optional hint, native input, and validation message."),
+      recommendedExample: section("Recommended example", "Log title demonstrates a useful label, constraint hint, required rule, and explicit submit action."),
+      variants: section("Variants", "Text, email, password, numeric-input-mode, and other native types share the field anatomy."),
+      statesAndAdaptation: section("States and adaptation", "Required, invalid, read-only, and disabled states work in light/dark and comfortable/compact contexts."),
+      behavior: section("Behavior", "Registration, value, blur, and validation state come from the nearest FormProvider."),
+      contentGuidance: section("Content guidance", "Labels name the value; hints explain format or consequence; errors tell the reader how to recover."),
+      accessibility: section("Accessibility", "htmlFor, aria-describedby, aria-invalid, and role=alert connect the field anatomy without relying on color."),
+      implementation: section("Implementation", "Create methods with useForm(), wrap fields in FormProvider, and submit through methods.handleSubmit()."),
+      apiReference: section("API reference", "InputProps requires name and label, accepts hint and register rules, and otherwise follows native input attributes."),
+      relatedPatterns: section("Related patterns", "Button submits the surrounding form; future choice controls reuse the same field anatomy."),
+      migration: section("Migration", "Move validation into register rules and remove application-owned label/error selectors."),
+      lifecycle: section("Lifecycle", "Stable in Paper 0.1.0 with deterministic associations and React Hook Form ownership."),
+    }),
+  }),
+  componentDocument({
+    id: "component.modal",
+    route: "/components/overlays/modal",
+    name: "Modal",
+    category: "overlays",
+    summary: "Temporarily focuses attention while managing focus, dismissal, and return.",
+    keywords: ["modal", "dialog", "overlay", "focus", "confirmation"],
+    sourcePath: "src/components/overlays/Modal/Modal.tsx",
+    fixtureIds: ["modal.recommended", "modal.long-content"],
+    behaviorTestIds: ["modal.keyboard", "modal.focus-containment", "modal.focus-return"],
+    guidance: {
+      whenToUse: ["Require a focused decision or a short task without losing page context."],
+      whenNotToUse: ["Use a page when the task is long, linkable, or needs deep navigation."],
+      content: ["Name the decision in the title and make the consequence concrete."],
+      commonMistakes: ["Do not nest modals or hide the only escape action."],
+    },
+    accessibility: {
+      requirements: ["Expose a labelled dialog, trap focus while open, and return focus on close."],
+      keyboard: ["Escape closes; Tab remains within the dialog."],
+      knownConstraints: ["Long workflows should move to a dedicated page."],
+    },
+    api: {
+      react: ["Modal"],
+      cssClasses: [],
+      publicTypes: ["ModalProps"],
+      defaults: ["modal=true", "triggerVariant=default", "closeLabel=Close"],
+      invalidCombinations: ["Do not nest Modal instances."],
+    },
+    migration: {
+      legacy: ["ui Modal", "Headless UI Dialog"],
+      notes: ["Paper owns the Base UI wrapper; applications do not import Base UI directly."],
+    },
+    sections: componentSections("Modal", {
+      overview: section("Overview", "Modal creates a focused layer above the current task and restores context after dismissal."),
+      whenToUse: section("When to use", "Use it for concise confirmations and bounded editing tasks."),
+      whenNotToUse: section("When not to use", "Avoid it for passive notices, multi-step flows, or content that deserves a URL."),
+      choosingBetween: section("Choose between", "Use Flash for non-blocking feedback, ActionMenu for contextual choices, and a page for sustained work."),
+      anatomy: section("Anatomy", "Backdrop, viewport, titled popup, optional description, content, close affordance, and footer."),
+      recommendedExample: section("Recommended example", "Deletion review states what will be removed before the user commits elsewhere."),
+      variants: section("Variants", "Trigger hierarchy can vary; the modal surface and focus behavior stay consistent."),
+      statesAndAdaptation: section("States and adaptation", "The viewport scrolls long content and remains bounded at phone, tablet, and desktop widths."),
+      behavior: section("Behavior", "Base UI manages opening, focus containment, Escape/outside dismissal, and focus return."),
+      contentGuidance: section("Content guidance", "Use a question for confirmation titles and put consequences in the description."),
+      accessibility: section("Accessibility", "Title and description label the dialog; two close paths ensure touch-screen-reader escape."),
+      implementation: section("Implementation", "Import Modal from paper-ui; Base UI remains a private interaction dependency."),
+      apiReference: section("API reference", "ModalProps supports controlled or uncontrolled open state, title, description, content, trigger, close, and optional primary action contracts."),
+      relatedPatterns: section("Related patterns", "Pair with destructive Button intent only when the action is genuinely destructive."),
+      migration: section("Migration", "Replace legacy Dialog imports with Modal and remove application-owned portal/focus logic."),
+      lifecycle: section("Lifecycle", "Stable in Paper 0.1.0 after keyboard, containment, dismissal, and return tests."),
+    }),
+  }),
+  componentDocument({
+    id: "component.action-menu",
+    route: "/components/overlays/action-menu",
+    name: "ActionMenu",
+    category: "overlays",
+    summary: "Presents a compact keyboard-operable set of contextual actions.",
+    keywords: ["menu", "actions", "keyboard", "disabled", "destructive"],
+    sourcePath: "src/components/overlays/ActionMenu/ActionMenu.tsx",
+    fixtureIds: ["action-menu.recommended"],
+    behaviorTestIds: ["action-menu.keyboard", "action-menu.disabled", "action-menu.selection"],
+    guidance: {
+      whenToUse: ["Group three or more contextual actions for one object."],
+      whenNotToUse: ["Keep a single important action visible as Button."],
+      content: ["Use parallel verb phrases ordered by frequency, with destructive actions last."],
+      commonMistakes: ["Do not use a menu to hide primary page navigation."],
+    },
+    accessibility: {
+      requirements: ["Expose a named trigger, menu semantics, roving focus, and disabled state."],
+      keyboard: ["Enter, Space, or ArrowDown opens; arrows move; Escape closes and returns focus."],
+      knownConstraints: ["Menu items are actions; router-neutral link integration is a separate contract."],
+    },
+    api: {
+      react: ["ActionMenu"],
+      cssClasses: [],
+      publicTypes: ["ActionMenuProps", "ActionMenuItem"],
+      defaults: ["triggerVariant=outline", "loopFocus=true"],
+      invalidCombinations: ["Do not treat disabled items as explanatory text."],
+    },
+    migration: {
+      legacy: ["ui ActionMenu", "Headless UI Menu"],
+      notes: ["Map each item to a stable id and explicit selection callback."],
+    },
+    sections: componentSections("ActionMenu", {
+      overview: section("Overview", "ActionMenu keeps secondary contextual operations available without crowding the page."),
+      whenToUse: section("When to use", "Use it for several actions that operate on the same reading log or table row."),
+      whenNotToUse: section("When not to use", "Do not hide the main task or global navigation in a contextual action menu."),
+      choosingBetween: section("Choose between", "Use Button for one visible action, Modal for a focused decision, and ActionMenu for a compact action set."),
+      anatomy: section("Anatomy", "A named trigger anchors a floating menu containing text-labelled action items."),
+      recommendedExample: section("Recommended example", "Reading-log actions place common editing first, unavailable duplication in place, and deletion last."),
+      variants: section("Variants", "The trigger may use an appropriate Button variant; destructive styling belongs to the item, not the whole menu."),
+      statesAndAdaptation: section("States and adaptation", "Highlighted, disabled, destructive, open, and closed states retain non-color cues and density sizing."),
+      behavior: section("Behavior", "Base UI owns trigger activation, placement, roving focus, typeahead, dismissal, selection, and focus return."),
+      contentGuidance: section("Content guidance", "Use short parallel verb phrases, order by likely use, and place destructive actions last."),
+      accessibility: section("Accessibility", "The trigger names the action set; disabled items remain identifiable but cannot be selected."),
+      implementation: section("Implementation", "Pass immutable item metadata and callbacks to ActionMenu; do not expose Base UI primitives to applications."),
+      apiReference: section("API reference", "ActionMenuItem requires id, label, and onSelect; icon, disabled, and destructive are optional."),
+      relatedPatterns: section("Related patterns", "Use Modal after selection only when the chosen action needs focused confirmation."),
+      migration: section("Migration", "Replace legacy render-prop menus and implicit class ordering with explicit item intent."),
+      lifecycle: section("Lifecycle", "Stable in Paper 0.1.0 with keyboard, disabled-item, selection, and real-browser pointer evidence."),
+    }),
+  }),
+] as const;

--- a/frontend/packages/paper-ui/src/catalog/phase-two.tsx
+++ b/frontend/packages/paper-ui/src/catalog/phase-two.tsx
@@ -518,9 +518,9 @@ export const phaseTwoDocuments = [
   }),
   componentDocument({
     id: "component.action-menu",
-    route: "/components/overlays/action-menu",
+    route: "/components/actions/action-menu",
     name: "ActionMenu",
-    category: "overlays",
+    category: "actions",
     summary: "Presents a compact keyboard-operable set of contextual actions.",
     keywords: ["menu", "actions", "keyboard", "disabled", "destructive"],
     sourcePath: "src/components/overlays/ActionMenu/ActionMenu.tsx",

--- a/frontend/packages/paper-ui/src/catalog/registry.ts
+++ b/frontend/packages/paper-ui/src/catalog/registry.ts
@@ -6,6 +6,7 @@ import {
   type CatalogRegistryInput,
 } from "./schema";
 import { validateCatalogRegistry } from "./validation";
+import { phaseTwoDocuments, phaseTwoFixtures } from "./phase-two";
 
 const REVIEW_DATE = "2026-08-08";
 const PACKAGE_VERSION = "0.1.0";
@@ -185,8 +186,12 @@ export function createCatalogRegistry(input: CatalogRegistryInput): CatalogRegis
 }
 
 export const catalogRegistry = createCatalogRegistry({
-  documents: [...foundationDocuments, ...governanceDocuments],
-  fixtures: [],
+  documents: [
+    ...foundationDocuments,
+    ...phaseTwoDocuments,
+    ...governanceDocuments,
+  ],
+  fixtures: phaseTwoFixtures,
   redirects: [
     { from: "/color", to: "/foundations/color" },
     { from: "/typography", to: "/foundations/typography" },

--- a/frontend/packages/paper-ui/src/catalog/schema.ts
+++ b/frontend/packages/paper-ui/src/catalog/schema.ts
@@ -180,6 +180,8 @@ export interface CatalogFixture {
    * function for known time, randomness, network, and router dependencies.
    */
   readonly deterministic: true;
+  /** Complete copyable consumer example for the catalogue Code view. */
+  readonly code?: string;
   readonly render: () => ReactNode;
 }
 

--- a/frontend/packages/paper-ui/src/components/actions/Button/Button.tsx
+++ b/frontend/packages/paper-ui/src/components/actions/Button/Button.tsx
@@ -1,0 +1,107 @@
+import {
+  forwardRef,
+  useId,
+  type ButtonHTMLAttributes,
+  type ReactNode,
+} from "react";
+
+export const BUTTON_VARIANTS = [
+  "default",
+  "outline",
+  "ghost",
+  "link",
+  "destructive",
+] as const;
+
+export type ButtonVariant = (typeof BUTTON_VARIANTS)[number];
+
+export interface ButtonRecipeOptions {
+  readonly variant?: ButtonVariant;
+  readonly fullWidth?: boolean;
+  readonly loading?: boolean;
+  readonly className?: string;
+}
+
+export function buttonClassName({
+  variant = "default",
+  fullWidth = false,
+  loading = false,
+  className,
+}: ButtonRecipeOptions = {}): string {
+  return [
+    "paper-button",
+    `paper-button--${variant}`,
+    fullWidth ? "paper-button--full-width" : "",
+    loading ? "paper-button--loading" : "",
+    className ?? "",
+  ]
+    .filter(Boolean)
+    .join(" ");
+}
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  readonly variant?: ButtonVariant;
+  readonly fullWidth?: boolean;
+  readonly loading?: boolean;
+  /** Visually hidden status announced without replacing the accessible name. */
+  readonly loadingLabel?: string;
+  readonly leadingIcon?: ReactNode;
+  readonly trailingIcon?: ReactNode;
+}
+
+export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button(
+  {
+    variant = "default",
+    fullWidth = false,
+    loading = false,
+    loadingLabel = "Working",
+    leadingIcon,
+    trailingIcon,
+    className,
+    children,
+    disabled,
+    type = "button",
+    "aria-describedby": describedBy,
+    "aria-label": ariaLabel,
+    ...props
+  },
+  ref,
+) {
+  const generatedId = useId();
+  const loadingStatusId = `paper-button-status-${generatedId.replace(/:/gu, "")}`;
+  return (
+    <button
+      {...props}
+      ref={ref}
+      type={type}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
+      aria-label={
+        ariaLabel ?? (loading && typeof children === "string" ? children : undefined)
+      }
+      aria-describedby={
+        [describedBy, loading ? loadingStatusId : undefined].filter(Boolean).join(" ") ||
+        undefined
+      }
+      className={buttonClassName({ variant, fullWidth, loading, className })}
+    >
+      {loading ? <span className="paper-button__spinner" aria-hidden="true" /> : null}
+      {!loading && leadingIcon ? (
+        <span className="paper-button__icon" aria-hidden="true">
+          {leadingIcon}
+        </span>
+      ) : null}
+      <span className="paper-button__label">{children}</span>
+      {!loading && trailingIcon ? (
+        <span className="paper-button__icon" aria-hidden="true">
+          {trailingIcon}
+        </span>
+      ) : null}
+      {loading ? (
+        <span className="paper-visually-hidden" id={loadingStatusId} role="status">
+          {loadingLabel}
+        </span>
+      ) : null}
+    </button>
+  );
+});

--- a/frontend/packages/paper-ui/src/components/actions/Button/button.css
+++ b/frontend/packages/paper-ui/src/components/actions/Button/button.css
@@ -1,0 +1,133 @@
+@layer paper-recipes {
+  .paper-button {
+    display: inline-flex;
+    position: relative;
+    align-items: center;
+    justify-content: center;
+    min-block-size: var(--paper-control-height);
+    gap: var(--paper-inline-gap);
+    padding: var(--paper-field-padding-block) var(--paper-field-padding-inline);
+    border: var(--paper-border-static-width) solid transparent;
+    border-block-end-width: var(--paper-border-action-edge-width);
+    border-radius: 0;
+    color: var(--paper-color-action-text);
+    background: var(--paper-color-action-default);
+    font-weight: var(--paper-type-label-weight);
+    line-height: 1;
+    text-align: center;
+    text-decoration: none;
+    cursor: pointer;
+    user-select: none;
+  }
+
+  .paper-button:hover:not(:disabled) {
+    background: var(--paper-color-action-hover);
+  }
+
+  .paper-button:active:not(:disabled) {
+    background: var(--paper-color-action-active);
+    transform: translateY(1px);
+  }
+
+  .paper-button:disabled,
+  .paper-button[aria-disabled="true"] {
+    cursor: not-allowed;
+    opacity: 0.56;
+  }
+
+  .paper-button--outline {
+    border-color: var(--paper-color-rule-strong);
+    border-block-end-color: var(--paper-color-rule-action-edge);
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-paper);
+  }
+
+  .paper-button--outline:hover:not(:disabled) {
+    background: var(--paper-color-surface-raised);
+  }
+
+  .paper-button--ghost,
+  .paper-button--link {
+    color: var(--paper-color-text-link);
+    background: transparent;
+  }
+
+  .paper-button--ghost:hover:not(:disabled),
+  .paper-button--link:hover:not(:disabled) {
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-action-soft);
+  }
+
+  .paper-button--link {
+    min-block-size: auto;
+    padding: 0;
+    border: 0;
+    text-decoration: underline;
+    text-underline-offset: 0.2em;
+  }
+
+  .paper-button--link:hover:not(:disabled) {
+    background: transparent;
+  }
+
+  .paper-button--destructive {
+    background: var(--paper-color-action-destructive);
+    border-block-end-color: color-mix(
+      in srgb,
+      var(--paper-color-action-destructive) 72%,
+      black
+    );
+  }
+
+  .paper-button--destructive:hover:not(:disabled) {
+    background: var(--paper-color-action-destructive-hover);
+  }
+
+  .paper-button--full-width {
+    inline-size: 100%;
+  }
+
+  .paper-button__icon,
+  .paper-button__spinner {
+    display: inline-grid;
+    flex: none;
+    place-items: center;
+    inline-size: var(--paper-icon-size-default);
+    block-size: var(--paper-icon-size-default);
+  }
+
+  .paper-button__icon > svg {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+
+  .paper-button__spinner {
+    border: 2px solid currentColor;
+    border-inline-end-color: transparent;
+    border-radius: 50%;
+    animation: paper-button-spin 700ms linear infinite;
+  }
+
+  .paper-visually-hidden {
+    position: absolute;
+    inline-size: 1px;
+    block-size: 1px;
+    overflow: hidden;
+    clip-path: inset(50%);
+    white-space: nowrap;
+  }
+
+  @keyframes paper-button-spin {
+    to {
+      transform: rotate(1turn);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .paper-button,
+    .paper-button__spinner {
+      animation: none;
+      transition: none;
+    }
+  }
+}

--- a/frontend/packages/paper-ui/src/components/actions/Button/index.ts
+++ b/frontend/packages/paper-ui/src/components/actions/Button/index.ts
@@ -1,0 +1,8 @@
+export {
+  BUTTON_VARIANTS,
+  Button,
+  buttonClassName,
+  type ButtonProps,
+  type ButtonRecipeOptions,
+  type ButtonVariant,
+} from "./Button";

--- a/frontend/packages/paper-ui/src/components/forms/Input/Input.tsx
+++ b/frontend/packages/paper-ui/src/components/forms/Input/Input.tsx
@@ -1,0 +1,113 @@
+import {
+  forwardRef,
+  useId,
+  type ForwardedRef,
+  type InputHTMLAttributes,
+  type MutableRefObject,
+} from "react";
+import {
+  useFormContext,
+  useFormState,
+  type FieldValues,
+  type RegisterOptions,
+} from "react-hook-form";
+
+export interface InputProps
+  extends Omit<
+    InputHTMLAttributes<HTMLInputElement>,
+    "name" | "onBlur" | "onChange"
+  > {
+  readonly name: string;
+  readonly label: string;
+  readonly hint?: string;
+  readonly rules?: RegisterOptions<FieldValues, string>;
+}
+
+function assignRef(
+  ref: ForwardedRef<HTMLInputElement>,
+  node: HTMLInputElement | null,
+): void {
+  if (typeof ref === "function") ref(node);
+  else if (ref) (ref as MutableRefObject<HTMLInputElement | null>).current = node;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
+  {
+    name,
+    label,
+    hint,
+    rules,
+    id: providedId,
+    required,
+    readOnly,
+    disabled,
+    className,
+    ...props
+  },
+  forwardedRef,
+) {
+  const form = useFormContext();
+  const generatedId = useId();
+  const id = providedId ?? `paper-input-${generatedId.replace(/:/gu, "")}`;
+
+  if (!form) {
+    throw new Error("Paper Input must be rendered inside react-hook-form FormProvider");
+  }
+
+  const registration = form.register(name, {
+    ...rules,
+    required: rules?.required ?? (required ? "This field is required." : undefined),
+  });
+  const subscribedFormState = useFormState({ control: form.control, name });
+  const error = form.getFieldState(name, subscribedFormState).error;
+  const hintId = hint ? `${id}-hint` : undefined;
+  const errorId = error ? `${id}-error` : undefined;
+  const describedBy = [hintId, errorId].filter(Boolean).join(" ") || undefined;
+
+  return (
+    <div
+      className={[
+        "paper-field",
+        error ? "paper-field--invalid" : "",
+        disabled ? "paper-field--disabled" : "",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <label className="paper-field__label" htmlFor={id}>
+        {label}
+        {required ? (
+          <span className="paper-field__required" aria-hidden="true">
+            *
+          </span>
+        ) : null}
+      </label>
+      {hint ? (
+        <p className="paper-field__hint" id={hintId}>
+          {hint}
+        </p>
+      ) : null}
+      <input
+        {...props}
+        {...registration}
+        id={id}
+        required={required}
+        readOnly={readOnly}
+        disabled={disabled}
+        aria-invalid={error ? true : undefined}
+        aria-describedby={describedBy}
+        className="paper-input"
+        ref={(node) => {
+          registration.ref(node);
+          assignRef(forwardedRef, node);
+        }}
+      />
+      {error ? (
+        <p className="paper-field__error" id={errorId} role="alert">
+          {error.message?.toString() || "Check this field."}
+        </p>
+      ) : null}
+    </div>
+  );
+});

--- a/frontend/packages/paper-ui/src/components/forms/Input/index.ts
+++ b/frontend/packages/paper-ui/src/components/forms/Input/index.ts
@@ -1,0 +1,1 @@
+export { Input, type InputProps } from "./Input";

--- a/frontend/packages/paper-ui/src/components/forms/Input/input.css
+++ b/frontend/packages/paper-ui/src/components/forms/Input/input.css
@@ -1,0 +1,71 @@
+@layer paper-recipes {
+  .paper-field {
+    display: grid;
+    gap: 0.35rem;
+    inline-size: 100%;
+    max-inline-size: 32rem;
+  }
+
+  .paper-field__label {
+    color: var(--paper-color-text-ink);
+    font-size: var(--paper-type-label-size);
+    font-weight: var(--paper-type-label-weight);
+    line-height: var(--paper-type-label-line-height);
+  }
+
+  .paper-field__required {
+    margin-inline-start: 0.25rem;
+    color: var(--paper-color-status-danger);
+  }
+
+  .paper-field__hint,
+  .paper-field__error {
+    margin: 0;
+    font-size: var(--paper-type-metadata-size);
+    line-height: var(--paper-type-metadata-line-height);
+  }
+
+  .paper-field__hint {
+    color: var(--paper-color-text-muted);
+  }
+
+  .paper-field__error {
+    color: var(--paper-color-status-danger);
+    font-weight: var(--paper-type-label-weight);
+  }
+
+  .paper-input {
+    inline-size: 100%;
+    min-block-size: var(--paper-control-height);
+    padding: var(--paper-field-padding-block) var(--paper-field-padding-inline);
+    border: var(--paper-border-static-width) solid var(--paper-color-rule-field-edge);
+    border-block-end: var(--paper-border-field-edge-width) solid
+      var(--paper-color-rule-action-edge);
+    border-radius: 0;
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-paper);
+  }
+
+  .paper-input::placeholder {
+    color: var(--paper-color-text-muted);
+    opacity: 0.78;
+  }
+
+  .paper-input:read-only {
+    border-block-end-color: var(--paper-color-rule-default);
+    background: var(--paper-color-surface-raised);
+  }
+
+  .paper-field--invalid .paper-input {
+    border-color: var(--paper-color-status-danger);
+    border-block-end-color: var(--paper-color-status-danger);
+  }
+
+  .paper-field--disabled {
+    opacity: 0.56;
+  }
+
+  .paper-input:disabled {
+    cursor: not-allowed;
+  }
+}

--- a/frontend/packages/paper-ui/src/components/overlays/ActionMenu/ActionMenu.tsx
+++ b/frontend/packages/paper-ui/src/components/overlays/ActionMenu/ActionMenu.tsx
@@ -1,0 +1,68 @@
+import { Menu } from "@base-ui/react/menu";
+import { useState, type ReactNode } from "react";
+import { buttonClassName, type ButtonVariant } from "../../actions/Button";
+
+export interface ActionMenuItem {
+  readonly id: string;
+  readonly label: string;
+  readonly icon?: ReactNode;
+  readonly disabled?: boolean;
+  readonly destructive?: boolean;
+  readonly onSelect: () => void;
+}
+
+export interface ActionMenuProps {
+  readonly label: string;
+  readonly items: readonly ActionMenuItem[];
+  readonly triggerVariant?: ButtonVariant;
+  readonly defaultOpen?: boolean;
+}
+
+export function ActionMenu({
+  label,
+  items,
+  triggerVariant = "outline",
+  defaultOpen,
+}: ActionMenuProps) {
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
+
+  return (
+    <Menu.Root defaultOpen={defaultOpen}>
+      <Menu.Trigger
+        ref={(node: HTMLElement | null) => {
+          if (node && node.ownerDocument.body !== portalContainer) {
+            setPortalContainer(node.ownerDocument.body);
+          }
+        }}
+        className={buttonClassName({ variant: triggerVariant })}
+      >
+        <span>{label}</span>
+        <span aria-hidden="true">▾</span>
+      </Menu.Trigger>
+      <Menu.Portal container={portalContainer}>
+        <Menu.Positioner className="paper-action-menu__positioner" sideOffset={6}>
+          <Menu.Popup className="paper-action-menu paper-elevation-floating">
+            {items.map((item) => (
+              <Menu.Item
+                key={item.id}
+                className={`paper-action-menu__item${
+                  item.destructive ? " paper-action-menu__item--destructive" : ""
+                }`}
+                disabled={item.disabled}
+                label={item.label}
+                onClick={item.onSelect}
+              >
+                {item.icon ? (
+                  <span className="paper-action-menu__icon" aria-hidden="true">
+                    {item.icon}
+                  </span>
+                ) : null}
+                <span>{item.label}</span>
+              </Menu.Item>
+            ))}
+          </Menu.Popup>
+        </Menu.Positioner>
+      </Menu.Portal>
+    </Menu.Root>
+  );
+}

--- a/frontend/packages/paper-ui/src/components/overlays/ActionMenu/action-menu.css
+++ b/frontend/packages/paper-ui/src/components/overlays/ActionMenu/action-menu.css
@@ -1,0 +1,71 @@
+@layer paper-recipes {
+  .paper-action-menu__positioner {
+    z-index: 90;
+    outline: 0;
+  }
+
+  .paper-action-menu {
+    min-inline-size: 13rem;
+    padding-block: 0.35rem;
+    border: var(--paper-border-static-width) solid var(--paper-color-rule-strong);
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-overlay);
+    transform-origin: var(--transform-origin);
+    transition:
+      opacity var(--paper-motion-quick),
+      transform var(--paper-motion-quick);
+  }
+
+  .paper-action-menu[data-starting-style],
+  .paper-action-menu[data-ending-style] {
+    opacity: 0;
+    transform: scale(0.98);
+  }
+
+  .paper-action-menu__item {
+    display: flex;
+    align-items: center;
+    min-block-size: var(--paper-control-height);
+    gap: var(--paper-inline-gap);
+    padding: var(--paper-field-padding-block) var(--paper-field-padding-inline);
+    outline: 0;
+    cursor: default;
+    user-select: none;
+  }
+
+  .paper-action-menu__item[data-highlighted] {
+    color: var(--paper-color-action-text);
+    background: var(--paper-color-action-default);
+  }
+
+  .paper-action-menu__item[data-disabled] {
+    opacity: 0.5;
+  }
+
+  .paper-action-menu__item--destructive {
+    color: var(--paper-color-status-danger);
+  }
+
+  .paper-action-menu__item--destructive[data-highlighted] {
+    color: var(--paper-color-text-inverse);
+    background: var(--paper-color-action-destructive);
+  }
+
+  .paper-action-menu__icon {
+    display: grid;
+    place-items: center;
+    inline-size: var(--paper-icon-size-default);
+    block-size: var(--paper-icon-size-default);
+  }
+
+  .paper-action-menu__icon > svg {
+    inline-size: 100%;
+    block-size: 100%;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .paper-action-menu {
+      transition: none;
+    }
+  }
+}

--- a/frontend/packages/paper-ui/src/components/overlays/ActionMenu/index.ts
+++ b/frontend/packages/paper-ui/src/components/overlays/ActionMenu/index.ts
@@ -1,0 +1,5 @@
+export {
+  ActionMenu,
+  type ActionMenuItem,
+  type ActionMenuProps,
+} from "./ActionMenu";

--- a/frontend/packages/paper-ui/src/components/overlays/Modal/Modal.tsx
+++ b/frontend/packages/paper-ui/src/components/overlays/Modal/Modal.tsx
@@ -1,0 +1,93 @@
+import { Dialog } from "@base-ui/react/dialog";
+import { useState, type ReactNode } from "react";
+import { buttonClassName, type ButtonVariant } from "../../actions/Button";
+
+export interface ModalProps {
+  readonly triggerLabel: string;
+  readonly triggerVariant?: ButtonVariant;
+  readonly title: string;
+  readonly description?: string;
+  readonly children: ReactNode;
+  readonly closeLabel?: string;
+  readonly action?: {
+    readonly label: string;
+    readonly variant?: ButtonVariant;
+    readonly disabled?: boolean;
+    readonly onAction: () => void;
+  };
+  readonly defaultOpen?: boolean;
+  readonly open?: boolean;
+  readonly onOpenChange?: (open: boolean) => void;
+}
+
+export function Modal({
+  triggerLabel,
+  triggerVariant = "default",
+  title,
+  description,
+  children,
+  closeLabel = "Close",
+  action,
+  defaultOpen,
+  open,
+  onOpenChange,
+}: ModalProps) {
+  const [portalContainer, setPortalContainer] = useState<HTMLElement | null>(null);
+
+  return (
+    <Dialog.Root
+      defaultOpen={defaultOpen}
+      open={open}
+      onOpenChange={(nextOpen) => onOpenChange?.(nextOpen)}
+    >
+      <Dialog.Trigger
+        ref={(node: HTMLElement | null) => {
+          if (node && node.ownerDocument.body !== portalContainer) {
+            setPortalContainer(node.ownerDocument.body);
+          }
+        }}
+        className={buttonClassName({ variant: triggerVariant })}
+      >
+        {triggerLabel}
+      </Dialog.Trigger>
+      <Dialog.Portal container={portalContainer}>
+        <Dialog.Backdrop className="paper-modal__backdrop" />
+        <Dialog.Viewport className="paper-modal__viewport">
+          <Dialog.Popup className="paper-modal paper-surface-raised paper-elevation-showcase">
+            <header className="paper-modal__header">
+              <div>
+                <Dialog.Title className="paper-modal__title">{title}</Dialog.Title>
+                {description ? (
+                  <Dialog.Description className="paper-modal__description">
+                    {description}
+                  </Dialog.Description>
+                ) : null}
+              </div>
+              <Dialog.Close
+                className="paper-modal__icon-close"
+                aria-label={closeLabel}
+              >
+                <span aria-hidden="true">×</span>
+              </Dialog.Close>
+            </header>
+            <div className="paper-modal__content">{children}</div>
+            <footer className="paper-modal__footer">
+              {action ? (
+                <Dialog.Close
+                  className={buttonClassName({ variant: action.variant })}
+                  disabled={action.disabled}
+                  onClick={action.onAction}
+                >
+                  {action.label}
+                </Dialog.Close>
+              ) : null}
+              <Dialog.Close className={buttonClassName({ variant: "outline" })}>
+                {closeLabel}
+              </Dialog.Close>
+            </footer>
+          </Dialog.Popup>
+        </Dialog.Viewport>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/frontend/packages/paper-ui/src/components/overlays/Modal/index.ts
+++ b/frontend/packages/paper-ui/src/components/overlays/Modal/index.ts
@@ -1,0 +1,1 @@
+export { Modal, type ModalProps } from "./Modal";

--- a/frontend/packages/paper-ui/src/components/overlays/Modal/modal.css
+++ b/frontend/packages/paper-ui/src/components/overlays/Modal/modal.css
@@ -1,0 +1,103 @@
+@layer paper-recipes {
+  .paper-modal__backdrop {
+    position: fixed;
+    z-index: 80;
+    inset: 0;
+    background: rgb(20 16 18 / 58%);
+    opacity: 1;
+    transition: opacity var(--paper-motion-standard);
+  }
+
+  .paper-modal__viewport {
+    position: fixed;
+    z-index: 81;
+    inset: 0;
+    display: grid;
+    place-items: center;
+    overflow-y: auto;
+    padding: 1rem;
+  }
+
+  .paper-modal {
+    inline-size: min(36rem, 100%);
+    max-block-size: min(42rem, calc(100vh - 2rem));
+    overflow-y: auto;
+    border: var(--paper-border-static-width) solid var(--paper-color-rule-strong);
+    background: var(--paper-color-surface-overlay);
+    transform: translateY(0);
+    transition:
+      opacity var(--paper-motion-standard),
+      transform var(--paper-motion-standard);
+  }
+
+  .paper-modal[data-starting-style],
+  .paper-modal[data-ending-style] {
+    opacity: 0;
+    transform: translateY(0.5rem);
+  }
+
+  .paper-modal__backdrop[data-starting-style],
+  .paper-modal__backdrop[data-ending-style] {
+    opacity: 0;
+  }
+
+  .paper-modal__header {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+    padding: 1.25rem;
+    border-block-end: 1px solid var(--paper-color-rule-subtle);
+  }
+
+  .paper-modal__title {
+    margin: 0;
+    font-family: var(--paper-font-display);
+    font-size: var(--paper-type-section-size);
+    line-height: var(--paper-type-section-line-height);
+  }
+
+  .paper-modal__description {
+    margin: 0.4rem 0 0;
+    color: var(--paper-color-text-muted);
+  }
+
+  .paper-modal__icon-close {
+    display: grid;
+    flex: none;
+    place-items: center;
+    inline-size: var(--paper-control-height);
+    block-size: var(--paper-control-height);
+    padding: 0;
+    border: 1px solid transparent;
+    color: var(--paper-color-text-muted);
+    background: transparent;
+    font-size: 1.5rem;
+    cursor: pointer;
+  }
+
+  .paper-modal__icon-close:hover {
+    color: var(--paper-color-text-ink);
+    border-color: var(--paper-color-rule-default);
+    background: var(--paper-color-surface-raised);
+  }
+
+  .paper-modal__content {
+    padding: 1.25rem;
+  }
+
+  .paper-modal__footer {
+    display: flex;
+    justify-content: end;
+    gap: var(--paper-inline-gap);
+    padding: 1rem 1.25rem;
+    border-block-start: 1px solid var(--paper-color-rule-subtle);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .paper-modal,
+    .paper-modal__backdrop {
+      transition: none;
+    }
+  }
+}

--- a/frontend/packages/paper-ui/src/foundations/tokens.css
+++ b/frontend/packages/paper-ui/src/foundations/tokens.css
@@ -46,6 +46,7 @@
   --paper-color-action-default: var(--paper-private-action-default);
   --paper-color-action-hover: var(--paper-private-action-hover);
   --paper-color-action-active: var(--paper-private-action-active);
+  --paper-color-action-soft: var(--paper-private-accent-soft);
   --paper-color-action-text: var(--paper-private-inverse);
   --paper-color-action-destructive: var(--paper-private-danger);
   --paper-color-action-destructive-hover: var(--paper-private-danger-hover);
@@ -125,6 +126,7 @@
   --paper-color-action-default: var(--paper-private-action-default);
   --paper-color-action-hover: var(--paper-private-action-hover);
   --paper-color-action-active: var(--paper-private-action-active);
+  --paper-color-action-soft: var(--paper-private-accent-soft);
   --paper-color-action-text: var(--paper-private-inverse);
 
   --paper-color-chart-1: #9a8bea;

--- a/frontend/packages/paper-ui/src/index.ts
+++ b/frontend/packages/paper-ui/src/index.ts
@@ -1,2 +1,17 @@
 export { chartPalette, chartSeries } from './foundations/chart-palette'
 export type { ChartSeries } from './foundations/chart-palette'
+export {
+  BUTTON_VARIANTS,
+  Button,
+  buttonClassName,
+  type ButtonProps,
+  type ButtonRecipeOptions,
+  type ButtonVariant,
+} from './components/actions/Button'
+export { Input, type InputProps } from './components/forms/Input'
+export { Modal, type ModalProps } from './components/overlays/Modal'
+export {
+  ActionMenu,
+  type ActionMenuItem,
+  type ActionMenuProps,
+} from './components/overlays/ActionMenu'

--- a/frontend/packages/paper-ui/tests/consumer-4.9/index.tsx
+++ b/frontend/packages/paper-ui/tests/consumer-4.9/index.tsx
@@ -1,6 +1,13 @@
 import { createElement } from "react";
 import { renderToString } from "react-dom/server";
-import { chartPalette, chartSeries, type ChartSeries } from "paper-ui";
+import {
+  Button,
+  buttonClassName,
+  chartPalette,
+  chartSeries,
+  type ButtonProps,
+  type ChartSeries,
+} from "paper-ui";
 import {
   CATALOG_LIFECYCLES,
   catalogRegistry,
@@ -28,6 +35,9 @@ const fixture: CatalogFixture = defineCatalogFixture({
 
 void CATALOG_LIFECYCLES;
 void chartPalette;
+const buttonProps: ButtonProps = { variant: "outline", children: "Review log" };
+void buttonClassName({ variant: "outline" });
+void renderToString(createElement(Button, buttonProps));
 void document;
 void series;
 void validateCatalogRegistry(registry);

--- a/frontend/packages/paper-ui/tests/phase-two-components.test.tsx
+++ b/frontend/packages/paper-ui/tests/phase-two-components.test.tsx
@@ -1,0 +1,226 @@
+import { render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FormProvider, useForm } from "react-hook-form";
+import { describe, expect, it, vi } from "vitest";
+import {
+  ActionMenu,
+  Button,
+  Input,
+  Modal,
+  buttonClassName,
+} from "../src";
+
+function InputForm({ onSubmit = vi.fn() }: { onSubmit?: (value: unknown) => void }) {
+  const methods = useForm<{ title: string }>({ defaultValues: { title: "" } });
+  return (
+    <FormProvider {...methods}>
+      <form noValidate onSubmit={methods.handleSubmit(onSubmit)}>
+        <Input
+          name="title"
+          label="Log title"
+          hint="Use a recognizable name."
+          rules={{ required: "Enter a log title." }}
+          required
+        />
+        <Button type="submit">Save log</Button>
+      </form>
+    </FormProvider>
+  );
+}
+
+describe("Button", () => {
+  it("defaults to a non-submitting native button and shares its recipe", async () => {
+    const user = userEvent.setup();
+    const submit = vi.fn((event: React.FormEvent) => event.preventDefault());
+    render(
+      <form onSubmit={submit}>
+        <Button variant="outline">Review log</Button>
+        <a className={buttonClassName({ variant: "outline" })} href="#logs">
+          View logs
+        </a>
+      </form>,
+    );
+
+    const button = screen.getByRole("button", { name: "Review log" });
+    expect(button).toHaveAttribute("type", "button");
+    expect(button.className).toBe(buttonClassName({ variant: "outline" }));
+    expect(screen.getByRole("link", { name: "View logs" })).not.toHaveAttribute(
+      "role",
+      "button",
+    );
+    await user.click(button);
+    expect(submit).not.toHaveBeenCalled();
+  });
+
+  it("keeps its name, reports busy, and blocks repeat activation while loading", async () => {
+    const user = userEvent.setup();
+    const activate = vi.fn();
+    render(
+      <Button loading loadingLabel="Saving reading log" onClick={activate}>
+        Save log
+      </Button>,
+    );
+
+    const button = screen.getByRole("button", { name: /Save log/u });
+    expect(button).toHaveAccessibleName("Save log");
+    expect(button).toHaveAccessibleDescription("Saving reading log");
+    expect(button).toHaveAttribute("aria-busy", "true");
+    expect(button).toBeDisabled();
+    await user.click(button);
+    expect(activate).not.toHaveBeenCalled();
+  });
+});
+
+describe("Input", () => {
+  it("associates label and hint, then submits through React Hook Form", async () => {
+    const user = userEvent.setup();
+    const submit = vi.fn();
+    render(<InputForm onSubmit={submit} />);
+
+    const input = screen.getByRole("textbox", { name: "Log title" });
+    expect(input).toHaveAccessibleDescription("Use a recognizable name.");
+    await user.type(input, "August reading");
+    await user.click(screen.getByRole("button", { name: "Save log" }));
+    expect(submit).toHaveBeenCalledWith(
+      { title: "August reading" },
+      expect.anything(),
+    );
+  });
+
+  it("associates a recoverable validation error", async () => {
+    const user = userEvent.setup();
+    render(<InputForm />);
+    await user.click(screen.getByRole("button", { name: "Save log" }));
+
+    await screen.findByRole("alert");
+    const input = screen.getByRole("textbox", { name: "Log title" });
+    expect(input).toHaveAttribute("aria-invalid", "true");
+    expect(input).toHaveAccessibleDescription(
+      "Use a recognizable name. Enter a log title.",
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent("Enter a log title.");
+  });
+});
+
+describe("Modal", () => {
+  it("opens with dialog semantics, closes with Escape, and returns focus", async () => {
+    const user = userEvent.setup();
+    render(
+      <Modal
+        triggerLabel="Review deletion"
+        title="Delete this log?"
+        description="This cannot be undone."
+      >
+        <p>August reading log</p>
+      </Modal>,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Review deletion" });
+    await user.click(trigger);
+    expect(screen.getByRole("dialog", { name: "Delete this log?" })).toHaveAccessibleDescription(
+      "This cannot be undone.",
+    );
+    await user.keyboard("{Escape}");
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("runs an explicit primary action and closes", async () => {
+    const user = userEvent.setup();
+    const remove = vi.fn();
+    render(
+      <Modal
+        triggerLabel="Review deletion"
+        title="Delete this log?"
+        closeLabel="Keep log"
+        action={{ label: "Delete log", variant: "destructive", onAction: remove }}
+      >
+        <p>August reading log</p>
+      </Modal>,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Review deletion" }));
+    await user.click(screen.getByRole("button", { name: "Delete log" }));
+    expect(remove).toHaveBeenCalledOnce();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+  });
+
+  it("keeps its portal in the trigger owner document", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    const frameDocument = frame.contentDocument!;
+    const container = frameDocument.createElement("div");
+    frameDocument.body.append(container);
+    const user = userEvent.setup({ document: frameDocument });
+    const { unmount } = render(
+      <Modal triggerLabel="Open details" title="Log details">
+        <p>Japanese · 120 pages</p>
+      </Modal>,
+      { container, baseElement: frameDocument.body },
+    );
+
+    await user.click(within(frameDocument.body).getByRole("button", { name: "Open details" }));
+    expect(within(frameDocument.body).getByRole("dialog", { name: "Log details" })).toBeInTheDocument();
+    expect(document.body.querySelector('[role="dialog"]')).toBeNull();
+    unmount();
+    frame.remove();
+  });
+});
+
+describe("ActionMenu", () => {
+  it("supports keyboard selection and skips disabled items", async () => {
+    const user = userEvent.setup();
+    const edit = vi.fn();
+    const duplicate = vi.fn();
+    render(
+      <ActionMenu
+        label="Log actions"
+        items={[
+          { id: "edit", label: "Edit log", onSelect: edit },
+          {
+            id: "duplicate",
+            label: "Duplicate log",
+            disabled: true,
+            onSelect: duplicate,
+          },
+        ]}
+      />,
+    );
+
+    const trigger = screen.getByRole("button", { name: "Log actions" });
+    trigger.focus();
+    await user.keyboard("{Enter}");
+    const editItem = await screen.findByRole("menuitem", { name: "Edit log" });
+    expect(screen.getByRole("menuitem", { name: "Duplicate log" })).toHaveAttribute(
+      "aria-disabled",
+      "true",
+    );
+    expect(editItem).toHaveFocus();
+    await user.keyboard("{Enter}");
+    expect(edit).toHaveBeenCalledOnce();
+    expect(duplicate).not.toHaveBeenCalled();
+    expect(trigger).toHaveFocus();
+  });
+
+  it("keeps its floating menu in the trigger owner document", async () => {
+    const frame = document.createElement("iframe");
+    document.body.append(frame);
+    const frameDocument = frame.contentDocument!;
+    const container = frameDocument.createElement("div");
+    frameDocument.body.append(container);
+    const user = userEvent.setup({ document: frameDocument });
+    const { unmount } = render(
+      <ActionMenu
+        label="Entry actions"
+        items={[{ id: "edit", label: "Edit entry", onSelect: vi.fn() }]}
+      />,
+      { container, baseElement: frameDocument.body },
+    );
+
+    await user.click(within(frameDocument.body).getByRole("button", { name: "Entry actions" }));
+    expect(await within(frameDocument.body).findByRole("menu")).toBeInTheDocument();
+    expect(document.body.querySelector('[role="menu"]')).toBeNull();
+    unmount();
+    frame.remove();
+  });
+});

--- a/frontend/packages/paper-ui/tests/public-exports.test.tsx
+++ b/frontend/packages/paper-ui/tests/public-exports.test.tsx
@@ -2,7 +2,7 @@ import { createElement } from "react";
 import { renderToString } from "react-dom/server";
 import { describe, expect, it } from "vitest";
 
-import { chartPalette, chartSeries } from "../src";
+import { Button, buttonClassName, chartPalette, chartSeries } from "../src";
 import {
   catalogRegistry,
   defineCatalogFixture,
@@ -31,6 +31,15 @@ describe("public source entries", () => {
 
     expect(renderToString(createElement("div", null, fixture.render()))).toContain(
       "Paper consumer",
+    );
+  });
+
+  it("server-renders the public component entry without browser globals", () => {
+    expect(renderToString(createElement(Button, null, "Save log"))).toContain(
+      "Save log",
+    );
+    expect(buttonClassName({ variant: "destructive" })).toContain(
+      "paper-button--destructive",
     );
   });
 });


### PR DESCRIPTION
## Summary
- add Stable Button, Input, Modal, and ActionMenu APIs with shared CSS recipes and semantic tokens
- add deterministic fixtures and complete 16-section catalogue pages with Preview, Code, API, and Accessibility views
- keep Base UI private while proving keyboard, focus, pointer, form, iframe portal, and raw-class/component parity

## Verification
- `pnpm --filter paper-ui lint`
- `pnpm --filter paper-ui typecheck`
- `pnpm --filter paper-ui test` (37)
- `pnpm --filter paper-ui build`
- `pnpm --filter paper-ui consumer:ts49`
- `pnpm --filter paper-ui pack:check`
- `pnpm --filter paper-styleguide lint`
- `pnpm --filter paper-styleguide typecheck`
- `pnpm --filter paper-styleguide test` (11)
- `pnpm --filter paper-styleguide build`
- `pnpm check:paper-boundaries`
- full `pnpm build`
- exact Docker build and `smoke-paper-image.sh`
- temporary mobile/desktop browser review with real pointer and keyboard interactions