### PR TITLE
Document the Tadoku Paper Phase 4 deployment gate

### DIFF
--- a/docs/wip/tadoku-paper/README.md
+++ b/docs/wip/tadoku-paper/README.md
@@ -8,6 +8,8 @@ The studies intentionally include rejected directions. They document why the fin
 
 - [Decision log](decision-log.md)
 - [Implementation plan](implementation-plan.md) ([Presenter](https://presentr.lab/md/tadoku-paper-implementation-plan))
+- [Phase 4 gate report](artifacts/tadoku-paper-phase-4-gate.html) ([Presenter](https://presentr.lab/html/tadoku-paper-phase-4-gate))
+- [Phase 4 deployment evidence](research/phase-4-deployment-gate.md)
 - [Original design-system refinement audit](artifacts/design-system-refinement-audit.html)
 
 ## Visual studies
@@ -31,4 +33,4 @@ The original audit also remains published at [Presenter](https://presentr.lab/ht
 
 ## Status
 
-The discussion and implementation-planning phases are complete. The audit, visual studies, and decision log remain the design history; the implementation plan defines the phased delivery and application migrations.
+Phases 0–4 are complete and the authoritative Paper catalogue is live at [paper.tadoku.app](https://paper.tadoku.app). Execution stopped before Phase 5: Admin, Auth, webv2, and the legacy `ui.tadoku.app` deployment remain unchanged. The audit, visual studies, decision log, gate report, and implementation plan remain the permanent design and delivery history.

--- a/docs/wip/tadoku-paper/artifacts/tadoku-paper-phase-4-gate.html
+++ b/docs/wip/tadoku-paper/artifacts/tadoku-paper-phase-4-gate.html
@@ -1,0 +1,228 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Tadoku Paper — Phase 4 Gate Report</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+        --paper: #f4f0e8;
+        --sheet: #fffdf8;
+        --ink: #201a1c;
+        --muted: #6b6265;
+        --rule: #c9c0b5;
+        --violet: #5b46c6;
+        --green: #176b4b;
+        --green-soft: #dff3e9;
+        --amber: #8a5414;
+        --shadow: #d9d1c7;
+      }
+
+      * { box-sizing: border-box; }
+      html { background: var(--paper); color: var(--ink); font: 16px/1.55 system-ui, sans-serif; }
+      body { margin: 0; }
+      main { width: min(74rem, calc(100% - 2rem)); margin: 0 auto; padding: 2rem 0 6rem; }
+      header { border-inline-start: .4rem solid var(--violet); padding: 1rem 1.5rem 1.25rem; margin-bottom: 2rem; }
+      h1, h2, h3 { font-family: Georgia, serif; line-height: 1.08; text-wrap: balance; }
+      h1 { font-size: clamp(2.6rem, 8vw, 5.8rem); margin: .2rem 0 1rem; max-width: 12ch; }
+      h2 { font-size: clamp(1.7rem, 4vw, 2.6rem); margin: 3rem 0 1rem; }
+      h3 { font-size: 1.25rem; margin: 0 0 .5rem; }
+      p { max-width: 72ch; }
+      a { color: var(--violet); }
+      .eyebrow { color: var(--violet); font-weight: 800; letter-spacing: .12em; text-transform: uppercase; }
+      .lede { color: var(--muted); font-size: clamp(1.1rem, 2vw, 1.35rem); max-width: 65ch; }
+      .gate { display: inline-flex; align-items: center; gap: .6rem; background: var(--green-soft); color: var(--green); border: 2px solid var(--green); padding: .6rem .8rem; font-weight: 800; }
+      .gate::before { content: "✓"; font-size: 1.25rem; }
+      .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(14rem, 1fr)); gap: 1rem; }
+      .card { background: var(--sheet); border: 1px solid var(--rule); border-bottom: 3px solid var(--ink); padding: 1.1rem; box-shadow: .35rem .35rem 0 var(--shadow); }
+      .metric { font: 800 clamp(1.8rem, 5vw, 3rem)/1.1 Georgia, serif; display: block; }
+      .label { color: var(--muted); display: block; margin-top: .35rem; }
+      .panel { background: var(--sheet); border: 1px solid var(--rule); padding: clamp(1rem, 3vw, 1.75rem); overflow-x: auto; }
+      table { border-collapse: collapse; width: 100%; min-width: 42rem; }
+      th, td { border-bottom: 1px solid var(--rule); padding: .7rem .65rem; text-align: left; vertical-align: top; }
+      th { color: var(--muted); font-size: .8rem; letter-spacing: .06em; text-transform: uppercase; }
+      td:not(:first-child), th:not(:first-child) { text-align: right; }
+      code { background: color-mix(in srgb, var(--violet) 10%, transparent); padding: .1rem .25rem; }
+      ul { padding-inline-start: 1.3rem; }
+      li + li { margin-top: .45rem; }
+      .decision { border-inline-start: .35rem solid var(--green); padding: .8rem 1rem; background: var(--green-soft); }
+      .caution { border-inline-start: .35rem solid var(--amber); padding: .8rem 1rem; background: color-mix(in srgb, #f4d59a 35%, var(--sheet)); }
+      .mermaid { background: var(--sheet); border: 1px solid var(--rule); padding: 1rem; }
+      footer { margin-top: 4rem; color: var(--muted); border-top: 1px solid var(--rule); padding-top: 1rem; }
+
+      @media (prefers-color-scheme: dark) {
+        :root {
+          --paper: #181416;
+          --sheet: #231e20;
+          --ink: #f6eee8;
+          --muted: #bfb4b5;
+          --rule: #4c4245;
+          --violet: #aa9aff;
+          --green: #7dd8ac;
+          --green-soft: #17382b;
+          --amber: #e5ae67;
+          --shadow: #0e0b0c;
+        }
+      }
+
+      @media (max-width: 36rem) {
+        main { width: min(100% - 1rem, 74rem); padding-top: 1rem; }
+        header { padding-inline-end: .5rem; }
+        .card { box-shadow: .2rem .2rem 0 var(--shadow); }
+      }
+
+      @media print {
+        :root { color-scheme: light; }
+        main { width: 100%; padding: 0; }
+        .card { box-shadow: none; }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <div class="eyebrow">Tadoku design system · 2026-08-08</div>
+        <h1>Paper is ready for application migration.</h1>
+        <p class="lede">Phase 4 is complete: the authoritative Paper catalogue is built, deployed, visually reviewed, production-smoked, and measured. Work stops here before Admin, Auth, or webv2 migration begins.</p>
+        <div class="gate">Phase 4 gate passed</div>
+      </header>
+
+      <section aria-labelledby="identity">
+        <h2 id="identity">Immutable production identity</h2>
+        <div class="cards">
+          <article class="card"><h3>Source</h3><span class="metric">f297aa7</span><span class="label">Phase 4 catalogue commit</span></article>
+          <article class="card"><h3>Image</h3><span class="metric">4f15ab54</span><span class="label">Immutable SHA-256 digest prefix</span></article>
+          <article class="card"><h3>Static bundle</h3><span class="metric">3.70 MB</span><span class="label">10 Vite output files, uncompressed</span></article>
+          <article class="card"><h3>Container</h3><span class="metric">22.33 MB</span><span class="label">Compressed linux/amd64 layers</span></article>
+        </div>
+        <p><code>ghcr.io/tadoku/tadoku/frontend-paper-styleguide:prod@sha256:4f15ab54ef5d6844df798ad3b08530f1a162ee0c6424a77977a362786a07b714</code></p>
+      </section>
+
+      <section aria-labelledby="sequence">
+        <h2 id="sequence">Delivered boundary</h2>
+        <pre class="mermaid">
+flowchart LR
+  P0[Phase 0\nResearch] --> P1[Phase 1\nFoundation]
+  P1 --> P2[Phase 2\nVertical slice]
+  P2 --> P3[Phase 3\nCatalogue]
+  P3 --> P4[Phase 4\nStabilize + deploy]
+  P4 --> STOP{{STOP}}
+  STOP -. explicit future authorization .-> P5[Phase 5\nAdmin migration]
+  classDef done fill:#dff3e9,stroke:#176b4b,color:#176b4b,stroke-width:2px;
+  classDef stop fill:#f4d59a,stroke:#8a5414,color:#8a5414,stroke-width:3px;
+  class P0,P1,P2,P3,P4 done;
+  class STOP stop;
+        </pre>
+      </section>
+
+      <section aria-labelledby="experience">
+        <h2 id="experience">Catalogue and visual QA</h2>
+        <div class="panel">
+          <ul>
+            <li>All 40 canonical catalogue routes are generated from one typed registry, with 17 planned legacy redirects.</li>
+            <li>Every stable component has instructional content, realistic Tadoku fixtures, source metadata, behavior coverage, and searchable navigation.</li>
+            <li>Preview, Code, API/Props, and Accessibility panels preserve iframe state; code copy uses the Clipboard API with accessible success/error feedback.</li>
+            <li>Phone, tablet, and desktop canvases use exact 360/768/1280 content-box widths so real media queries execute.</li>
+            <li>Keyboard search, result navigation, drawer/search focus containment, focus restoration, and deep-link scrolling were exercised in production.</li>
+            <li>The visual QA round fixed clipped accent rails, mobile header overflow, oversized index cards, leaked iframe resets, selected-control contrast, raw glyphs, and the dark wordmark.</li>
+          </ul>
+        </div>
+        <div class="cards" style="margin-top:1rem">
+          <article class="card"><h3>Mobile viewport</h3><span class="metric">320×700</span><span class="label">0 px horizontal overflow</span></article>
+          <article class="card"><h3>Deep link</h3><span class="metric">96 px</span><span class="label">Accessibility heading below sticky header</span></article>
+          <article class="card"><h3>Fixture width</h3><span class="metric">360 px</span><span class="label">Exact phone iframe width</span></article>
+          <article class="card"><h3>Automated UI</h3><span class="metric">104 tests</span><span class="label">73 paper-ui + 31 styleguide</span></article>
+        </div>
+      </section>
+
+      <section aria-labelledby="delivery">
+        <h2 id="delivery">Static delivery</h2>
+        <div class="panel">
+          <table>
+            <thead><tr><th>Check</th><th>Result</th><th>Evidence</th></tr></thead>
+            <tbody>
+              <tr><td>Nested document requests</td><td>Pass</td><td>All 40 canonical routes return the SPA shell</td></tr>
+              <tr><td>HTML caching</td><td>Pass</td><td><code>cache-control: no-cache</code></td></tr>
+              <tr><td>Hashed assets</td><td>Pass</td><td>gzip + one-year immutable cache</td></tr>
+              <tr><td>Missing assets</td><td>Pass</td><td><code>/assets/missing.*</code> returns 404</td></tr>
+              <tr><td>Sensitive dot paths</td><td>Pass</td><td><code>/.env</code> and <code>/.git/config</code> return 404</td></tr>
+              <tr><td>Health and rollout</td><td>Pass</td><td><code>/healthz</code> 200; maxUnavailable 0; one Ready endpoint retained</td></tr>
+              <tr><td>Pod state</td><td>Pass</td><td>1/1 Ready, zero restarts, exact digest</td></tr>
+            </tbody>
+          </table>
+        </div>
+      </section>
+
+      <section aria-labelledby="resources">
+        <h2 id="resources">Three-run production resource gate</h2>
+        <p>Each fresh pod completed 15 minutes idle, cold asset and canonical-route loads, representative navigation, five minutes at 1 request/second, one minute at concurrency 10, and five minutes recovery.</p>
+        <div class="cards">
+          <article class="card"><h3>Responses</h3><span class="metric">49,516</span><span class="label">0 failures including control runs</span></article>
+          <article class="card"><h3>Warm Ready</h3><span class="metric">2.0 s</span><span class="label">Worst container start → Ready</span></article>
+          <article class="card"><h3>Working peak</h3><span class="metric">11.48 MB</span><span class="label">17.1% of the 64Mi limit</span></article>
+          <article class="card"><h3>Burst throttle</h3><span class="metric">0.17%</span><span class="label">Worst; gate is below 5%</span></article>
+        </div>
+        <div class="panel" style="margin-top:1rem">
+          <table>
+            <thead><tr><th>Run</th><th>Ready</th><th>Idle CPU</th><th>Sustained CPU</th><th>Burst avg</th><th>Idle memory</th><th>Peak memory</th><th>Throttle</th><th>Recovery</th></tr></thead>
+            <tbody>
+              <tr><td>1</td><td>2.0 s</td><td>0.160m</td><td>0.328m</td><td>37.9m</td><td>4.45 MB</td><td>11.48 MB</td><td>0.17%</td><td>+4.2%</td></tr>
+              <tr><td>2</td><td>2.0 s</td><td>0.379m</td><td>0.336m</td><td>42.7m</td><td>6.23 MB</td><td>11.31 MB</td><td>0%</td><td>−6.2%</td></tr>
+              <tr><td>3</td><td>1.0 s</td><td>0.147m</td><td>0.341m</td><td>46.4m</td><td>4.29 MB</td><td>11.40 MB</td><td>0.17%</td><td>−7.4%</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p>Three observer-neutral navigation controls added 60 requests with zero failures and zero throttled periods. The normal boundary snapshots run inside the tiny cgroup and explain isolated control increments.</p>
+      </section>
+
+      <section aria-labelledby="selection">
+        <h2 id="selection">Selected requests and limits</h2>
+        <div class="panel">
+          <table>
+            <thead><tr><th>Resource</th><th>Formula result</th><th>Selected</th><th>Decision</th></tr></thead>
+            <tbody>
+              <tr><td>CPU request</td><td>&lt;5m, floor 10m</td><td>10m</td><td>Sustained worst is 0.341m</td></tr>
+              <tr><td>CPU limit</td><td>110m from partial sampled p99</td><td>250m</td><td>Keep conservative ceiling; do not lower on a truncated API stream</td></tr>
+              <tr><td>Memory request</td><td>12Mi, floor 32Mi</td><td>32Mi</td><td>Navigation worst is 9.11 MB</td></tr>
+              <tr><td>Memory limit</td><td>24Mi, floor 64Mi</td><td>64Mi</td><td>Worst peak is 11.48 MB with &gt;52Mi headroom</td></tr>
+            </tbody>
+          </table>
+        </div>
+        <p class="decision"><strong>Decision:</strong> retain the deployed <code>10m/32Mi</code> requests and <code>250m/64Mi</code> limits. No GitOps resource change is warranted.</p>
+        <p class="caution"><strong>Measurement limitation:</strong> the cluster has no Metrics API, and the API server resets a continuous <code>kubectl exec</code> stream after roughly 30 seconds. The valid 27-second sample measured 52.626m p99; full-minute boundary counters are complete. The reproducible driver now uses three 20-second streams for future complete p99 collection.</p>
+      </section>
+
+      <section aria-labelledby="gates">
+        <h2 id="gates">Source and deployment gates</h2>
+        <div class="panel">
+          <ul>
+            <li><code>paper-ui</code>: 73 tests, lint, TypeScript 7 package check, build, TS 4.9 declaration consumer, pack smoke.</li>
+            <li><code>paper-styleguide</code>: 31 tests, lint, TypeScript 7 package check, Vite production build.</li>
+            <li>Full seven-project frontend build and Paper boundary scan passed.</li>
+            <li>Production Docker image build and static-image smoke passed before publication.</li>
+            <li>GitHub quality, image, boundary, and SQL checks passed on the source PR.</li>
+            <li>Production browser smoke passed at desktop and 320×700 mobile, in light/dark and key keyboard/focus flows during visual QA.</li>
+          </ul>
+        </div>
+      </section>
+
+      <section aria-labelledby="followups">
+        <h2 id="followups">Follow-up opportunities</h2>
+        <ul>
+          <li>Split the current 571.22 kB raw / 183.00 kB gzip application chunk by route or catalogue section. This is a performance improvement, not a static-server resource blocker.</li>
+          <li>Add cluster metrics and browser visual regression infrastructure, then cross-check one cgroup run against telemetry.</li>
+          <li>Begin Admin migration only under a new explicit authorization. Auth, webv2, and the legacy <code>ui.tadoku.app</code> deployment remain unchanged.</li>
+        </ul>
+      </section>
+
+      <footer>
+        <p>Authoritative catalogue: <a href="https://paper.tadoku.app">paper.tadoku.app</a> · Raw observations and the measurement driver live with the Tadoku Paper research archive.</p>
+      </footer>
+    </main>
+    <script type="module">
+      import mermaid from "https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs";
+      mermaid.initialize({ startOnLoad: true, theme: matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "neutral" });
+    </script>
+  </body>
+</html>

--- a/docs/wip/tadoku-paper/implementation-plan.md
+++ b/docs/wip/tadoku-paper/implementation-plan.md
@@ -1,12 +1,14 @@
 # Tadoku Paper implementation plan
 
-Status: ready for implementation
+Status: Phases 0–4 complete; execution stopped before Phase 5 application migration
 
 Last updated: 2026-08-08
 
 Decision source: [decision-log.md](decision-log.md)
 
 Design history: [README.md](README.md)
+
+Execution evidence: [Phase 4 deployment gate](research/phase-4-deployment-gate.md) and [HTML gate report](artifacts/tadoku-paper-phase-4-gate.html)
 
 ## Outcome
 

--- a/docs/wip/tadoku-paper/research/phase-4-deployment-gate.md
+++ b/docs/wip/tadoku-paper/research/phase-4-deployment-gate.md
@@ -1,0 +1,37 @@
+# Tadoku Paper Phase 4 deployment gate
+
+Status: **passed on 2026-08-08**
+
+The complete report is available as [the repository HTML artifact](../artifacts/tadoku-paper-phase-4-gate.html) and [the Presentr copy](https://presentr.lab/html/tadoku-paper-phase-4-gate). Raw counter snapshots and request summaries are preserved in [phase-4-resource-observations.md](phase-4-resource-observations.md); the repeatable driver is [scripts/measure-paper-resources.sh](scripts/measure-paper-resources.sh).
+
+## Production identity
+
+- Tadoku commit: `f297aa7899d54dba2302d6d26f377fe9fe9d570b`
+- Image: `ghcr.io/tadoku/tadoku/frontend-paper-styleguide:prod@sha256:4f15ab54ef5d6844df798ad3b08530f1a162ee0c6424a77977a362786a07b714`
+- Base image: `nginxinc/nginx-unprivileged:1.27-alpine@sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0`
+- Static output: 10 files, 3,696,801 uncompressed bytes
+- Registry image: linux/amd64 manifest `sha256:43f3a5e40be55ac899c8bf45c7c4862617baecd4d2a29c9db46b574b5349b19c`, 22,325,290 compressed layer bytes
+- Deployment: `lke20948-ctx/tdk-prod-paper-styleguide/tadoku-paper-styleguide`, rolling update with `maxUnavailable: 0`
+
+## Gate result
+
+- Source gates: 73 `paper-ui` tests, 31 styleguide tests, both lint/typecheck/build suites, TS 4.9 declaration consumer, pack smoke, Paper boundary scan, seven-project frontend build, production image build and image smoke passed.
+- Production content: all 40 canonical routes, static assets, SPA fallback, nested routes, health, caching, gzip, immutable assets, dot-path rejection, and missing-asset behavior passed.
+- Production visual/interaction: desktop plus 320×700 mobile, no horizontal overflow, exact 360px fixture width, drawer/search focus behavior, keyboard search navigation, persistent workbench panels, copy feedback, dark wordmark, and direct hash positioning passed.
+- Three production-shaped fresh-pod runs completed 49,456 requests with zero failed responses, restarts, OOM/pressure events, probe warnings, or readiness loss. Three observer-neutral navigation controls added 60 successes and zero throttled periods.
+- Container readiness was 2s, 2s, and 1s. Worst sustained CPU was `0.341m`; worst burst throttling was `0.17%`; worst memory peak was 11.48 MB; worst recovery delta was +4.2%.
+
+## Resource decision
+
+| Resource | Formula | Selected |
+| --- | ---: | ---: |
+| CPU request | below 5m; 10m floor | `10m` |
+| CPU limit | 110m from valid partial p99 | `250m` |
+| Memory request | 12Mi; 32Mi floor | `32Mi` |
+| Memory limit | 24Mi; 64Mi floor | `64Mi` |
+
+The existing values stay unchanged. The cluster has no Metrics API and reset the continuous exec sampler after 27 valid one-second samples; its p99 was `52.626m`, and complete boundary counters show burst averages of `37.9m`, `42.7m`, and `46.4m`. The safer `250m` limit remains until complete telemetry justifies lowering it. No GitOps resource PR is needed.
+
+## Stop boundary
+
+`paper.tadoku.app` is the authoritative Paper catalogue. `ui.tadoku.app` remains the independent legacy catalogue. Admin, Auth, webv2, and production application migration work have not started. Phase 5 requires a new explicit authorization.

--- a/docs/wip/tadoku-paper/research/phase-4-resource-observations.md
+++ b/docs/wip/tadoku-paper/research/phase-4-resource-observations.md
@@ -1,0 +1,143 @@
+# Tadoku Paper Phase 4 raw resource observations
+
+Measurement date: 2026-08-08 UTC
+
+Source commit: `f297aa7899d54dba2302d6d26f377fe9fe9d570b`
+
+Image digest: `sha256:4f15ab54ef5d6844df798ad3b08530f1a162ee0c6424a77977a362786a07b714`
+
+Environment: `lke20948-ctx`, namespace `tdk-prod-paper-styleguide`, deployment `tadoku-paper-styleguide`, node architecture `x86_64`, public traffic through `https://paper.tadoku.app`.
+
+Configured resources: CPU request `10m`, CPU limit `250m`, memory request `32Mi`, memory limit `64Mi`.
+
+The reproducible driver is [scripts/measure-paper-resources.sh](scripts/measure-paper-resources.sh). Each run used a fresh rolling-restart pod, 15 minutes of probe-only idle, all static files, all 40 canonical routes, 20 representative navigation routes, 300 requests at 1 request/second, 60 seconds at concurrency 10, and five minutes of recovery. Every `memory.events` counter was zero in every snapshot. Short `kubectl exec` snapshots execute inside the measured cgroup and can add one throttled period; the observer-neutral navigation controls below separate that cost from traffic.
+
+## Run 1
+
+Pod `tadoku-paper-styleguide-5f9f6d4c76-7c5pn`; pod start to Ready 4,000 ms; container start to Ready 2,000 ms; zero restarts and warning events.
+
+```csv
+label,memory.current,memory.peak,cpu.usage_usec,cpu.nr_periods,cpu.nr_throttled,cpu.throttled_usec
+ready,7979008,10321920,95121,5,1,52164
+idle_00,8192000,10588160,128626,7,2,92212
+idle_05,4448256,10588160,176566,32,3,164213
+idle_10,4399104,10588160,219509,53,3,164213
+idle_15,4411392,10588160,263275,74,4,209117
+cold_catalogue_before,4714496,10588160,296198,77,5,278009
+cold_catalogue_after,9035776,11456512,335088,85,5,278009
+deep_links_before,9166848,11472896,367508,87,6,319014
+deep_links_after,9052160,11476992,405165,98,7,361315
+navigation_before,9142272,11476992,438965,100,8,405775
+navigation_after,9109504,11476992,475011,106,9,438328
+sustained_before,9043968,11481088,507598,108,10,490248
+sustained_after,4419584,11481088,610670,240,11,537315
+burst_before,4354048,11481088,644647,242,12,576071
+burst_after,4599808,11481088,2953892,845,13,597265
+recovery_05,4534272,11481088,3003835,866,13,597265
+```
+
+| Scenario | Requests | Failures | Average latency | Maximum latency |
+| --- | ---: | ---: | ---: | ---: |
+| Cold catalogue | 11 | 0 | 66.7 ms | 306.8 ms |
+| Canonical deep links | 40 | 0 | 23.8 ms | 96.4 ms |
+| Representative navigation | 20 | 0 | 21.4 ms | 22.8 ms |
+| Sustained | 300 | 0 | 42.7 ms | 466.7 ms |
+| Burst | 15,839 | 0 | 33.8 ms | 5,178.7 ms |
+
+Sustained CPU averaged `0.328m`. Burst CPU averaged `37.9m`; 1 of 603 active cgroup periods was throttled (`0.17%`). Recovery memory was `4.2%` above the pre-burst level. PID 1 settled at `1,324–1,400 kB` RSS with a `5,512 kB` HWM.
+
+## Run 2
+
+Pod `tadoku-paper-styleguide-7b8bd66658-g6jk4`; pod start to Ready 4,000 ms; container start to Ready 2,000 ms; zero restarts and warning events.
+
+```csv
+label,memory.current,memory.peak,cpu.usage_usec,cpu.nr_periods,cpu.nr_throttled,cpu.throttled_usec
+ready,8101888,10887168,99756,5,0,0
+idle_00,8208384,10887168,132753,8,1,56152
+idle_05,4894720,10887168,183111,31,2,96149
+idle_10,6230016,10887168,297261,62,2,96149
+idle_15,4481024,10887168,342509,83,3,168303
+cold_catalogue_before,4255744,10887168,376659,85,4,169953
+cold_catalogue_after,8933376,11313152,418185,91,5,227417
+deep_links_before,8855552,11313152,452630,93,6,268603
+deep_links_after,8843264,11313152,488367,104,7,310373
+navigation_before,8871936,11313152,522785,106,8,362738
+navigation_after,8601600,11313152,560550,112,8,362738
+sustained_before,8548352,11313152,593785,114,8,362738
+sustained_after,4366336,11313152,699412,246,9,378618
+burst_before,4472832,11313152,730803,248,10,395829
+burst_after,4894720,11313152,3332803,851,10,395829
+recovery_05,4194304,11313152,3378665,874,11,429848
+```
+
+| Scenario | Requests | Failures | Average latency | Maximum latency |
+| --- | ---: | ---: | ---: | ---: |
+| Cold catalogue | 11 | 0 | 31.5 ms | 54.0 ms |
+| Canonical deep links | 40 | 0 | 21.4 ms | 23.7 ms |
+| Representative navigation | 20 | 0 | 21.4 ms | 23.4 ms |
+| Sustained | 300 | 0 | 32.0 ms | 578.0 ms |
+| Burst | 16,509 | 0 | 32.0 ms | 3,111.4 ms |
+
+Sustained CPU averaged `0.336m`. Burst CPU averaged `42.7m`; 0 of 603 active cgroup periods was throttled. Recovery memory was `6.2%` below the pre-burst level. PID 1 settled at `1,328 kB` RSS with a `5,524 kB` HWM.
+
+The first p99 sampler revision had a shell-quoting defect. It did not affect traffic or the authoritative boundary counters and its output is excluded.
+
+## Run 3
+
+Pod `tadoku-paper-styleguide-c948b7f95-x5clw`; pod start to Ready 3,000 ms; container start to Ready 1,000 ms; zero restarts and warning events.
+
+```csv
+label,memory.current,memory.peak,cpu.usage_usec,cpu.nr_periods,cpu.nr_throttled,cpu.throttled_usec
+ready,8458240,10596352,104560,5,2,89784
+idle_00,8642560,10850304,140816,7,2,89784
+idle_05,4227072,10850304,184936,28,3,133889
+idle_10,4169728,10850304,228527,47,4,175728
+idle_15,4288512,10850304,271768,68,5,200377
+cold_catalogue_before,4304896,10850304,307113,70,6,248377
+cold_catalogue_after,8990720,11395072,347006,78,7,313171
+deep_links_before,8663040,11395072,380605,80,8,316536
+deep_links_after,8753152,11395072,417740,90,8,316536
+navigation_before,8687616,11395072,449448,92,9,353994
+navigation_after,8130560,11395072,485674,98,10,423211
+sustained_before,8056832,11395072,518436,100,11,464516
+sustained_after,4448256,11395072,624882,231,12,504515
+burst_before,4546560,11395072,659756,233,12,504515
+burst_after,4620288,11395072,3441610,834,13,564515
+recovery_05,4210688,11395072,3494498,856,14,604513
+```
+
+| Scenario | Requests | Failures | Average latency | Maximum latency |
+| --- | ---: | ---: | ---: | ---: |
+| Cold catalogue | 11 | 0 | 75.8 ms | 525.6 ms |
+| Canonical deep links | 40 | 0 | 23.0 ms | 43.2 ms |
+| Representative navigation | 20 | 0 | 25.4 ms | 85.9 ms |
+| Sustained | 300 | 0 | 34.3 ms | 499.7 ms |
+| Burst | 15,995 | 0 | 33.2 ms | 5,183.3 ms |
+
+Sustained CPU averaged `0.341m`. Burst CPU averaged `46.4m`; 1 of 601 active cgroup periods was throttled (`0.17%`). A valid 27-second one-second sampler measured `52.626m` p99 and zero throttling; the Kubernetes API server reset the long-running exec stream before 60 seconds. Recovery memory was `7.4%` below the pre-burst level. PID 1 settled at `1,324 kB` RSS with a `5,568 kB` HWM.
+
+## Observer-neutral navigation controls
+
+The normal before/after snapshots execute inside the measured cgroup. Three additional repetitions established the baseline after the observer became idle, issued the same 20 public navigation requests, then read the ending counter with shell builtins.
+
+| Repetition | Requests | Failures | CPU use | Active periods | Throttled periods |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 1 | 20 | 0 | 4,944 µs | 8 | 0 |
+| 2 | 20 | 0 | 3,908 µs | 6 | 0 |
+| 3 | 20 | 0 | 4,317 µs | 6 | 0 |
+
+## Aggregates
+
+| Measurement | Median | Worst |
+| --- | ---: | ---: |
+| Container start to Ready | 2.0 s | 2.0 s |
+| Settled idle CPU | 0.160m | 0.379m |
+| Sustained CPU | 0.336m | 0.341m |
+| Burst average CPU | 42.7m | 46.4m |
+| Settled idle memory | 4.45 MB | 6.23 MB |
+| Representative-navigation memory | 8.60 MB | 9.11 MB |
+| Working peak memory | 11.40 MB | 11.48 MB |
+| Burst throttling | 0.17% | 0.17% |
+| Recovery delta | −6.2% | +4.2% |
+
+Across the three primary runs, 49,456 responses completed with zero failure. The observer-neutral controls add 60 successful navigation responses.

--- a/docs/wip/tadoku-paper/research/scripts/measure-paper-resources.sh
+++ b/docs/wip/tadoku-paper/research/scripts/measure-paper-resources.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+context="${KUBE_CONTEXT:-lke20948-ctx}"
+namespace="${KUBE_NAMESPACE:-tdk-prod-paper-styleguide}"
+deployment="${KUBE_DEPLOYMENT:-tadoku-paper-styleguide}"
+base_url="${PAPER_BASE_URL:-https://paper.tadoku.app}"
+run="${1:?usage: measure-paper-resources.sh RUN_NUMBER}"
+
+repo_root="$(git rev-parse --show-toplevel)"
+catalog_dir="$repo_root/frontend/packages/paper-ui/src/catalog"
+dist_dir="$repo_root/frontend/apps/paper-styleguide/dist"
+
+snapshot() {
+  local label="$1"
+  local pod="$2"
+
+  printf 'SNAPSHOT_BEGIN label=%s timestamp=%s pod=%s\n' "$label" "$(date -u +%FT%TZ)" "$pod"
+  kubectl --context "$context" --namespace "$namespace" exec "$pod" -- sh -c '
+    printf "memory.current="; cat /sys/fs/cgroup/memory.current
+    printf "memory.peak="; cat /sys/fs/cgroup/memory.peak
+    sed "s/^/memory.events./" /sys/fs/cgroup/memory.events
+    sed "s/^/cpu.stat./" /sys/fs/cgroup/cpu.stat
+    awk "/VmRSS|VmHWM/ {print \"pid1.\" \$1 \"=\" \$2 \" \" \$3}" /proc/1/status
+  '
+  printf 'SNAPSHOT_END label=%s\n' "$label"
+}
+
+latest_ready_pod() {
+  kubectl --context "$context" --namespace "$namespace" get pods \
+    -l 'app=tadoku-paper-styleguide' \
+    --sort-by=.metadata.creationTimestamp \
+    -o json | jq -r '[.items[] | select(any(.status.conditions[]?; .type == "Ready" and .status == "True"))][-1].metadata.name // empty'
+}
+
+wait_for_new_ready_pod() {
+  local old_pod="$1"
+  local deadline=$((SECONDS + 180))
+  local candidate=""
+
+  while (( SECONDS < deadline )); do
+    candidate="$(latest_ready_pod)"
+    if [[ -n "$candidate" && "$candidate" != "$old_pod" ]]; then
+      printf '%s\n' "$candidate"
+      return 0
+    fi
+    sleep 1
+  done
+
+  printf 'new ready pod did not appear within 180 seconds\n' >&2
+  return 1
+}
+
+request_once() {
+  local path="$1"
+  curl --silent --show-error --output /dev/null \
+    --write-out '%{http_code} %{time_total}\n' \
+    --header 'Cache-Control: no-cache' \
+    "$base_url$path"
+}
+
+summarize_requests() {
+  local label="$1"
+  awk -v label="$label" '
+    { count += 1; total += $2; if ($1 < 200 || $1 >= 400) failures += 1; if ($2 > maximum) maximum = $2 }
+    END { printf "TRAFFIC label=%s requests=%d failures=%d latency_avg_seconds=%.6f latency_max_seconds=%.6f\n", label, count, failures, count ? total / count : 0, maximum }
+  '
+}
+
+mapfile -t canonical_routes < <(
+  rg --no-filename --only-matching 'route: "[^"]+"' "$catalog_dir" \
+    | sed -E 's/route: "([^"]+)"/\1/' \
+    | sort -u
+)
+
+mapfile -t static_paths < <(
+  find "$dist_dir" -type f -printf '/%P\n' | sort
+)
+
+printf 'RUN_BEGIN run=%s timestamp=%s commit=%s\n' "$run" "$(date -u +%FT%TZ)" "$(git rev-parse origin/main)"
+printf 'ENV context=%s namespace=%s deployment=%s base_url=%s node_arch=%s\n' \
+  "$context" "$namespace" "$deployment" "$base_url" "$(uname -m)"
+printf 'ROUTES canonical=%s static_files=%s\n' "${#canonical_routes[@]}" "${#static_paths[@]}"
+
+old_pod="$(latest_ready_pod)"
+rollout_started_epoch="$(date +%s%3N)"
+kubectl --context "$context" --namespace "$namespace" rollout restart "deployment/$deployment"
+pod="$(wait_for_new_ready_pod "$old_pod")"
+rollout_ready_epoch="$(date +%s%3N)"
+
+pod_json="$(kubectl --context "$context" --namespace "$namespace" get pod "$pod" -o json)"
+pod_started="$(jq -r '.status.startTime' <<<"$pod_json")"
+container_started="$(jq -r '.status.containerStatuses[0].state.running.startedAt' <<<"$pod_json")"
+pod_ready="$(jq -r '.status.conditions[] | select(.type == "Ready") | .lastTransitionTime' <<<"$pod_json")"
+started_epoch="$(date -u -d "$pod_started" +%s%3N)"
+container_started_epoch="$(date -u -d "$container_started" +%s%3N)"
+ready_epoch="$(date -u -d "$pod_ready" +%s%3N)"
+printf 'STARTUP pod=%s previous_pod=%s rollout_milliseconds=%s pod_ready_milliseconds=%s container_ready_milliseconds=%s pod_started=%s container_started=%s ready=%s image_id=%s\n' \
+  "$pod" "$old_pod" "$((rollout_ready_epoch - rollout_started_epoch))" "$((ready_epoch - started_epoch))" \
+  "$((ready_epoch - container_started_epoch))" "$pod_started" "$container_started" "$pod_ready" \
+  "$(jq -r '.status.containerStatuses[0].imageID' <<<"$pod_json")"
+
+snapshot ready "$pod"
+snapshot idle_00 "$pod"
+sleep 300
+snapshot idle_05 "$pod"
+sleep 300
+snapshot idle_10 "$pod"
+sleep 300
+snapshot idle_15 "$pod"
+
+snapshot cold_catalogue_before "$pod"
+{
+  request_once /index.html
+  for path in "${static_paths[@]}"; do
+    request_once "$path"
+  done
+} | summarize_requests cold_catalogue
+snapshot cold_catalogue_after "$pod"
+
+snapshot deep_links_before "$pod"
+for path in "${canonical_routes[@]}"; do
+  request_once "$path"
+done | summarize_requests deep_links
+snapshot deep_links_after "$pod"
+
+navigation_routes=(
+  /foundations/color
+  /components/actions/button
+  /components/forms/input
+  /components/navigation/navbar
+  /components/navigation/sidebar
+  /components/navigation/breadcrumb
+  /components/navigation/tabbar
+  /components/navigation/vertical-tabbar
+  /components/navigation/pagination
+  /components/data-display/table
+  /components/data-display/heatmap-chart
+  /components/feedback/flash
+  /components/feedback/toast
+  /components/overlays/modal
+  /patterns/logging
+  /experiments/logging-v2
+  /foundations/typography
+  /foundations/layout
+  /contributing
+  /changelog
+)
+
+snapshot navigation_before "$pod"
+for path in "${navigation_routes[@]}"; do
+  request_once "$path"
+done | summarize_requests navigation
+snapshot navigation_after "$pod"
+
+traffic_routes=(/ /components/actions/button /components/data-display/table /patterns/logging)
+snapshot sustained_before "$pod"
+{
+  for ((request_index = 0; request_index < 300; request_index += 1)); do
+    request_once "${traffic_routes[$((request_index % ${#traffic_routes[@]}))]}"
+    sleep 1
+  done
+} | summarize_requests sustained
+snapshot sustained_after "$pod"
+
+burst_dir="$(mktemp -d)"
+trap 'rm -rf -- "$burst_dir"' EXIT
+snapshot burst_before "$pod"
+for ((segment = 0; segment < 3; segment += 1)); do
+  (
+    sleep "$((segment * 20))"
+    kubectl --context "$context" --namespace "$namespace" exec "$pod" -- sh -c '
+      previous_usage="$(grep "^usage_usec " /sys/fs/cgroup/cpu.stat | cut -d " " -f 2)"
+      previous_periods="$(grep "^nr_periods " /sys/fs/cgroup/cpu.stat | cut -d " " -f 2)"
+      previous_throttled="$(grep "^nr_throttled " /sys/fs/cgroup/cpu.stat | cut -d " " -f 2)"
+      sample=0
+      while [ "$sample" -lt 20 ]; do
+        sleep 1
+        usage="$(grep "^usage_usec " /sys/fs/cgroup/cpu.stat | cut -d " " -f 2)"
+        periods="$(grep "^nr_periods " /sys/fs/cgroup/cpu.stat | cut -d " " -f 2)"
+        throttled="$(grep "^nr_throttled " /sys/fs/cgroup/cpu.stat | cut -d " " -f 2)"
+        printf "%s %s %s\n" "$((usage - previous_usage))" "$((periods - previous_periods))" "$((throttled - previous_throttled))"
+        previous_usage="$usage"
+        previous_periods="$periods"
+        previous_throttled="$throttled"
+        sample=$((sample + 1))
+      done
+    '
+  ) >"$burst_dir/cpu-samples-$segment" &
+done
+for ((worker = 0; worker < 10; worker += 1)); do
+  worker_path="${traffic_routes[$((worker % ${#traffic_routes[@]}))]}"
+  timeout 60 bash -c '
+    while true; do
+      curl --silent --show-error --output /dev/null \
+        --write-out "%{http_code} %{time_total}\\n" \
+        "$1$2"
+    done
+  ' _ "$base_url" "$worker_path" >"$burst_dir/worker-$worker" &
+done
+wait || true
+cat "$burst_dir"/worker-* | summarize_requests burst
+sort -n "$burst_dir"/cpu-samples-* | awk '
+  { usage[NR] = $1; periods += $2; throttled += $3 }
+  END {
+    percentile = int((NR * 99 + 99) / 100)
+    printf "BURST_CPU samples=%d p99_millicores=%.3f periods=%d throttled=%d throttled_percent=%.3f\n", NR, usage[percentile] / 1000, periods, throttled, periods ? throttled * 100 / periods : 0
+  }
+'
+snapshot burst_after "$pod"
+
+sleep 300
+snapshot recovery_05 "$pod"
+
+final_json="$(kubectl --context "$context" --namespace "$namespace" get pod "$pod" -o json)"
+printf 'POD_FINAL restarts=%s ready=%s phase=%s\n' \
+  "$(jq -r '.status.containerStatuses[0].restartCount' <<<"$final_json")" \
+  "$(jq -r '.status.containerStatuses[0].ready' <<<"$final_json")" \
+  "$(jq -r '.status.phase' <<<"$final_json")"
+kubectl --context "$context" --namespace "$namespace" get events \
+  --field-selector "involvedObject.name=$pod,type=Warning" \
+  -o json | jq -c '{warning_events: [.items[] | {reason, message, count}]}'
+printf 'RUN_END run=%s timestamp=%s\n' "$run" "$(date -u +%FT%TZ)"


### PR DESCRIPTION
## What changed

- records the final Phase 4 deployment and resource gate
- preserves three production-shaped runs with raw cgroup/request observations
- adds the reproducible measurement driver
- publishes and indexes the user-facing HTML gate report
- marks execution as stopped before Phase 5 application migration

## Why

The Paper plan requires a measured production gate before application migration starts. This makes the exact source/image identity, visual QA, static-delivery checks, resource selection, limitations, and stop boundary durable and reviewable.

## Impact

Documentation and measurement tooling only. No package, application, deployment, GitOps, Admin, Auth, webv2, or legacy styleguide files change.

## Validation

- three complete production-shaped runs: 49,456 responses, zero failures/restarts/OOM/probe warnings
- three observer-neutral navigation controls: 60 responses, zero failures/throttling
- production desktop and 320×700 browser smoke
- Presentr rendering and artifact SHA match
- `bash -n docs/wip/tadoku-paper/research/scripts/measure-paper-resources.sh`
- `git diff --check`
- `cd frontend && pnpm build` (all seven projects)
