### PR TITLE
Fix the Tadoku Paper header wordmark alignment

### DIFF
--- a/frontend/apps/paper-styleguide/src/styles/shell.css
+++ b/frontend/apps/paper-styleguide/src/styles/shell.css
@@ -92,6 +92,7 @@
     display: grid;
     place-items: center;
     inline-size: 2.25rem;
+    block-size: 2.25rem;
     aspect-ratio: 1;
     color: var(--paper-color-action-default);
   }

--- a/frontend/apps/paper-styleguide/tests/visual-contract.test.tsx
+++ b/frontend/apps/paper-styleguide/tests/visual-contract.test.tsx
@@ -84,6 +84,9 @@ describe('responsive visual contract', () => {
     expect(browse.querySelector('svg')).not.toBeNull()
     expect(browse.querySelector('.mobile-nav-trigger__label')).not.toBeNull()
     expect(brandMarks).toHaveLength(2)
+    expect(shellStyles).toContain(
+      'inline-size: 2.25rem;\n    block-size: 2.25rem;\n    aspect-ratio: 1;',
+    )
     expect([...brandMarks].map((mark) => mark.getAttribute('src'))).toEqual(
       expect.arrayContaining([
         expect.stringContaining('cut-meter.svg'),


### PR DESCRIPTION
## What changed

- fixes the Cut Meter wrapper to an explicit 2.25rem square
- adds a regression assertion for the fixed inline/block dimensions

## Root cause

The wrapper had a fixed inline size but no block size while the image used `block-size: 100%`. It stretched to the full header height, placing the visible mark 18px above the wordmark text center at a 430px viewport.

## User impact

The Cut Meter now sits directly to the left of and vertically centered with “Tadoku Paper” instead of appearing above it.

## Validation

- failing regression reproduced before the fix
- focused visual contract: 9/9
- full styleguide suite: 31/31
- styleguide lint and TypeScript
- Paper boundary scan
- full seven-project frontend build
- browser geometry at 430px: center delta reduced from 18px to 0px, no horizontal overflow
