### PR TITLE
Reuse the platform score snapshot for contests

### DIFF
--- a/services/immersion-api/domain/contestscoring.go
+++ b/services/immersion-api/domain/contestscoring.go
@@ -8,7 +8,6 @@ import (
 )
 
 type contestScoringRuleSetFinder interface {
-	FindActivePlatformScoringRuleSet(context.Context) (*ScoringRuleSet, error)
 	FindContestScoringRuleSets(context.Context, uuid.UUID) (*ScoringRuleSet, *ScoringRuleSet, error)
 }
 
@@ -53,13 +52,7 @@ func resolveContestLogTracking(
 	}
 
 	tracking := platformTracking
-	if contestRuleSet == nil {
-		result, evaluateErr := EvaluateActivePlatformScore(ctx, finder, input)
-		if evaluateErr != nil {
-			return ContestLogTracking{}, fmt.Errorf("could not evaluate platform scoring rules: %w", evaluateErr)
-		}
-		ApplyScoringResult(&tracking, result)
-	} else {
+	if contestRuleSet != nil {
 		result, evaluateErr := EvaluateContestScore(input, *contestRuleSet, fallbackRuleSet)
 		if evaluateErr != nil {
 			return ContestLogTracking{}, fmt.Errorf("could not evaluate contest scoring rules: %w", evaluateErr)

--- a/services/immersion-api/domain/logcreate_test.go
+++ b/services/immersion-api/domain/logcreate_test.go
@@ -601,6 +601,65 @@ func TestLogCreate_Execute(t *testing.T) {
 		assert.Equal(t, domain.ScoreSourceAmount, tracking.ScoreProvenance.Source)
 	})
 
+	t.Run("reuses the platform score for contests without rule sets", func(t *testing.T) {
+		secondRegistrationID := uuid.New()
+		secondContestID := uuid.New()
+		registrations := &domain.ContestRegistrations{
+			Registrations: []domain.ContestRegistration{
+				validRegistrations.Registrations[0],
+				{
+					ID:        secondRegistrationID,
+					ContestID: secondContestID,
+					UserID:    userID,
+					Languages: []domain.Language{{Code: "jpn", Name: "Japanese"}},
+					Contest: &domain.ContestView{
+						ID:       secondContestID,
+						Official: false,
+						AllowedActivities: []domain.Activity{
+							{ID: 1, Name: "Reading"},
+						},
+					},
+				},
+			},
+		}
+		platformRuleSetID := uuid.New()
+		platformRuleID := uuid.New()
+		repo := &mockLogCreateRepository{
+			registrations: registrations,
+			scoringRuleSet: &domain.ScoringRuleSet{
+				ID: platformRuleSetID,
+				Rules: []domain.ScoringRule{{
+					ID:          platformRuleID,
+					Priority:    1,
+					ActivityID:  1,
+					UnitKey:     domain.UnitKeyReadingPage,
+					ScoreSource: domain.ScoreSourceAmount,
+					Rate:        2,
+				}},
+			},
+			createdLogID: &logID,
+			log:          createdLog,
+		}
+		clock := commondomain.NewMockClock(now)
+		svc := newLogCreateServiceWithScoringEngine(repo, clock)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			RegistrationIDs: []uuid.UUID{registrationID, secondRegistrationID},
+			UnitID:          &unitID,
+			ActivityID:      1,
+			LanguageCode:    "jpn",
+			Amount:          &amount100,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.scoringRuleCalls)
+		platformTracking := repo.createCalledWith.Tracking()
+		contestTrackings := repo.createCalledWith.ContestTrackings()
+		require.Len(t, contestTrackings, 2)
+		assert.Equal(t, platformTracking, contestTrackings[0].Tracking)
+		assert.Equal(t, platformTracking, contestTrackings[1].Tracking)
+	})
+
 	t.Run("snapshots an independent contest score when enabled", func(t *testing.T) {
 		platformRuleSetID := uuid.New()
 		contestRuleSetID := uuid.New()


### PR DESCRIPTION
Stacked on #750.

## What changed

- Reuse the already-evaluated platform tracking snapshot for contests without custom scoring rules.
- Keep independent evaluation unchanged for contests with custom rule sets.
- Add a regression test covering one submission attached to multiple contests.

## Why

The contest scoring path re-fetched and re-evaluated the active platform rule set once per contest without custom rules, after it had already evaluated that rule set for the base log. For N such contests, one submission performed 1 + N platform rule-set fetches and could observe different active configurations within the same submission.

## Impact

Platform rules are fetched once per log submission, all contests without custom rules receive the exact base platform score/provenance snapshot, and custom contest scoring remains independent.

## Validation

- `bazel test //services/immersion-api/domain:domain_test`
- `bazel build //services/...`
- `bazel test //services/...` (16 test targets)
