### PR TITLE
Stabilize the Tadoku Paper catalogue experience

### DIFF
--- a/docs/wip/tadoku-paper/research/README.md
+++ b/docs/wip/tadoku-paper/research/README.md
@@ -16,6 +16,7 @@ This packet freezes the evidence and reversible architecture decisions required 
 - [Tokens and shared CSS recipes](adr-002-tokens-and-recipes.md)
 - [Catalogue, fixture, and route contracts](adr-003-catalogue-contract.md)
 - [Dependency and build baseline](adr-compatibility-dependency-baseline.md)
+- [TypeScript 7 compiler and TypeScript 6 tooling boundary](adr-typescript-7-tooling-boundary.md)
 - [Base UI import and wrapper boundary](adr-base-ui-import-boundary.md)
 - [Native versus Base UI ownership](adr-native-base-ui-ownership.md)
 

--- a/frontend/apps/paper-styleguide/src/app/CatalogueSearch.tsx
+++ b/frontend/apps/paper-styleguide/src/app/CatalogueSearch.tsx
@@ -4,7 +4,12 @@ import {
   XMarkIcon,
   iconClassName,
 } from 'paper-ui/icons'
-import { useEffect, useRef, useState } from 'react'
+import {
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 import { Link } from 'react-router-dom'
 import { searchCatalog } from './catalogue'
 
@@ -25,6 +30,7 @@ export function CatalogueSearch({ documents }: CatalogueSearchProps) {
   const [query, setQuery] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const triggerRef = useRef<HTMLButtonElement>(null)
+  const resultRefs = useRef<Array<HTMLAnchorElement | null>>([])
   const results = searchCatalog(documents, query)
   const closeSearch = (restoreFocus = false) => {
     setOpen(false)
@@ -54,6 +60,43 @@ export function CatalogueSearch({ documents }: CatalogueSearchProps) {
   useEffect(() => {
     if (open) inputRef.current?.focus()
   }, [open])
+
+  function moveResult(
+    event: ReactKeyboardEvent<HTMLElement>,
+    currentIndex: number,
+  ) {
+    if (!['ArrowDown', 'ArrowUp', 'Home', 'End'].includes(event.key)) return
+    event.preventDefault()
+    const nextIndex =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? results.length - 1
+          : (currentIndex + (event.key === 'ArrowDown' ? 1 : -1) +
+              results.length) %
+            results.length
+    resultRefs.current[nextIndex]?.focus()
+  }
+
+  function trapDialogFocus(event: ReactKeyboardEvent<HTMLElement>) {
+    if (event.key !== 'Tab') return
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), input:not([disabled]), a[href]',
+      ),
+    )
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!first || !last) return
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
 
   return (
     <>
@@ -87,6 +130,7 @@ export function CatalogueSearch({ documents }: CatalogueSearchProps) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="catalogue-search-title"
+            onKeyDown={trapDialogFocus}
           >
             <div className="search-dialog__heading">
               <h2 id="catalogue-search-title" className="paper-type-component">
@@ -112,18 +156,31 @@ export function CatalogueSearch({ documents }: CatalogueSearchProps) {
                 value={query}
                 placeholder="Try “color” or “foundations”"
                 onChange={(event) => setQuery(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'ArrowDown' && results.length > 0) {
+                    event.preventDefault()
+                    resultRefs.current[0]?.focus()
+                  } else if (event.key === 'ArrowUp' && results.length > 0) {
+                    event.preventDefault()
+                    resultRefs.current[results.length - 1]?.focus()
+                  }
+                }}
               />
             </label>
             <p className="search-count paper-type-metadata" aria-live="polite">
               {results.length} {results.length === 1 ? 'result' : 'results'}
             </p>
             <ul className="search-results">
-              {results.map((document) => (
+              {results.map((document, index) => (
                 <li key={document.id}>
                   <Link
+                    ref={(node) => {
+                      resultRefs.current[index] = node
+                    }}
                     className="search-result paper-focus-ring"
                     to={document.route}
                     onClick={() => closeSearch()}
+                    onKeyDown={(event) => moveResult(event, index)}
                   >
                     <span>
                       <strong>{document.name}</strong>

--- a/frontend/apps/paper-styleguide/src/app/DocsShell.tsx
+++ b/frontend/apps/paper-styleguide/src/app/DocsShell.tsx
@@ -2,7 +2,13 @@ import type { CatalogDocument } from 'paper-ui/catalog'
 import cutMeterUrl from 'paper-ui/assets/brand/cut-meter.svg?no-inline'
 import cutMeterReversedUrl from 'paper-ui/assets/brand/cut-meter-reversed.svg?no-inline'
 import { Bars3Icon, XMarkIcon, iconClassName } from 'paper-ui/icons'
-import { type PropsWithChildren, useEffect, useRef, useState } from 'react'
+import {
+  type PropsWithChildren,
+  useEffect,
+  useRef,
+  useState,
+  type KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
 import { Link, NavLink } from 'react-router-dom'
 import { buildNavigationGroups } from './catalogue'
 import { CatalogueSearch } from './CatalogueSearch'
@@ -88,9 +94,11 @@ function PreferenceControls() {
 export function DocsShell({ documents, children }: DocsShellProps) {
   const [mobileNavigationOpen, setMobileNavigationOpen] = useState(false)
   const mobileTriggerRef = useRef<HTMLButtonElement>(null)
+  const mobileCloseRef = useRef<HTMLButtonElement>(null)
 
   useEffect(() => {
     if (!mobileNavigationOpen) return
+    mobileCloseRef.current?.focus()
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         setMobileNavigationOpen(false)
@@ -100,6 +108,26 @@ export function DocsShell({ documents, children }: DocsShellProps) {
     window.addEventListener('keydown', onKeyDown)
     return () => window.removeEventListener('keydown', onKeyDown)
   }, [mobileNavigationOpen])
+
+  function trapMobileFocus(event: ReactKeyboardEvent<HTMLElement>) {
+    if (event.key !== 'Tab') return
+    const focusable = Array.from(
+      event.currentTarget.querySelectorAll<HTMLElement>(
+        'button:not([disabled]), select:not([disabled]), a[href]',
+      ),
+    )
+    const first = focusable[0]
+    const last = focusable[focusable.length - 1]
+    if (!first || !last) return
+
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault()
+      last.focus()
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault()
+      first.focus()
+    }
+  }
 
   return (
     <div className="docs-shell">
@@ -161,10 +189,12 @@ export function DocsShell({ documents, children }: DocsShellProps) {
             id="mobile-catalogue-navigation"
             className="mobile-nav-drawer paper-surface-raised paper-elevation-showcase"
             aria-label="Mobile catalogue navigation"
+            onKeyDown={trapMobileFocus}
           >
             <div className="mobile-nav-drawer__heading">
               <strong className="paper-type-component">Browse Paper</strong>
               <button
+                ref={mobileCloseRef}
                 type="button"
                 className="shell-icon-button paper-focus-ring"
                 aria-label="Close navigation"

--- a/frontend/apps/paper-styleguide/src/app/designHistory.ts
+++ b/frontend/apps/paper-styleguide/src/app/designHistory.ts
@@ -1,0 +1,27 @@
+export const DESIGN_HISTORY_LINKS = [
+  {
+    label: 'Original refinement audit',
+    description: 'The findings that established the Paper redesign brief.',
+    href: 'https://github.com/tadoku/tadoku/blob/main/docs/wip/tadoku-paper/artifacts/design-system-refinement-audit.html',
+  },
+  {
+    label: 'Visual studies',
+    description: 'Approved and rejected directions from Bookplate through the final component grammar.',
+    href: 'https://github.com/tadoku/tadoku/tree/main/docs/wip/tadoku-paper/artifacts',
+  },
+  {
+    label: 'Paper decision log',
+    description: 'The product and visual decisions that shaped Tadoku Paper.',
+    href: 'https://github.com/tadoku/tadoku/blob/main/docs/wip/tadoku-paper/decision-log.md',
+  },
+  {
+    label: 'Implementation plan',
+    description: 'The phased delivery, gates, risks, and migration sequence.',
+    href: 'https://github.com/tadoku/tadoku/blob/main/docs/wip/tadoku-paper/implementation-plan.md',
+  },
+  {
+    label: 'Research archive',
+    description: 'ADRs, inventories, compatibility evidence, and provenance.',
+    href: 'https://github.com/tadoku/tadoku/tree/main/docs/wip/tadoku-paper/research',
+  },
+] as const

--- a/frontend/apps/paper-styleguide/src/app/routes.tsx
+++ b/frontend/apps/paper-styleguide/src/app/routes.tsx
@@ -1,7 +1,9 @@
 import { catalogRegistry, type CatalogKind } from 'paper-ui/catalog'
+import { useEffect } from 'react'
 import { Link, Navigate, useLocation } from 'react-router-dom'
 import { DocumentPage } from '../documentation/DocumentPage'
 import { resolveCatalogRoute } from './catalogue'
+import { DESIGN_HISTORY_LINKS } from './designHistory'
 
 const INDEX_SECTIONS: readonly {
   id: string
@@ -10,6 +12,8 @@ const INDEX_SECTIONS: readonly {
 }[] = [
   { id: 'foundations', label: 'Foundations', kind: 'foundation' },
   { id: 'components', label: 'Components', kind: 'component' },
+  { id: 'patterns', label: 'Patterns', kind: 'pattern' },
+  { id: 'experiments', label: 'Experiments', kind: 'experiment' },
   { id: 'governance', label: 'Governance', kind: 'governance' },
 ]
 
@@ -59,12 +63,44 @@ export function CatalogIndex() {
           </section>
         )
       })}
+      <section
+        className="catalogue-index__section design-history"
+        aria-labelledby="design-history-title"
+      >
+        <h2 id="design-history-title" className="paper-type-section">
+          Design history
+        </h2>
+        <p>
+          Trace the decisions, evidence, and delivery gates behind the system.
+        </p>
+        <ul className="design-history__links">
+          {DESIGN_HISTORY_LINKS.map((entry) => (
+            <li key={entry.href}>
+              <a className="paper-focus-ring" href={entry.href}>
+                <strong>{entry.label}</strong>
+                <span>{entry.description}</span>
+              </a>
+            </li>
+          ))}
+        </ul>
+      </section>
     </article>
   )
 }
 
 export function ResolvedCatalogueRoute() {
   const location = useLocation()
+
+  useEffect(() => {
+    if (!location.hash) return
+    let id = location.hash.slice(1)
+    try {
+      id = decodeURIComponent(id)
+    } catch {
+      return
+    }
+    document.getElementById(id)?.scrollIntoView?.({ block: 'start' })
+  }, [location.hash, location.pathname])
 
   if (location.pathname === '/') return <CatalogIndex />
 

--- a/frontend/apps/paper-styleguide/src/documentation/ComponentWorkbench.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/ComponentWorkbench.tsx
@@ -1,9 +1,11 @@
 import { useRef, useState, type KeyboardEvent } from 'react'
+import { buttonClassName } from 'paper-ui'
 import type { CatalogDocument, CatalogFixture } from 'paper-ui/catalog'
 import { ExampleCanvas } from './ExampleCanvas'
 
 const VIEWS = ['preview', 'code', 'api', 'accessibility'] as const
 type View = (typeof VIEWS)[number]
+type CopyState = 'idle' | 'copied' | 'error'
 
 function label(view: View): string {
   if (view === 'api') return 'API / Props'
@@ -15,7 +17,13 @@ function ApiList({ title, items }: { title: string; items: readonly string[] }) 
     <section>
       <h4>{title}</h4>
       {items.length ? (
-        <ul>{items.map((item) => <li key={item}><code>{item}</code></li>)}</ul>
+        <ul>
+          {items.map((item) => (
+            <li key={item}>
+              <code>{item}</code>
+            </li>
+          ))}
+        </ul>
       ) : (
         <p>None.</p>
       )}
@@ -32,30 +40,62 @@ export function ComponentWorkbench({
 }) {
   const [view, setView] = useState<View>('preview')
   const [fixtureId, setFixtureId] = useState(fixtures[0]?.id ?? '')
+  const [copyState, setCopyState] = useState<CopyState>('idle')
   const tabRefs = useRef<Array<HTMLButtonElement | null>>([])
-  const fixture = fixtures.find((candidate) => candidate.id === fixtureId) ?? fixtures[0]
+  const fixture =
+    fixtures.find((candidate) => candidate.id === fixtureId) ?? fixtures[0]
+
+  function selectView(nextView: View) {
+    setView(nextView)
+  }
 
   function moveTab(event: KeyboardEvent<HTMLButtonElement>, index: number) {
     if (!['ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) return
     event.preventDefault()
-    const nextIndex = event.key === 'Home'
-      ? 0
-      : event.key === 'End'
-        ? VIEWS.length - 1
-        : (index + (event.key === 'ArrowRight' ? 1 : -1) + VIEWS.length) % VIEWS.length
+    const nextIndex =
+      event.key === 'Home'
+        ? 0
+        : event.key === 'End'
+          ? VIEWS.length - 1
+          : (index + (event.key === 'ArrowRight' ? 1 : -1) + VIEWS.length) %
+            VIEWS.length
     const nextView = VIEWS[nextIndex]
-    setView(nextView)
+    selectView(nextView)
     tabRefs.current[nextIndex]?.focus()
   }
 
+  async function copyCode() {
+    const code = fixture?.code
+    if (!code || !navigator.clipboard?.writeText) {
+      setCopyState('error')
+      return
+    }
+
+    try {
+      await navigator.clipboard.writeText(code)
+      setCopyState('copied')
+    } catch {
+      setCopyState('error')
+    }
+  }
+
   return (
-    <section className="component-workbench" aria-label={`${document.name} examples`}>
+    <section
+      className="component-workbench"
+      aria-label={`${document.name} examples`}
+    >
       <div className="component-workbench__toolbar">
-        <div className="component-workbench__tabs" role="tablist" aria-label="Example views">
+        <div
+          className="component-workbench__tabs"
+          role="tablist"
+          aria-label="Example views"
+        >
           {VIEWS.map((candidate, index) => (
             <button
               key={candidate}
-              ref={(node) => { tabRefs.current[index] = node }}
+              ref={(node) => {
+                tabRefs.current[index] = node
+              }}
               id={`workbench-tab-${candidate}`}
               type="button"
               role="tab"
@@ -63,7 +103,7 @@ export function ComponentWorkbench({
               aria-controls={`workbench-panel-${candidate}`}
               tabIndex={view === candidate ? 0 : -1}
               onKeyDown={(event) => moveTab(event, index)}
-              onClick={() => setView(candidate)}
+              onClick={() => selectView(candidate)}
             >
               {label(candidate)}
             </button>
@@ -72,9 +112,17 @@ export function ComponentWorkbench({
         {fixtures.length > 1 ? (
           <label className="component-workbench__fixture-select">
             <span>Fixture</span>
-            <select value={fixture?.id} onChange={(event) => setFixtureId(event.target.value)}>
+            <select
+              value={fixture?.id}
+              onChange={(event) => {
+                setFixtureId(event.target.value)
+                setCopyState('idle')
+              }}
+            >
               {fixtures.map((candidate) => (
-                <option key={candidate.id} value={candidate.id}>{candidate.name}</option>
+                <option key={candidate.id} value={candidate.id}>
+                  {candidate.name}
+                </option>
               ))}
             </select>
           </label>
@@ -82,37 +130,89 @@ export function ComponentWorkbench({
       </div>
 
       <div
-        id={`workbench-panel-${view}`}
+        id="workbench-panel-preview"
         role="tabpanel"
-        aria-labelledby={`workbench-tab-${view}`}
+        aria-labelledby="workbench-tab-preview"
         className="component-workbench__panel"
+        hidden={view !== 'preview'}
       >
-        {view === 'preview' ? <ExampleCanvas fixture={fixture} /> : null}
-        {view === 'code' ? (
-          <div className="code-view">
+        <ExampleCanvas fixture={fixture} />
+      </div>
+
+      <div
+        id="workbench-panel-code"
+        role="tabpanel"
+        aria-labelledby="workbench-tab-code"
+        className="component-workbench__panel"
+        hidden={view !== 'code'}
+      >
+        <div className="code-view">
+          <div className="code-view__heading">
             <div>
               <h3>{fixture?.name ?? 'Example'}</h3>
               <p>{fixture?.description}</p>
             </div>
-            <pre tabIndex={0}><code>{fixture?.code ?? 'No copyable example is registered.'}</code></pre>
+            <div className="code-copy">
+              <button
+                className={`${buttonClassName({ variant: 'outline' })} code-copy__button`}
+                type="button"
+                disabled={!fixture?.code}
+                onClick={copyCode}
+              >
+                {copyState === 'copied' ? 'Copied' : 'Copy code'}
+              </button>
+              <span className="code-copy__status" role="status" aria-live="polite">
+                {copyState === 'copied'
+                  ? 'Code copied to clipboard.'
+                  : copyState === 'error'
+                    ? 'Copy failed. Select the code and copy it manually.'
+                    : ''}
+              </span>
+            </div>
           </div>
-        ) : null}
-        {view === 'api' ? (
-          <div className="workbench-reference-grid">
-            <ApiList title="React" items={document.api.react} />
-            <ApiList title="CSS and recipes" items={document.api.cssClasses} />
-            <ApiList title="Public types" items={document.api.publicTypes} />
-            <ApiList title="Defaults" items={document.api.defaults} />
-            <ApiList title="Invalid combinations" items={document.api.invalidCombinations} />
-          </div>
-        ) : null}
-        {view === 'accessibility' ? (
-          <div className="workbench-reference-grid">
-            <ApiList title="Requirements" items={document.accessibility.requirements} />
-            <ApiList title="Keyboard" items={document.accessibility.keyboard} />
-            <ApiList title="Known constraints" items={document.accessibility.knownConstraints} />
-          </div>
-        ) : null}
+          <pre tabIndex={0}>
+            <code>{fixture?.code ?? 'No copyable example is registered.'}</code>
+          </pre>
+        </div>
+      </div>
+
+      <div
+        id="workbench-panel-api"
+        role="tabpanel"
+        aria-labelledby="workbench-tab-api"
+        className="component-workbench__panel"
+        hidden={view !== 'api'}
+      >
+        <div className="workbench-reference-grid">
+          <ApiList title="React" items={document.api.react} />
+          <ApiList title="CSS and recipes" items={document.api.cssClasses} />
+          <ApiList title="Public types" items={document.api.publicTypes} />
+          <ApiList title="Defaults" items={document.api.defaults} />
+          <ApiList
+            title="Invalid combinations"
+            items={document.api.invalidCombinations}
+          />
+        </div>
+      </div>
+
+      <div
+        id="workbench-panel-accessibility"
+        role="tabpanel"
+        aria-labelledby="workbench-tab-accessibility"
+        className="component-workbench__panel"
+        hidden={view !== 'accessibility'}
+      >
+        <div className="workbench-reference-grid">
+          <ApiList
+            title="Requirements"
+            items={document.accessibility.requirements}
+          />
+          <ApiList title="Keyboard" items={document.accessibility.keyboard} />
+          <ApiList
+            title="Known constraints"
+            items={document.accessibility.knownConstraints}
+          />
+        </div>
       </div>
     </section>
   )

--- a/frontend/apps/paper-styleguide/src/documentation/DocumentPage.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/DocumentPage.tsx
@@ -32,6 +32,13 @@ function SectionCopy({ value, fallback }: { value: unknown; fallback: string }) 
   return <p>{copy || fallback}</p>
 }
 
+function sourceHref(sourcePath: string): string {
+  const repositoryPath = sourcePath.startsWith('docs/')
+    ? sourcePath
+    : `frontend/packages/paper-ui/${sourcePath}`
+  return `https://github.com/tadoku/tadoku/blob/main/${repositoryPath}`
+}
+
 function Metadata({ document }: { document: CatalogDocument }) {
   return (
     <dl className="metadata-list">
@@ -41,7 +48,11 @@ function Metadata({ document }: { document: CatalogDocument }) {
       </div>
       <div>
         <dt>Source</dt>
-        <dd><code>{document.sourcePath}</code></dd>
+        <dd>
+          <a className="text-link paper-focus-ring" href={sourceHref(document.sourcePath)}>
+            <code>{document.sourcePath}</code>
+          </a>
+        </dd>
       </div>
       <div>
         <dt>Dependencies</dt>
@@ -122,19 +133,25 @@ function ComponentDocumentPage({ document }: { document: CatalogDocument }) {
 }
 
 function GeneralDocumentPage({ document }: { document: CatalogDocument }) {
+  const fixture = catalogRegistry.fixtures.find((candidate) =>
+    document.fixtureIds.includes(candidate.id),
+  )
+
   return (
     <div className="document-layout">
       <article className="document-page">
         <div id="overview"><Hero document={document} /></div>
         <section id="guidance" className="document-section">
           <h2 className="paper-type-section">Guidance</h2>
-          <SectionCopy value={document.guidance} fallback="Detailed usage guidance will arrive with this catalogue slice." />
+          <SectionCopy value={document.guidance} fallback="No additional guidance is registered for this document." />
         </section>
         <section id="accessibility" className="document-section">
           <h2 className="paper-type-section">Accessibility</h2>
           <SectionCopy value={document.accessibility} fallback="Accessibility requirements are tracked in the catalogue registry." />
         </section>
-        <div id="preview" className="document-section document-section--wide"><ExampleCanvas /></div>
+        <div id="preview" className="document-section document-section--wide">
+          <ExampleCanvas fixture={fixture} />
+        </div>
         <section id="contract" className="document-section">
           <h2 className="paper-type-section">Public contract</h2>
           <SectionCopy value={document.api} fallback="This foundation does not expose a component API." />

--- a/frontend/apps/paper-styleguide/src/documentation/ExampleCanvas.tsx
+++ b/frontend/apps/paper-styleguide/src/documentation/ExampleCanvas.tsx
@@ -122,9 +122,14 @@ export function ExampleCanvas({ fixture }: { fixture?: CatalogFixture }) {
       <div className="example-canvas__stage">
         <iframe
           title="Paper responsive component preview"
+          width={viewport.width}
+          data-fixture-id={fixture?.id}
           srcDoc={'<!doctype html><html lang="en"><head><meta charset="UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1"></head><body><div id="paper-preview-root"></div></body></html>'}
           data-preview-width={viewport.width}
-          style={{ inlineSize: `${viewport.width}px` }}
+          style={{
+            inlineSize: `${viewport.width}px`,
+            boxSizing: 'content-box',
+          }}
           onLoad={(event) => {
             const targetDocument = event.currentTarget.contentDocument
             if (!targetDocument) return

--- a/frontend/apps/paper-styleguide/src/styles/shell.css
+++ b/frontend/apps/paper-styleguide/src/styles/shell.css
@@ -252,6 +252,36 @@
     margin-block: 0 1rem;
   }
 
+  .design-history > p {
+    max-inline-size: 46rem;
+    color: var(--paper-color-text-muted);
+  }
+
+  .design-history__links {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(min(100%, 16rem), 1fr));
+    gap: 1rem;
+    margin: 1.25rem 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  .design-history__links a {
+    display: block;
+    block-size: 100%;
+    padding: 1rem;
+    border: 1px solid var(--paper-color-rule-default);
+    color: var(--paper-color-text-ink);
+    background: var(--paper-color-surface-raised);
+    text-decoration: none;
+  }
+
+  .design-history__links span {
+    display: block;
+    margin-block-start: 0.35rem;
+    color: var(--paper-color-text-muted);
+  }
+
   .catalogue-index__hero h1,
   .document-hero h1,
   .not-found h1 {
@@ -451,6 +481,27 @@
   .code-view,
   .workbench-reference-grid {
     padding: 1.25rem;
+  }
+
+  .code-view__heading {
+    display: flex;
+    align-items: start;
+    justify-content: space-between;
+    gap: 1rem;
+  }
+
+  .code-copy {
+    display: grid;
+    justify-items: end;
+    gap: 0.35rem;
+    min-inline-size: 12rem;
+  }
+
+  .code-copy__status {
+    min-block-size: var(--paper-type-metadata-line-height);
+    color: var(--paper-color-text-muted);
+    font-size: var(--paper-type-metadata-size);
+    text-align: end;
   }
 
   .code-view h3,
@@ -745,6 +796,16 @@
 
     .document-card p {
       display: none;
+    }
+
+    .code-view__heading {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .code-copy {
+      justify-items: start;
+      min-inline-size: 0;
     }
 
     .mobile-nav-drawer {

--- a/frontend/apps/paper-styleguide/tests/experience-stability.test.tsx
+++ b/frontend/apps/paper-styleguide/tests/experience-stability.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { catalogRegistry } from 'paper-ui/catalog'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { CatalogueSearch } from '../src/app/CatalogueSearch'
+import { DocsShell } from '../src/app/DocsShell'
+import { DisplayPreferencesProvider } from '../src/app/preferences'
+import { CatalogIndex, ResolvedCatalogueRoute } from '../src/app/routes'
+import { DocumentPage } from '../src/documentation/DocumentPage'
+import { ExampleCanvas } from '../src/documentation/ExampleCanvas'
+
+const buttonDocument = catalogRegistry.documents.find(
+  (document) => document.id === 'component.button',
+)!
+const buttonFixture = catalogRegistry.fixtures.find((fixture) =>
+  buttonDocument.fixtureIds.includes(fixture.id),
+)!
+const loggingPatternDocument = catalogRegistry.documents.find(
+  (document) => document.id === 'pattern.logging',
+)!
+
+const originalScrollIntoView = HTMLElement.prototype.scrollIntoView
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  if (originalScrollIntoView) {
+    HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+  } else {
+    Reflect.deleteProperty(HTMLElement.prototype, 'scrollIntoView')
+  }
+  Reflect.deleteProperty(navigator, 'clipboard')
+})
+
+describe('catalogue experience stability', () => {
+  it('copies the registered example and announces successful feedback', async () => {
+    const user = userEvent.setup()
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    render(<DocumentPage document={buttonDocument} />)
+
+    await user.click(screen.getByRole('tab', { name: 'Code' }))
+    await user.click(screen.getByRole('button', { name: 'Copy code' }))
+
+    expect(writeText).toHaveBeenCalledWith(buttonFixture.code)
+    expect(screen.getByRole('status')).toHaveTextContent('Code copied')
+  })
+
+  it('keeps all workbench panels stable while switching views', async () => {
+    const user = userEvent.setup()
+    render(<DocumentPage document={buttonDocument} />)
+
+    const panels = screen.getAllByRole('tabpanel', { hidden: true })
+    expect(panels).toHaveLength(4)
+    const previewFrame = screen.getByTitle('Paper responsive component preview')
+
+    await user.click(screen.getByRole('tab', { name: 'Code' }))
+    await user.click(screen.getByRole('tab', { name: 'Preview' }))
+
+    expect(screen.getByTitle('Paper responsive component preview')).toBe(
+      previewFrame,
+    )
+  })
+
+  it('exposes exact iframe content widths for every viewport control', async () => {
+    const user = userEvent.setup()
+    render(<ExampleCanvas />)
+
+    await user.click(screen.getByRole('button', { name: 'Tablet, 768 pixels' }))
+    const frame = screen.getByTitle('Paper responsive component preview')
+    expect(frame).toHaveAttribute('width', '768')
+    expect(frame).toHaveStyle({ inlineSize: '768px', boxSizing: 'content-box' })
+  })
+
+  it('moves from search input to the first result with ArrowDown', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <CatalogueSearch documents={catalogRegistry.documents} />
+      </MemoryRouter>,
+    )
+
+    await user.keyboard('/')
+    await user.type(screen.getByRole('searchbox'), 'button')
+    await user.keyboard('{ArrowDown}')
+
+    expect(
+      within(screen.getByRole('dialog')).getAllByRole('link')[0],
+    ).toHaveFocus()
+  })
+
+  it('focuses mobile navigation and preserves its accessible close path', async () => {
+    const user = userEvent.setup()
+    render(
+      <MemoryRouter>
+        <DisplayPreferencesProvider>
+          <DocsShell documents={catalogRegistry.documents}>Content</DocsShell>
+        </DisplayPreferencesProvider>
+      </MemoryRouter>,
+    )
+
+    await user.click(screen.getByRole('button', { name: 'Browse' }))
+    expect(screen.getByRole('button', { name: 'Close navigation' })).toHaveFocus()
+  })
+
+  it('scrolls direct hash routes to their documented section', async () => {
+    const scrollIntoView = vi.fn()
+    HTMLElement.prototype.scrollIntoView = scrollIntoView
+
+    render(
+      <MemoryRouter initialEntries={[`${buttonDocument.route}#accessibility`]}>
+        <Routes>
+          <Route path="*" element={<ResolvedCatalogueRoute />} />
+        </Routes>
+      </MemoryRouter>,
+    )
+
+    await waitFor(() => expect(scrollIntoView).toHaveBeenCalled())
+    expect(document.getElementById('accessibility')).not.toBeNull()
+  })
+
+  it('keeps local outline anchors and design history discoverable', () => {
+    const { unmount } = render(<DocumentPage document={buttonDocument} />)
+    expect(
+      screen.getByRole('link', { name: 'Accessibility' }),
+    ).toHaveAttribute('href', '#accessibility')
+    unmount()
+
+    render(
+      <MemoryRouter>
+        <CatalogIndex />
+      </MemoryRouter>,
+    )
+    const history = screen.getByRole('heading', { name: 'Design history' })
+      .closest('section')
+    expect(history).not.toBeNull()
+    expect(within(history!).getAllByRole('link')).toHaveLength(5)
+    expect(
+      within(history!).getByRole('link', { name: /Original refinement audit/u }),
+    ).toBeInTheDocument()
+    expect(
+      within(history!).getByRole('link', { name: /Visual studies/u }),
+    ).toBeInTheDocument()
+  })
+
+  it('indexes product patterns and experiments as distinct catalogue sections', () => {
+    render(
+      <MemoryRouter>
+        <CatalogIndex />
+      </MemoryRouter>,
+    )
+
+    expect(screen.getByRole('heading', { name: 'Patterns' })).toBeInTheDocument()
+    expect(screen.getByRole('heading', { name: 'Experiments' })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /LoggingStable/u })).toBeInTheDocument()
+    expect(screen.getByRole('link', { name: /Logging v2Experimental/u })).toBeInTheDocument()
+  })
+
+  it('renders a registered fixture for a product-pattern document', () => {
+    render(<DocumentPage document={loggingPatternDocument} />)
+
+    expect(screen.getByTitle('Paper responsive component preview')).toHaveAttribute(
+      'data-fixture-id',
+      'pattern.logging-summary',
+    )
+  })
+
+  it('links source metadata to the registry-owned repository path', () => {
+    render(<DocumentPage document={buttonDocument} />)
+
+    expect(screen.getByRole('link', { name: buttonDocument.sourcePath })).toHaveAttribute(
+      'href',
+      `https://github.com/tadoku/tadoku/blob/main/frontend/packages/paper-ui/${buttonDocument.sourcePath}`,
+    )
+  })
+})

--- a/frontend/packages/paper-ui/src/catalog/phase-three-data-layout.tsx
+++ b/frontend/packages/paper-ui/src/catalog/phase-three-data-layout.tsx
@@ -93,7 +93,13 @@ export const phaseThreeDataLayoutFixtures = [
     densities: ["comfortable", "compact"],
     viewports: VIEWPORTS,
     deterministic: true,
-    code: `<Table caption="Recent reading" columns={columns} rows={[]} emptyMessage="No reading logged yet." />`,
+    code: `import { Table, type TableColumn } from "paper-ui";
+
+const columns = [
+  { id: "title", header: "Title", rowHeader: true, cell: (entry) => entry.title },
+] satisfies readonly TableColumn<{ title: string }>[];
+
+<Table caption="Recent reading" columns={columns} rows={[]} emptyMessage="No reading logged yet." />`,
     render: () => (
       <Table
         caption="Recent reading"

--- a/frontend/packages/paper-ui/tests/data-display-layout.test.tsx
+++ b/frontend/packages/paper-ui/tests/data-display-layout.test.tsx
@@ -189,6 +189,12 @@ describe("HeatmapChart", () => {
 });
 
 describe("Phase 3 data-display catalogue contracts", () => {
+  it("keeps every copied data-display example self-identifying with imports", () => {
+    for (const fixture of phaseThreeDataLayoutFixtures) {
+      expect(fixture.code, fixture.id).toContain('from "paper-ui"');
+    }
+  });
+
   it("publishes deterministic fixtures and complete valid Stable documents", () => {
     expect(
       validateCatalogRegistry({


### PR DESCRIPTION
## Summary

- make search and the mobile catalogue drawer keyboard-contained with deliberate initial focus and result navigation
- keep all workbench panels mounted so preview state and iframe documents survive view changes
- add real Clipboard API code copy with accessible success/error feedback
- give phone/tablet/desktop frames exact content-box widths for real media-query behavior
- initialize phone previews from the active viewport and render registered Pattern/Experiment fixtures
- add post-render deep-link scrolling and registry-derived source links
- add distinct Pattern and Experiment indexes plus discoverable audit, visual-study, decision, plan, and research history
- complete the copied empty-Table example and index the TypeScript tooling ADR

## Visual and behavior regressions

- 31 paper-styleguide tests, including 10 focused experience-stability cases
- 73 paper-ui tests
- 320px and desktop collaborative-browser review
- no document overflow at 320px
- exact 360px phone iframe and real registered fixture content

## Gates

- Paper TypeScript 7 typechecks
- package and styleguide ESLint
- paper-ui build, strict TS4.9 declaration consumer, and 36-file package validation
- paper-styleguide production build
- Paper boundary scan
- full seven-project frontend workspace build
- production-shaped Docker build and static-image smoke

The Vite build retains a non-failing 571.22 kB raw / 183.00 kB gzip single-chunk warning; static delivery/resource evidence is being measured separately against the exact deployed image.

## Scope

This is Phase 4 catalogue stabilization only. It does not modify or begin migration of admin, auth, webv2, or the legacy styleguide.