### PR TITLE
test(paper): respect wordmark package boundary

### DIFF
--- a/frontend/apps/paper-styleguide/tests/legacy-wordmark-contract.test.tsx
+++ b/frontend/apps/paper-styleguide/tests/legacy-wordmark-contract.test.tsx
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
@@ -6,12 +7,14 @@ import { describe, expect, it } from 'vitest'
 import { catalogRegistry } from 'paper-ui/catalog'
 import { DocsShell } from '../src/app/DocsShell'
 
+const require = createRequire(import.meta.url)
+
 const legacyWordmark = readFileSync(
   resolve('../../packages/ui/components/logo.svg'),
   'utf8',
 )
 const paperWordmark = readFileSync(
-  resolve('../../packages/paper-ui/src/assets/brand/wordmark-accent.svg'),
+  require.resolve('paper-ui/assets/brand/wordmark-accent.svg'),
   'utf8',
 )
 const legacyReversedWordmark = readFileSync(
@@ -19,7 +22,7 @@ const legacyReversedWordmark = readFileSync(
   'utf8',
 )
 const paperReversedWordmark = readFileSync(
-  resolve('../../packages/paper-ui/src/assets/brand/wordmark-reversed.svg'),
+  require.resolve('paper-ui/assets/brand/wordmark-reversed.svg'),
   'utf8',
 )
 


### PR DESCRIPTION
## Summary

- resolve the Paper wordmark fixtures through the public `paper-ui/assets/*` package export
- preserve byte-for-byte comparisons against the legacy design-system wordmarks
- remove the private `paper-ui/src` access rejected by the Paper boundary check

## Root cause

The wordmark fidelity regression test read files directly from `paper-ui/src/assets`. The package boundary workflow correctly rejects any Paper consumer that reaches into private source, even from a test.

## Validation

- `pnpm check:paper-boundaries`
- `pnpm --filter paper-styleguide exec vitest run tests/legacy-wordmark-contract.test.tsx`
- full styleguide suite: 128 tests passed
- Paper package build and package validation passed