### PR TITLE
fix(paper): correct visual QA regressions

### DIFF
--- a/frontend/apps/paper-styleguide/src/app/CatalogueSearch.tsx
+++ b/frontend/apps/paper-styleguide/src/app/CatalogueSearch.tsx
@@ -1,4 +1,9 @@
 import type { CatalogDocument } from 'paper-ui/catalog'
+import {
+  MagnifyingGlassIcon,
+  XMarkIcon,
+  iconClassName,
+} from 'paper-ui/icons'
 import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
 import { searchCatalog } from './catalogue'
@@ -56,11 +61,16 @@ export function CatalogueSearch({ documents }: CatalogueSearchProps) {
         ref={triggerRef}
         className="shell-search-trigger paper-focus-ring"
         type="button"
+        aria-label="Search Paper"
         aria-haspopup="dialog"
         aria-expanded={open}
         onClick={() => setOpen(true)}
       >
-        <span>Search Paper</span>
+        <MagnifyingGlassIcon
+          aria-hidden="true"
+          className={iconClassName('default')}
+        />
+        <span className="shell-search-trigger__label">Search Paper</span>
         <kbd aria-label="Command or Control K">⌘/Ctrl K</kbd>
       </button>
 
@@ -88,7 +98,10 @@ export function CatalogueSearch({ documents }: CatalogueSearchProps) {
                 aria-label="Close search"
                 onClick={() => closeSearch(true)}
               >
-                ×
+                <XMarkIcon
+                  aria-hidden="true"
+                  className={iconClassName('default')}
+                />
               </button>
             </div>
             <label className="search-field">

--- a/frontend/apps/paper-styleguide/src/app/DocsShell.tsx
+++ b/frontend/apps/paper-styleguide/src/app/DocsShell.tsx
@@ -1,5 +1,7 @@
 import type { CatalogDocument } from 'paper-ui/catalog'
-import cutMeterUrl from 'paper-ui/assets/brand/cut-meter.svg'
+import cutMeterUrl from 'paper-ui/assets/brand/cut-meter.svg?no-inline'
+import cutMeterReversedUrl from 'paper-ui/assets/brand/cut-meter-reversed.svg?no-inline'
+import { Bars3Icon, XMarkIcon, iconClassName } from 'paper-ui/icons'
 import { type PropsWithChildren, useEffect, useRef, useState } from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { buildNavigationGroups } from './catalogue'
@@ -107,7 +109,16 @@ export function DocsShell({ documents, children }: DocsShellProps) {
       <header className="docs-header">
         <Link className="paper-wordmark paper-focus-ring" to="/">
           <span aria-hidden="true">
-            <img src={cutMeterUrl} alt="" />
+            <img
+              className="paper-wordmark__mark--light"
+              src={cutMeterUrl}
+              alt=""
+            />
+            <img
+              className="paper-wordmark__mark--dark"
+              src={cutMeterReversedUrl}
+              alt=""
+            />
           </span>
           <strong>Tadoku Paper</strong>
         </Link>
@@ -117,12 +128,16 @@ export function DocsShell({ documents, children }: DocsShellProps) {
             ref={mobileTriggerRef}
             className="mobile-nav-trigger paper-focus-ring"
             type="button"
+            aria-label="Browse"
             aria-controls="mobile-catalogue-navigation"
             aria-expanded={mobileNavigationOpen}
             onClick={() => setMobileNavigationOpen((value) => !value)}
           >
-            <span aria-hidden="true">☰</span>
-            <span>Browse</span>
+            <Bars3Icon
+              aria-hidden="true"
+              className={iconClassName('default')}
+            />
+            <span className="mobile-nav-trigger__label">Browse</span>
           </button>
         </div>
       </header>
@@ -158,7 +173,10 @@ export function DocsShell({ documents, children }: DocsShellProps) {
                   mobileTriggerRef.current?.focus()
                 }}
               >
-                ×
+                <XMarkIcon
+                  aria-hidden="true"
+                  className={iconClassName('default')}
+                />
               </button>
             </div>
             <PreferenceControls />

--- a/frontend/apps/paper-styleguide/src/app/routes.tsx
+++ b/frontend/apps/paper-styleguide/src/app/routes.tsx
@@ -1,7 +1,17 @@
-import { catalogRegistry } from 'paper-ui/catalog'
+import { catalogRegistry, type CatalogKind } from 'paper-ui/catalog'
 import { Link, Navigate, useLocation } from 'react-router-dom'
 import { DocumentPage } from '../documentation/DocumentPage'
 import { resolveCatalogRoute } from './catalogue'
+
+const INDEX_SECTIONS: readonly {
+  id: string
+  label: string
+  kind: CatalogKind
+}[] = [
+  { id: 'foundations', label: 'Foundations', kind: 'foundation' },
+  { id: 'components', label: 'Components', kind: 'component' },
+  { id: 'governance', label: 'Governance', kind: 'governance' },
+]
 
 export function CatalogIndex() {
   return (
@@ -14,24 +24,41 @@ export function CatalogIndex() {
           patterns that keep Tadoku calm, accessible, and recognizably ours.
         </p>
       </header>
-      <section aria-labelledby="index-documents-title">
-        <h2 id="index-documents-title" className="paper-type-section">
-          Foundation documents
-        </h2>
-        <div className="document-card-grid">
-          {catalogRegistry.documents.map((document) => (
-            <Link
-              key={document.id}
-              className="document-card paper-surface-raised paper-elevation-floating paper-focus-ring"
-              to={document.route}
+      {INDEX_SECTIONS.map((section) => {
+        const documents = catalogRegistry.documents.filter(
+          (document) => document.kind === section.kind,
+        )
+
+        if (documents.length === 0) return null
+
+        return (
+          <section
+            key={section.id}
+            className="catalogue-index__section"
+            aria-labelledby={`index-${section.id}-title`}
+          >
+            <h2
+              id={`index-${section.id}-title`}
+              className="paper-type-section"
             >
-              <span className="paper-type-component">{document.name}</span>
-              <small>{document.lifecycle}</small>
-              <p>{document.summary}</p>
-            </Link>
-          ))}
-        </div>
-      </section>
+              {section.label}
+            </h2>
+            <div className="document-card-grid">
+              {documents.map((document) => (
+                <Link
+                  key={document.id}
+                  className="document-card paper-surface-raised paper-elevation-floating paper-focus-ring"
+                  to={document.route}
+                >
+                  <span className="paper-type-component">{document.name}</span>
+                  <small>{document.lifecycle}</small>
+                  <p>{document.summary}</p>
+                </Link>
+              ))}
+            </div>
+          </section>
+        )
+      })}
     </article>
   )
 }

--- a/frontend/apps/paper-styleguide/src/documentation/ExampleCanvas.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/ExampleCanvas.tsx
@@ -9,6 +9,13 @@ const VIEWPORTS = [
   { id: 'desktop', name: 'Desktop', width: 1280 },
 ] as const
 
+function initialViewportId(): (typeof VIEWPORTS)[number]['id'] {
+  return typeof window.matchMedia === 'function' &&
+    window.matchMedia('(max-width: 48rem)').matches
+    ? 'phone'
+    : 'desktop'
+}
+
 function PreviewSpecimen() {
   return (
     <article className="preview-specimen paper-surface paper-accent-rail">
@@ -37,7 +44,7 @@ export function ExampleCanvas({ fixture }: { fixture?: CatalogFixture }) {
   const [theme, setTheme] = useState<PaperTheme>('light')
   const [density, setDensity] = useState<PaperDensity>('comfortable')
   const [viewportId, setViewportId] = useState<(typeof VIEWPORTS)[number]['id']>(
-    'desktop',
+    initialViewportId,
   )
   const [previewRoot, setPreviewRoot] = useState<HTMLElement | null>(null)
   const frameDocumentRef = useRef<Document | null>(null)

--- a/frontend/apps/paper-styleguide/src/styles/shell.css
+++ b/frontend/apps/paper-styleguide/src/styles/shell.css
@@ -1,3 +1,15 @@
+/* Keep this structural inset unlayered so isolated preview/test documents that
+   do not implement cascade layers still reserve space for the public rail. */
+.catalogue-index__hero.paper-accent-rail,
+.document-hero.paper-accent-rail,
+.not-found.paper-accent-rail {
+  padding-inline-start: 1rem;
+}
+
+.paper-wordmark {
+  white-space: nowrap;
+}
+
 @layer paper-styleguide {
   :root {
     color-scheme: light;
@@ -15,19 +27,18 @@
     margin: 0;
   }
 
-  button,
-  input,
-  select {
+  /* Native .docs-shell button/input/select defaults stay scoped and use
+     :where() so component and selected-state recipes win the cascade. */
+  .docs-shell :where(button, input, select) {
     color: inherit;
     font: inherit;
   }
 
-  button,
-  select {
+  .docs-shell :where(button, select) {
     min-block-size: var(--paper-control-height);
   }
 
-  button {
+  .docs-shell :where(button) {
     cursor: pointer;
   }
 
@@ -74,6 +85,7 @@
     align-items: center;
     color: var(--paper-color-text-ink);
     text-decoration: none;
+    white-space: nowrap;
   }
 
   .paper-wordmark > span {
@@ -88,6 +100,15 @@
     display: block;
     inline-size: 100%;
     block-size: 100%;
+  }
+
+  .paper-wordmark__mark--dark,
+  :root[data-theme='dark'] .paper-wordmark__mark--light {
+    display: none;
+  }
+
+  :root[data-theme='dark'] .paper-wordmark__mark--dark {
+    display: block;
   }
 
   .docs-header__actions {
@@ -118,6 +139,8 @@
   }
 
   .shell-icon-button {
+    display: grid;
+    place-items: center;
     inline-size: var(--paper-control-height);
     padding: 0;
     font-size: var(--paper-type-section-size);
@@ -219,6 +242,14 @@
   .catalogue-index__hero {
     max-inline-size: 48rem;
     margin-block-end: 4rem;
+  }
+
+  .catalogue-index__section + .catalogue-index__section {
+    margin-block-start: 3.5rem;
+  }
+
+  .catalogue-index__section > h2 {
+    margin-block: 0 1rem;
   }
 
   .catalogue-index__hero h1,
@@ -325,7 +356,7 @@
     border-block-end: 1px solid var(--paper-color-rule-subtle);
   }
 
-  code {
+  .docs-shell code {
     overflow-wrap: anywhere;
     color: var(--paper-color-text-link);
   }
@@ -676,13 +707,15 @@
       min-block-size: 4rem;
     }
 
-    .shell-search-trigger > span,
+    .shell-search-trigger__label,
     .shell-search-trigger kbd {
       display: none;
     }
 
-    .shell-search-trigger::before {
-      content: 'Search';
+    .shell-search-trigger {
+      inline-size: var(--paper-control-height);
+      justify-content: center;
+      padding-inline: 0;
     }
 
     .mobile-nav-trigger {
@@ -691,6 +724,27 @@
 
     .docs-main {
       padding-block-start: 2rem;
+    }
+
+    .catalogue-index__hero {
+      margin-block-end: 2.5rem;
+    }
+
+    .catalogue-index__section + .catalogue-index__section {
+      margin-block-start: 2.5rem;
+    }
+
+    .document-card-grid {
+      gap: 0.75rem;
+    }
+
+    .document-card {
+      min-block-size: 0;
+      padding: 0.85rem;
+    }
+
+    .document-card p {
+      display: none;
     }
 
     .mobile-nav-drawer {
@@ -733,6 +787,20 @@
 
     .component-workbench__fixture-select {
       inline-size: 100%;
+    }
+  }
+
+  @media (max-width: 23rem) {
+    .shell-search-trigger__label,
+    .mobile-nav-trigger__label,
+    .shell-search-trigger kbd {
+      display: none;
+    }
+
+    .mobile-nav-trigger {
+      inline-size: var(--paper-control-height);
+      justify-content: center;
+      padding-inline: 0;
     }
   }
 

--- a/frontend/apps/paper-styleguide/tests/example-canvas.test.tsx
+++ b/frontend/apps/paper-styleguide/tests/example-canvas.test.tsx
@@ -1,8 +1,10 @@
 import '@testing-library/jest-dom/vitest'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { ExampleCanvas } from '../src/documentation/ExampleCanvas'
+
+afterEach(() => vi.unstubAllGlobals())
 
 describe('ExampleCanvas', () => {
   it('uses an iframe with a real selected viewport width', async () => {
@@ -27,5 +29,17 @@ describe('ExampleCanvas', () => {
     expect(
       screen.getByText('Desktop · 1280px · dark · compact'),
     ).toBeInTheDocument()
+  })
+
+  it('starts with the phone canvas when the host viewport is narrow', () => {
+    vi.stubGlobal('matchMedia', vi.fn(() => ({ matches: true })))
+
+    render(<ExampleCanvas />)
+
+    expect(screen.getByTitle('Paper responsive component preview')).toHaveAttribute(
+      'data-preview-width',
+      '360',
+    )
+    expect(screen.getByText('Phone · 360px · light · comfortable')).toBeInTheDocument()
   })
 })

--- a/frontend/apps/paper-styleguide/tests/visual-contract.test.tsx
+++ b/frontend/apps/paper-styleguide/tests/visual-contract.test.tsx
@@ -1,0 +1,140 @@
+import { readFileSync } from 'node:fs'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router-dom'
+import { describe, expect, it } from 'vitest'
+import { catalogRegistry } from 'paper-ui/catalog'
+import { DocsShell } from '../src/app/DocsShell'
+import { DisplayPreferencesProvider } from '../src/app/preferences'
+import { CatalogIndex, ResolvedCatalogueRoute } from '../src/app/routes'
+import { DocumentPage } from '../src/documentation/DocumentPage'
+import '../src/styles/shell.css'
+
+const testDirectory = dirname(fileURLToPath(import.meta.url))
+const shellStyles = readFileSync(
+  resolve(testDirectory, '../src/styles/shell.css'),
+  'utf8',
+)
+
+describe('responsive visual contract', () => {
+  it('reserves inline space between the home hero accent rail and its copy', () => {
+    render(
+      <MemoryRouter>
+        <CatalogIndex />
+      </MemoryRouter>,
+    )
+
+    const hero = screen
+      .getByRole('heading', { name: 'Paper makes the interface legible.' })
+      .closest('header')
+
+    expect(hero).not.toBeNull()
+    expect(getComputedStyle(hero!).paddingInlineStart).toBe('1rem')
+  })
+
+  it('reserves the same rail inset on document heroes', () => {
+    const document = catalogRegistry.documents.find(
+      (candidate) => candidate.id === 'component.button',
+    )
+
+    expect(document).toBeDefined()
+    render(<DocumentPage document={document!} />)
+
+    const hero = screen.getByRole('heading', { name: 'Button' }).closest('header')
+
+    expect(hero).not.toBeNull()
+    expect(getComputedStyle(hero!).paddingInlineStart).toBe('1rem')
+  })
+
+  it('reserves the same rail inset on the not-found state', () => {
+    render(
+      <MemoryRouter initialEntries={['/outside-the-catalogue']}>
+        <ResolvedCatalogueRoute />
+      </MemoryRouter>,
+    )
+
+    const notFound = screen
+      .getByRole('heading', { name: 'This Paper page does not exist.' })
+      .closest('section')
+
+    expect(notFound).not.toBeNull()
+    expect(getComputedStyle(notFound!).paddingInlineStart).toBe('1rem')
+  })
+
+  it('uses the approved Paper icon grammar in the responsive header', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <DisplayPreferencesProvider>
+          <DocsShell documents={catalogRegistry.documents}>
+            <p>Page content</p>
+          </DocsShell>
+        </DisplayPreferencesProvider>
+      </MemoryRouter>,
+    )
+
+    const search = screen.getByRole('button', { name: 'Search Paper' })
+    const browse = screen.getByRole('button', { name: 'Browse' })
+    const wordmark = screen.getByRole('link', { name: 'Tadoku Paper' })
+    const brandMarks = wordmark.querySelectorAll('img')
+
+    expect(search.querySelector('svg')).not.toBeNull()
+    expect(browse.querySelector('svg')).not.toBeNull()
+    expect(browse.querySelector('.mobile-nav-trigger__label')).not.toBeNull()
+    expect(brandMarks).toHaveLength(2)
+    expect([...brandMarks].map((mark) => mark.getAttribute('src'))).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining('cut-meter.svg'),
+        expect.stringContaining('cut-meter-reversed.svg'),
+      ]),
+    )
+    expect(getComputedStyle(wordmark).whiteSpace).toBe('nowrap')
+
+    await user.click(browse)
+    expect(
+      screen.getByRole('button', { name: 'Close navigation' }).querySelector('svg'),
+    ).not.toBeNull()
+  })
+
+  it('groups the catalogue index by document kind', () => {
+    render(
+      <MemoryRouter>
+        <CatalogIndex />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Foundations' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Components' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Governance' })).toBeInTheDocument()
+  })
+
+  it('keeps shell element resets out of isolated component previews', () => {
+    expect(shellStyles).not.toContain('\n  button,\n  input,\n  select {')
+    expect(shellStyles).not.toContain('\n  button,\n  select {')
+    expect(shellStyles).not.toContain('\n  button {\n')
+    expect(shellStyles).not.toContain('\n  code {\n')
+    expect(shellStyles).toContain('.docs-shell button')
+  })
+
+  it('keeps scoped shell resets low-specificity so selected controls retain contrast', () => {
+    expect(shellStyles).not.toContain('\n  .docs-shell button,\n')
+    expect(shellStyles).toContain('.docs-shell :where(button, input, select)')
+  })
+
+  it('collapses both header actions to icons at the narrow phone floor', () => {
+    expect(shellStyles).toContain(
+      '.shell-search-trigger__label,\n    .mobile-nav-trigger__label,',
+    )
+  })
+
+  it('switches the Cut Meter to its canonical reversed asset in dark mode', () => {
+    expect(shellStyles).toContain(
+      ":root[data-theme='dark'] .paper-wordmark__mark--light",
+    )
+    expect(shellStyles).toContain(
+      ":root[data-theme='dark'] .paper-wordmark__mark--dark",
+    )
+  })
+})

--- a/frontend/packages/paper-ui/src/components/feedback/feedback.tsx
+++ b/frontend/packages/paper-ui/src/components/feedback/feedback.tsx
@@ -5,6 +5,7 @@ import {
   type PropsWithChildren,
   type ReactNode,
 } from "react";
+import { XMarkIcon, iconClassName } from "../../icons";
 import { buttonClassName } from "../actions/Button";
 
 export const FLASH_VARIANTS = ["information", "success", "warning", "danger"] as const;
@@ -201,7 +202,7 @@ function PaperToastViewport() {
             aria-label="Dismiss notification"
             onClick={() => manager.close(toast.id)}
           >
-            ×
+            <XMarkIcon className={iconClassName("prominent")} aria-hidden="true" />
           </button>
         </Toast.Root>
       ))}

--- a/frontend/packages/paper-ui/src/components/forms/controls.tsx
+++ b/frontend/packages/paper-ui/src/components/forms/controls.tsx
@@ -15,6 +15,7 @@ import {
   type FieldValues,
   type RegisterOptions,
 } from "react-hook-form";
+import { CheckIcon, ChevronDownIcon, XMarkIcon, iconClassName } from "../../icons";
 
 export interface Option<Value = string> {
   readonly value: Value;
@@ -386,7 +387,9 @@ function ComboboxPopup<Value>({
                 index={index}
                 className="paper-combobox__item"
               >
-                <Combobox.ItemIndicator className="paper-combobox__indicator" aria-hidden="true">✓</Combobox.ItemIndicator>
+                <Combobox.ItemIndicator className="paper-combobox__indicator" aria-hidden="true">
+                  <CheckIcon className={iconClassName("compact")} />
+                </Combobox.ItemIndicator>
                 <span>{format(option)}</span>
               </Combobox.Item>
             ))}
@@ -441,7 +444,9 @@ export function AutocompleteInput<Value>({
               if (node && node.ownerDocument.body !== portalContainer) setPortalContainer(node.ownerDocument.body);
             }}
           />
-          <Combobox.Trigger className="paper-combobox__trigger" aria-label={`Show ${label.toLocaleLowerCase()} options`}>⌄</Combobox.Trigger>
+          <Combobox.Trigger className="paper-combobox__trigger" aria-label={`Show ${label.toLocaleLowerCase()} options`}>
+            <ChevronDownIcon className={iconClassName("compact")} aria-hidden="true" />
+          </Combobox.Trigger>
         </div>
         <ComboboxPopup options={filtered} getId={getId} format={format} portalContainer={portalContainer} />
       </Combobox.Root>
@@ -491,7 +496,9 @@ export function AutocompleteMultiInput<Value>({
           {values.map((value) => (
             <Combobox.Chip key={getId(value)} className="paper-combobox__chip">
               {format(value)}
-              <Combobox.ChipRemove aria-label={`Remove ${format(value)}`}>×</Combobox.ChipRemove>
+              <Combobox.ChipRemove aria-label={`Remove ${format(value)}`}>
+                <XMarkIcon className={iconClassName("compact")} aria-hidden="true" />
+              </Combobox.ChipRemove>
             </Combobox.Chip>
           ))}
           <Combobox.Input
@@ -506,7 +513,9 @@ export function AutocompleteMultiInput<Value>({
               if (node && node.ownerDocument.body !== portalContainer) setPortalContainer(node.ownerDocument.body);
             }}
           />
-          <Combobox.Trigger className="paper-combobox__trigger" aria-label={`Show ${label.toLocaleLowerCase()} options`}>⌄</Combobox.Trigger>
+          <Combobox.Trigger className="paper-combobox__trigger" aria-label={`Show ${label.toLocaleLowerCase()} options`}>
+            <ChevronDownIcon className={iconClassName("compact")} aria-hidden="true" />
+          </Combobox.Trigger>
         </Combobox.Chips>
         <ComboboxPopup options={filtered} getId={getId} format={format} portalContainer={portalContainer} />
       </Combobox.Root>

--- a/frontend/packages/paper-ui/src/components/overlays/Modal/Modal.tsx
+++ b/frontend/packages/paper-ui/src/components/overlays/Modal/Modal.tsx
@@ -1,5 +1,6 @@
 import { Dialog } from "@base-ui/react/dialog";
 import { useState, type ReactNode } from "react";
+import { XMarkIcon, iconClassName } from "../../../icons";
 import { buttonClassName, type ButtonVariant } from "../../actions/Button";
 
 export interface ModalProps {
@@ -67,7 +68,7 @@ export function Modal({
                 className="paper-modal__icon-close"
                 aria-label={closeLabel}
               >
-                <span aria-hidden="true">×</span>
+                <XMarkIcon className={iconClassName("prominent")} aria-hidden="true" />
               </Dialog.Close>
             </header>
             <div className="paper-modal__content">{children}</div>

--- a/frontend/packages/paper-ui/src/icons/index.ts
+++ b/frontend/packages/paper-ui/src/icons/index.ts
@@ -3,7 +3,6 @@ export {
   ArrowLeftIcon,
   ArrowRightIcon,
   Bars3Icon,
-  CheckIcon,
   ChevronDownIcon,
   ChevronLeftIcon,
   ChevronRightIcon,
@@ -17,6 +16,7 @@ export {
 
 // Solid icons are reserved for status and confirmation.
 export {
+  CheckIcon,
   CheckCircleIcon,
   ExclamationCircleIcon,
   ExclamationTriangleIcon,

--- a/frontend/packages/paper-ui/tests/forms-feedback.test.tsx
+++ b/frontend/packages/paper-ui/tests/forms-feedback.test.tsx
@@ -125,6 +125,13 @@ describe("native React Hook Form controls", () => {
 });
 
 describe("Base UI autocomplete controls", () => {
+  it("uses Paper icons instead of text glyphs for combobox actions", () => {
+    render(<AutocompleteForm />);
+    const trigger = screen.getByRole("button", { name: "Show languages options" });
+    expect(trigger.querySelector("svg")).not.toBeNull();
+    expect(trigger).not.toHaveTextContent("⌄");
+  });
+
   it("filters and selects one option from the keyboard", async () => {
     const user = userEvent.setup();
     render(<AutocompleteForm />);
@@ -142,8 +149,10 @@ describe("Base UI autocomplete controls", () => {
     await user.click(input);
     await user.type(input, "jap");
     await user.keyboard("{ArrowDown}{Enter}");
-    expect(screen.getByRole("button", { name: "Remove Japanese" })).toBeInTheDocument();
-    await user.click(screen.getByRole("button", { name: "Remove Japanese" }));
+    const remove = screen.getByRole("button", { name: "Remove Japanese" });
+    expect(remove.querySelector("svg")).not.toBeNull();
+    expect(remove).not.toHaveTextContent("×");
+    await user.click(remove);
     expect(screen.getByTestId("value")).toHaveTextContent("[]");
   });
 
@@ -201,7 +210,9 @@ describe("feedback and action compositions", () => {
     expect(screen.getByText("Reading summary")).toHaveClass(surfaceClassName({ elevation: "floating", accent: true }));
     await user.click(screen.getByRole("button", { name: "Show notification" }));
     expect(await screen.findByText("Entry saved")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Dismiss notification" })).toBeInTheDocument();
+    const dismiss = screen.getByRole("button", { name: "Dismiss notification" });
+    expect(dismiss.querySelector("svg")).not.toBeNull();
+    expect(dismiss).not.toHaveTextContent("×");
   });
 
   it("keeps its toast viewport in the provider owner document", async () => {

--- a/frontend/packages/paper-ui/tests/phase-two-components.test.tsx
+++ b/frontend/packages/paper-ui/tests/phase-two-components.test.tsx
@@ -120,6 +120,9 @@ describe("Modal", () => {
     expect(screen.getByRole("dialog", { name: "Delete this log?" })).toHaveAccessibleDescription(
       "This cannot be undone.",
     );
+    const iconClose = document.querySelector(".paper-modal__icon-close");
+    expect(iconClose?.querySelector("svg")).not.toBeNull();
+    expect(iconClose).not.toHaveTextContent("×");
     await user.keyboard("{Escape}");
     expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
     expect(trigger).toHaveFocus();


### PR DESCRIPTION
## Summary

- correct clipped accent rails, responsive catalogue navigation, mobile card density, and initial preview viewport
- isolate documentation-shell CSS so Paper fixtures retain their intended filled, selected, and disabled states
- use the canonical reversed brand mark in dark mode and replace raw control glyphs with the approved Heroicons grammar

## Verification

- paper-ui: 49 tests; lint, typecheck, build, TS 4.9 declaration consumer, and package-content check
- paper-styleguide: 21 tests; lint, typecheck, and production build
- paper package-boundary check and full frontend workspace build
- manual visual QA at 320px, 390px, and desktop, including light/dark themes, iframe fixtures, modal, forms, toast, and 404 routes

The styleguide production build retains the existing non-failing ~507 kB chunk-size warning.