### PR TITLE
Instrument scoring shadow parity

### DIFF
--- a/services/immersion-api/BUILD.bazel
+++ b/services/immersion-api/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//services/immersion-api/domain",
         "//services/immersion-api/http/rest",
         "//services/immersion-api/http/rest/openapi",
+        "//services/immersion-api/observability",
         "//services/immersion-api/storage/postgres/repository",
         "//services/immersion-api/storage/valkey",
         "@com_github_getsentry_sentry_go//:sentry-go",

--- a/services/immersion-api/deployments/api.yaml
+++ b/services/immersion-api/deployments/api.yaml
@@ -34,7 +34,10 @@ spec:
         image: immersion-api-image
         imagePullPolicy: IfNotPresent
         ports:
-        - containerPort: 8000
+        - name: http
+          containerPort: 8000
+        - name: metrics
+          containerPort: 9090
         env:
           - name: API_POSTGRES_URL
             value: "postgres://immersion:dev-foobar@tadoku-dev-db.default/immersion?sslmode=require"
@@ -56,6 +59,8 @@ spec:
             value: "immersion-api"
           - name: API_SCORING_ENGINE_ENABLED
             value: "false"
+          - name: API_METRICS_PORT
+            value: "9090"
         volumeMounts:
         - name: k8s-token
           mountPath: /var/run/secrets/tokens
@@ -96,6 +101,23 @@ spec:
   - port: 80
     targetPort: 8000
     name: http
+  selector:
+    app: immersion-api
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: immersion-api-metrics
+  namespace: tdk-immersion-api
+  labels:
+    app: immersion-api
+    service: immersion-api-metrics
+spec:
+  type: ClusterIP
+  ports:
+  - port: 9090
+    targetPort: metrics
+    name: metrics
   selector:
     app: immersion-api
 ---

--- a/services/immersion-api/domain/logcreate.go
+++ b/services/immersion-api/domain/logcreate.go
@@ -54,6 +54,7 @@ type LogCreate struct {
 	validate         *validator.Validate
 	userUpsert       *UserUpsert
 	useScoringEngine bool
+	scoringObserver  ScoringShadowObserver
 }
 
 func NewLogCreate(
@@ -61,7 +62,7 @@ func NewLogCreate(
 	clock commondomain.Clock,
 	userUpsert *UserUpsert,
 ) *LogCreate {
-	return NewLogCreateWithScoringEngine(repo, clock, userUpsert, false)
+	return NewLogCreateWithScoringObserver(repo, clock, userUpsert, false, nil)
 }
 
 func NewLogCreateWithScoringEngine(
@@ -70,12 +71,23 @@ func NewLogCreateWithScoringEngine(
 	userUpsert *UserUpsert,
 	enabled bool,
 ) *LogCreate {
+	return NewLogCreateWithScoringObserver(repo, clock, userUpsert, enabled, nil)
+}
+
+func NewLogCreateWithScoringObserver(
+	repo LogCreateRepository,
+	clock commondomain.Clock,
+	userUpsert *UserUpsert,
+	enabled bool,
+	observer ScoringShadowObserver,
+) *LogCreate {
 	return &LogCreate{
 		repo:             repo,
 		clock:            clock,
 		validate:         validator.New(),
 		userUpsert:       userUpsert,
 		useScoringEngine: enabled,
+		scoringObserver:  observer,
 	}
 }
 
@@ -179,8 +191,20 @@ func (s *LogCreate) Execute(ctx context.Context, req *LogCreateRequest) (*Log, e
 		Amount:          req.Amount,
 		DurationSeconds: req.DurationSeconds,
 	}
+	mode := ScoringShadowModeShadow
 	if s.useScoringEngine {
-		result, scoringErr := EvaluateActivePlatformScore(ctx, s.repo, scoringInput)
+		mode = ScoringShadowModeAuthoritative
+	}
+	result, scoringErr := EvaluateAndObservePlatformScoring(
+		ctx,
+		s.repo,
+		s.scoringObserver,
+		ScoringShadowOperationCreate,
+		mode,
+		scoringInput,
+		req.tracking.ComputedScore,
+	)
+	if s.useScoringEngine {
 		if scoringErr != nil {
 			return nil, fmt.Errorf("could not score log: %w", scoringErr)
 		}
@@ -200,8 +224,6 @@ func (s *LogCreate) Execute(ctx context.Context, req *LogCreateRequest) (*Log, e
 			}
 			req.contestTrackings = append(req.contestTrackings, contestTracking)
 		}
-	} else {
-		RecordPlatformScoringShadow(ctx, s.repo, scoringInput, req.tracking.ComputedScore)
 	}
 
 	req.year = int16(s.clock.Now().Year())

--- a/services/immersion-api/domain/logcreate_test.go
+++ b/services/immersion-api/domain/logcreate_test.go
@@ -802,4 +802,48 @@ func TestLogCreate_Execute(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, repo.createCalledWith.EligibleOfficialLeaderboard())
 	})
+
+	t.Run("observes one create comparison in shadow mode", func(t *testing.T) {
+		repo := &mockLogCreateRepository{createdLogID: &logID, log: createdLog}
+		clock := commondomain.NewMockClock(now)
+		observer := &recordingScoringShadowObserver{}
+		userUpsert := domain.NewUserUpsert(&mockUserUpsertRepositoryForLog{})
+		svc := domain.NewLogCreateWithScoringObserver(repo, clock, userUpsert, false, observer)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			UnitID:       &unitID,
+			ActivityID:   1,
+			LanguageCode: "jpn",
+			Amount:       &amount100,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.scoringRuleCalls)
+		require.Len(t, observer.observations, 1)
+		assert.Equal(t, domain.ScoringShadowOperationCreate, observer.observations[0].Operation)
+		assert.Equal(t, domain.ScoringShadowModeShadow, observer.observations[0].Mode)
+		assert.Equal(t, domain.ScoringShadowOutcomeMatch, observer.observations[0].Outcome)
+	})
+
+	t.Run("observes an authoritative create error before rejecting the write", func(t *testing.T) {
+		repo := &mockLogCreateRepository{scoringRuleErr: errors.New("scoring unavailable")}
+		clock := commondomain.NewMockClock(now)
+		observer := &recordingScoringShadowObserver{}
+		userUpsert := domain.NewUserUpsert(&mockUserUpsertRepositoryForLog{})
+		svc := domain.NewLogCreateWithScoringObserver(repo, clock, userUpsert, true, observer)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogCreateRequest{
+			UnitID:       &unitID,
+			ActivityID:   1,
+			LanguageCode: "jpn",
+			Amount:       &amount100,
+		})
+
+		assert.Error(t, err)
+		assert.False(t, repo.createCalled)
+		assert.Equal(t, 1, repo.scoringRuleCalls)
+		require.Len(t, observer.observations, 1)
+		assert.Equal(t, domain.ScoringShadowModeAuthoritative, observer.observations[0].Mode)
+		assert.Equal(t, domain.ScoringShadowOutcomeError, observer.observations[0].Outcome)
+	})
 }

--- a/services/immersion-api/domain/logupdate.go
+++ b/services/immersion-api/domain/logupdate.go
@@ -47,13 +47,14 @@ type LogUpdate struct {
 	clock            commondomain.Clock
 	validate         *validator.Validate
 	useScoringEngine bool
+	scoringObserver  ScoringShadowObserver
 }
 
 func NewLogUpdate(
 	repo LogUpdateRepository,
 	clock commondomain.Clock,
 ) *LogUpdate {
-	return NewLogUpdateWithScoringEngine(repo, clock, false)
+	return NewLogUpdateWithScoringObserver(repo, clock, false, nil)
 }
 
 func NewLogUpdateWithScoringEngine(
@@ -61,11 +62,21 @@ func NewLogUpdateWithScoringEngine(
 	clock commondomain.Clock,
 	enabled bool,
 ) *LogUpdate {
+	return NewLogUpdateWithScoringObserver(repo, clock, enabled, nil)
+}
+
+func NewLogUpdateWithScoringObserver(
+	repo LogUpdateRepository,
+	clock commondomain.Clock,
+	enabled bool,
+	observer ScoringShadowObserver,
+) *LogUpdate {
 	return &LogUpdate{
 		repo:             repo,
 		clock:            clock,
 		validate:         validator.New(),
 		useScoringEngine: enabled,
+		scoringObserver:  observer,
 	}
 }
 
@@ -124,8 +135,20 @@ func (s *LogUpdate) Execute(ctx context.Context, req *LogUpdateRequest) (*Log, e
 		Amount:          req.Amount,
 		DurationSeconds: req.DurationSeconds,
 	}
+	mode := ScoringShadowModeShadow
 	if s.useScoringEngine {
-		result, scoringErr := EvaluateActivePlatformScore(ctx, s.repo, scoringInput)
+		mode = ScoringShadowModeAuthoritative
+	}
+	result, scoringErr := EvaluateAndObservePlatformScoring(
+		ctx,
+		s.repo,
+		s.scoringObserver,
+		ScoringShadowOperationUpdate,
+		mode,
+		scoringInput,
+		req.tracking.ComputedScore,
+	)
+	if s.useScoringEngine {
 		if scoringErr != nil {
 			return nil, fmt.Errorf("could not score log: %w", scoringErr)
 		}
@@ -148,8 +171,8 @@ func (s *LogUpdate) Execute(ctx context.Context, req *LogUpdateRequest) (*Log, e
 			}
 			req.contestTrackings = append(req.contestTrackings, contestTracking)
 		}
-	} else {
-		RecordPlatformScoringShadow(ctx, s.repo, scoringInput, req.tracking.ComputedScore)
+	}
+	if !s.useScoringEngine {
 		req.now = s.clock.Now()
 	}
 

--- a/services/immersion-api/domain/logupdate_test.go
+++ b/services/immersion-api/domain/logupdate_test.go
@@ -510,4 +510,51 @@ func TestLogUpdate_Execute(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, []string{"book", "fiction"}, repo.updateCalledWith.Tags)
 	})
+
+	t.Run("observes one update comparison in shadow mode", func(t *testing.T) {
+		repo := &mockLogUpdateRepository{
+			log:        makeLog(userID),
+			updatedLog: &domain.Log{ID: logID, UserID: userID, ActivityID: 1},
+		}
+		clock := commondomain.NewMockClock(now)
+		observer := &recordingScoringShadowObserver{}
+		svc := domain.NewLogUpdateWithScoringObserver(repo, clock, false, observer)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogUpdateRequest{
+			LogID:  logID,
+			UnitID: &unitID,
+			Amount: &amount10,
+		})
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, repo.scoringRuleCalls)
+		require.Len(t, observer.observations, 1)
+		assert.Equal(t, domain.ScoringShadowOperationUpdate, observer.observations[0].Operation)
+		assert.Equal(t, domain.ScoringShadowModeShadow, observer.observations[0].Mode)
+		assert.Equal(t, domain.ScoringShadowOutcomeMatch, observer.observations[0].Outcome)
+	})
+
+	t.Run("observes an authoritative update error before rejecting the write", func(t *testing.T) {
+		repo := &mockLogUpdateRepository{
+			log:            makeLog(userID),
+			scoringRuleErr: errors.New("scoring unavailable"),
+		}
+		clock := commondomain.NewMockClock(now)
+		observer := &recordingScoringShadowObserver{}
+		svc := domain.NewLogUpdateWithScoringObserver(repo, clock, true, observer)
+
+		_, err := svc.Execute(ctxWithUserSubject(userID.String()), &domain.LogUpdateRequest{
+			LogID:  logID,
+			UnitID: &unitID,
+			Amount: &amount10,
+		})
+
+		assert.Error(t, err)
+		assert.False(t, repo.updateCalled)
+		assert.Equal(t, 1, repo.scoringRuleCalls)
+		require.Len(t, observer.observations, 1)
+		assert.Equal(t, domain.ScoringShadowOperationUpdate, observer.observations[0].Operation)
+		assert.Equal(t, domain.ScoringShadowModeAuthoritative, observer.observations[0].Mode)
+		assert.Equal(t, domain.ScoringShadowOutcomeError, observer.observations[0].Outcome)
+	})
 }

--- a/services/immersion-api/domain/scoringshadow.go
+++ b/services/immersion-api/domain/scoringshadow.go
@@ -2,13 +2,64 @@ package domain
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"log/slog"
 	"math"
+
+	"github.com/google/uuid"
 )
 
 type activePlatformScoringRuleSetFinder interface {
 	FindActivePlatformScoringRuleSet(context.Context) (*ScoringRuleSet, error)
+}
+
+type ScoringShadowOutcome string
+
+const (
+	ScoringShadowOutcomeMatch     ScoringShadowOutcome = "match"
+	ScoringShadowOutcomeMismatch  ScoringShadowOutcome = "mismatch"
+	ScoringShadowOutcomeUnmatched ScoringShadowOutcome = "unmatched"
+	ScoringShadowOutcomeError     ScoringShadowOutcome = "error"
+)
+
+type ScoringShadowOperation string
+
+const (
+	ScoringShadowOperationCreate ScoringShadowOperation = "create"
+	ScoringShadowOperationUpdate ScoringShadowOperation = "update"
+)
+
+type ScoringShadowMode string
+
+const (
+	ScoringShadowModeShadow        ScoringShadowMode = "shadow"
+	ScoringShadowModeAuthoritative ScoringShadowMode = "authoritative"
+)
+
+// ScoringShadowObservation is the privacy-reviewed data contract passed to the
+// telemetry adapter. It intentionally contains no user, registration, or log
+// identifiers and no user-authored content.
+type ScoringShadowObservation struct {
+	Outcome        ScoringShadowOutcome
+	Operation      ScoringShadowOperation
+	Mode           ScoringShadowMode
+	ActivityID     int32
+	UnitKey        string
+	LanguageCode   string
+	ScoreSource    ScoreSource
+	LegacyScore    float32
+	EngineScore    *float32
+	AbsoluteDelta  *float64
+	RelativeDelta  *float64
+	RuleSetID      *uuid.UUID
+	AppliedRuleIDs []uuid.UUID
+	ErrorType      string
+}
+
+// ScoringShadowObserver is defined where scoring comparisons are consumed so
+// the domain does not depend on an observability implementation.
+type ScoringShadowObserver interface {
+	ObserveScoringShadow(context.Context, ScoringShadowObservation)
 }
 
 type ScoringShadowComparison struct {
@@ -49,48 +100,89 @@ func EvaluateActivePlatformScore(
 	return EvaluateScoringRuleSet(input, *ruleSet)
 }
 
-func RecordPlatformScoringShadow(
+// EvaluateAndObservePlatformScoring evaluates the engine exactly once and
+// records exactly one mutually exclusive outcome. Observer failures cannot
+// affect scoring because the observer has no error return.
+func EvaluateAndObservePlatformScoring(
 	ctx context.Context,
 	finder activePlatformScoringRuleSetFinder,
+	observer ScoringShadowObserver,
+	operation ScoringShadowOperation,
+	mode ScoringShadowMode,
 	input ScoringInput,
-	interimScore float32,
-) {
-	comparison, err := EvaluatePlatformScoringShadow(ctx, finder, input, interimScore)
+	legacyScore float32,
+) (ScoringResult, error) {
+	result, err := EvaluateActivePlatformScore(ctx, finder, input)
+	observation := ScoringShadowObservation{
+		Operation:    operation,
+		Mode:         mode,
+		ActivityID:   input.ActivityID,
+		UnitKey:      input.UnitKey,
+		LanguageCode: input.LanguageCode,
+		ScoreSource:  scoringShadowScoreSource(input),
+		LegacyScore:  legacyScore,
+	}
 	if err != nil {
-		slog.ErrorContext(
-			ctx,
-			"scoring shadow evaluation failed",
-			"activity_id", input.ActivityID,
-			"unit_key", input.UnitKey,
-			"language_code", input.LanguageCode,
-			"error", err,
-		)
-		return
+		observation.Outcome = ScoringShadowOutcomeError
+		observation.ErrorType = scoringShadowErrorType(err)
+		observeScoringShadow(ctx, observer, observation)
+		return ScoringResult{}, err
 	}
-	if !comparison.RuleResult.Matched {
-		slog.WarnContext(
-			ctx,
-			"scoring shadow input unmatched",
-			"activity_id", input.ActivityID,
-			"unit_key", input.UnitKey,
-			"language_code", input.LanguageCode,
-			"score_source", comparison.RuleResult.ScoreSource,
-			"interim_score", interimScore,
-		)
-		return
+
+	engineScore := result.Score
+	absoluteDelta := math.Abs(float64(legacyScore - result.Score))
+	scale := math.Max(math.Abs(float64(legacyScore)), math.Abs(float64(result.Score)))
+	relativeDelta := float64(0)
+	if scale > 0 {
+		relativeDelta = absoluteDelta / scale
 	}
-	if comparison.Mismatch {
-		slog.WarnContext(
-			ctx,
-			"scoring shadow mismatch",
-			"activity_id", input.ActivityID,
-			"unit_key", input.UnitKey,
-			"language_code", input.LanguageCode,
-			"score_source", comparison.RuleResult.ScoreSource,
-			"interim_score", interimScore,
-			"rule_score", comparison.RuleResult.Score,
-			"rule_set_id", comparison.RuleResult.AppliedRuleSetID,
-		)
+	observation.EngineScore = &engineScore
+	observation.AbsoluteDelta = &absoluteDelta
+	observation.RelativeDelta = &relativeDelta
+	observation.RuleSetID = result.AppliedRuleSetID
+	observation.AppliedRuleIDs = make([]uuid.UUID, len(result.AppliedRules))
+	for index, rule := range result.AppliedRules {
+		observation.AppliedRuleIDs[index] = rule.RuleID
+	}
+
+	switch {
+	case !result.Matched:
+		observation.Outcome = ScoringShadowOutcomeUnmatched
+	case scoringScoresEqual(legacyScore, result.Score):
+		observation.Outcome = ScoringShadowOutcomeMatch
+	default:
+		observation.Outcome = ScoringShadowOutcomeMismatch
+	}
+	observeScoringShadow(ctx, observer, observation)
+	return result, nil
+}
+
+func observeScoringShadow(ctx context.Context, observer ScoringShadowObserver, observation ScoringShadowObservation) {
+	if observer != nil {
+		observer.ObserveScoringShadow(ctx, observation)
+	}
+}
+
+func scoringShadowScoreSource(input ScoringInput) ScoreSource {
+	if input.Amount != nil {
+		return ScoreSourceAmount
+	}
+	if input.DurationSeconds != nil {
+		return ScoreSourceDurationMinutes
+	}
+	return ""
+}
+
+func scoringShadowErrorType(err error) string {
+	switch {
+	case errors.Is(err, ErrScoringRuleSetNotFound):
+		return "scoring_rule_set_not_found"
+	case errors.Is(err, ErrInvalidScoringRuleSet):
+		return "invalid_scoring_rule_set"
+	case errors.Is(err, ErrInvalidLog):
+		return "invalid_scoring_input"
+	default:
+		return "evaluation_failed"
 	}
 }
 

--- a/services/immersion-api/domain/scoringshadow_test.go
+++ b/services/immersion-api/domain/scoringshadow_test.go
@@ -14,10 +14,20 @@ import (
 type mockActivePlatformScoringRuleSetFinder struct {
 	ruleSet *domain.ScoringRuleSet
 	err     error
+	calls   int
 }
 
 func (m *mockActivePlatformScoringRuleSetFinder) FindActivePlatformScoringRuleSet(context.Context) (*domain.ScoringRuleSet, error) {
+	m.calls++
 	return m.ruleSet, m.err
+}
+
+type recordingScoringShadowObserver struct {
+	observations []domain.ScoringShadowObservation
+}
+
+func (o *recordingScoringShadowObserver) ObserveScoringShadow(_ context.Context, observation domain.ScoringShadowObservation) {
+	o.observations = append(o.observations, observation)
 }
 
 func TestEvaluatePlatformScoringShadow(t *testing.T) {
@@ -132,4 +142,94 @@ func TestEvaluatePlatformScoringShadowUsesDurationMinutes(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, comparison.Mismatch)
 	assert.InDelta(t, float32(0.6), comparison.RuleResult.Score, 0.0001)
+}
+
+func TestEvaluateAndObservePlatformScoringRecordsOneMutuallyExclusiveOutcome(t *testing.T) {
+	amount := float32(10)
+	matchingRuleSet := func(rate float32) *domain.ScoringRuleSet {
+		return &domain.ScoringRuleSet{
+			ID: uuid.New(),
+			Rules: []domain.ScoringRule{{
+				ID:          uuid.New(),
+				Priority:    1,
+				ActivityID:  1,
+				UnitKey:     domain.UnitKeyReadingPage,
+				ScoreSource: domain.ScoreSourceAmount,
+				Rate:        rate,
+			}},
+		}
+	}
+	unmatchedRuleSet := &domain.ScoringRuleSet{
+		ID: uuid.New(),
+		Rules: []domain.ScoringRule{{
+			ID:          uuid.New(),
+			Priority:    1,
+			ActivityID:  2,
+			ScoreSource: domain.ScoreSourceAmount,
+			Rate:        1,
+		}},
+	}
+
+	testCases := []struct {
+		name      string
+		ruleSet   *domain.ScoringRuleSet
+		err       error
+		outcome   domain.ScoringShadowOutcome
+		wantError bool
+	}{
+		{name: "match", ruleSet: matchingRuleSet(1), outcome: domain.ScoringShadowOutcomeMatch},
+		{name: "mismatch", ruleSet: matchingRuleSet(2), outcome: domain.ScoringShadowOutcomeMismatch},
+		{name: "unmatched", ruleSet: unmatchedRuleSet, outcome: domain.ScoringShadowOutcomeUnmatched},
+		{name: "error", err: errors.New("database connection details must stay private"), outcome: domain.ScoringShadowOutcomeError, wantError: true},
+	}
+	modes := []domain.ScoringShadowMode{
+		domain.ScoringShadowModeShadow,
+		domain.ScoringShadowModeAuthoritative,
+	}
+
+	for _, mode := range modes {
+		for _, testCase := range testCases {
+			t.Run(string(mode)+"/"+testCase.name, func(t *testing.T) {
+				finder := &mockActivePlatformScoringRuleSetFinder{ruleSet: testCase.ruleSet, err: testCase.err}
+				observer := &recordingScoringShadowObserver{}
+
+				_, err := domain.EvaluateAndObservePlatformScoring(
+					context.Background(),
+					finder,
+					observer,
+					domain.ScoringShadowOperationCreate,
+					mode,
+					domain.ScoringInput{
+						ActivityID:   1,
+						UnitKey:      domain.UnitKeyReadingPage,
+						LanguageCode: "jpn",
+						Amount:       &amount,
+					},
+					10,
+				)
+
+				if testCase.wantError {
+					assert.Error(t, err)
+				} else {
+					require.NoError(t, err)
+				}
+				assert.Equal(t, 1, finder.calls, "the engine must be evaluated exactly once")
+				require.Len(t, observer.observations, 1, "one comparison must produce one outcome")
+				observation := observer.observations[0]
+				assert.Equal(t, testCase.outcome, observation.Outcome)
+				assert.Equal(t, mode, observation.Mode)
+				assert.Equal(t, domain.ScoringShadowOperationCreate, observation.Operation)
+				assert.Equal(t, domain.ScoreSourceAmount, observation.ScoreSource)
+				assert.Equal(t, int32(1), observation.ActivityID)
+				if testCase.wantError {
+					assert.Equal(t, "evaluation_failed", observation.ErrorType)
+					assert.NotContains(t, observation.ErrorType, "database")
+				} else {
+					require.NotNil(t, observation.EngineScore)
+					require.NotNil(t, observation.AbsoluteDelta)
+					require.NotNil(t, observation.RelativeDelta)
+				}
+			})
+		}
+	}
 }

--- a/services/immersion-api/main.go
+++ b/services/immersion-api/main.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"log/slog"
+	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
@@ -20,6 +22,7 @@ import (
 	immersiondomain "github.com/tadoku/tadoku/services/immersion-api/domain"
 	"github.com/tadoku/tadoku/services/immersion-api/http/rest"
 	"github.com/tadoku/tadoku/services/immersion-api/http/rest/openapi"
+	"github.com/tadoku/tadoku/services/immersion-api/observability"
 	"github.com/tadoku/tadoku/services/immersion-api/storage/postgres/repository"
 	valkeystore "github.com/tadoku/tadoku/services/immersion-api/storage/valkey"
 
@@ -44,6 +47,7 @@ type Config struct {
 	SentryDSN              string  `envconfig:"sentry_dns"`
 	SentryTracesSampleRate float64 `validate:"required_with=SentryDSN" envconfig:"sentry_traces_sample_rate"`
 	ScoringEngineEnabled   bool    `envconfig:"scoring_engine_enabled" default:"false"`
+	MetricsPort            int64   `envconfig:"metrics_port" default:"9090"`
 }
 
 func main() {
@@ -84,6 +88,20 @@ func main() {
 
 	leaderboardStore := valkeystore.NewLeaderboardStore(valkeyClient, clock)
 	leaderboardUpdater := immersiondomain.NewLeaderboardUpdater(leaderboardStore, postgresRepository)
+	scoringMetrics := observability.NewScoringShadowMetrics(cfg.ScoringEngineEnabled)
+	scoringObserver := observability.NewScoringShadowObserver(
+		scoringMetrics,
+		slog.New(slog.NewJSONHandler(os.Stdout, nil)),
+	)
+	metricsMux := http.NewServeMux()
+	metricsMux.Handle("/metrics", scoringMetrics)
+	metricsServer := observability.NewMetricsServer(
+		fmt.Sprintf("0.0.0.0:%d", cfg.MetricsPort),
+		metricsMux,
+	)
+	if err := metricsServer.Start(); err != nil {
+		panic(fmt.Errorf("could not start internal metrics server: %w", err))
+	}
 
 	// Start leaderboard outbox worker for async leaderboard sync
 	outboxWorker := immersiondomain.NewLeaderboardOutboxWorker(postgresRepository, leaderboardUpdater, clock, 500*time.Millisecond)
@@ -146,8 +164,8 @@ func main() {
 	contestModerationDetachLog := immersiondomain.NewContestModerationDetachLog(postgresRepository)
 	userUpsert := immersiondomain.NewUserUpsert(postgresRepository)
 	registrationUpsert := immersiondomain.NewRegistrationUpsert(postgresRepository, userUpsert)
-	logCreate := immersiondomain.NewLogCreateWithScoringEngine(postgresRepository, clock, userUpsert, cfg.ScoringEngineEnabled)
-	logUpdate := immersiondomain.NewLogUpdateWithScoringEngine(postgresRepository, clock, cfg.ScoringEngineEnabled)
+	logCreate := immersiondomain.NewLogCreateWithScoringObserver(postgresRepository, clock, userUpsert, cfg.ScoringEngineEnabled, scoringObserver)
+	logUpdate := immersiondomain.NewLogUpdateWithScoringObserver(postgresRepository, clock, cfg.ScoringEngineEnabled, scoringObserver)
 	contestCreate := immersiondomain.NewContestCreate(postgresRepository, clock, userUpsert)
 	languageList := immersiondomain.NewLanguageList(postgresRepository)
 	languageCreate := immersiondomain.NewLanguageCreate(postgresRepository)
@@ -208,12 +226,19 @@ func main() {
 	// Wait for interrupt signal
 	quit := make(chan os.Signal, 1)
 	signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-	<-quit
+	select {
+	case <-quit:
+	case metricsErr := <-metricsServer.Errors():
+		slog.Error("internal metrics server stopped", "error", metricsErr)
+	}
 
 	// Graceful shutdown
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	if err := e.Shutdown(ctx); err != nil {
-		e.Logger.Fatal(err)
+		slog.Error("could not gracefully shut down application server", "error", err)
+	}
+	if err := metricsServer.Shutdown(ctx); err != nil {
+		slog.Error("could not gracefully shut down metrics server", "error", err)
 	}
 }

--- a/services/immersion-api/observability/BUILD.bazel
+++ b/services/immersion-api/observability/BUILD.bazel
@@ -1,0 +1,24 @@
+load("@rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "observability",
+    srcs = [
+        "scoring_shadow.go",
+        "server.go",
+    ],
+    importpath = "github.com/tadoku/tadoku/services/immersion-api/observability",
+    visibility = ["//visibility:public"],
+    deps = ["//services/immersion-api/domain"],
+)
+
+go_test(
+    name = "observability_test",
+    srcs = ["scoring_shadow_test.go"],
+    embed = [":observability"],
+    deps = [
+        "//services/immersion-api/domain",
+        "@com_github_google_uuid//:uuid",
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/services/immersion-api/observability/scoring_shadow.go
+++ b/services/immersion-api/observability/scoring_shadow.go
@@ -1,0 +1,198 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/tadoku/tadoku/services/immersion-api/domain"
+)
+
+const maxAppliedRuleIDs = 10
+
+type scoringShadowLabels struct {
+	outcome     domain.ScoringShadowOutcome
+	operation   domain.ScoringShadowOperation
+	mode        domain.ScoringShadowMode
+	activityID  int32
+	scoreSource domain.ScoreSource
+}
+
+// ScoringShadowMetrics is both a bounded in-memory metric registry and a
+// Prometheus text exposition handler. Only values from the approved label
+// contract are accepted.
+type ScoringShadowMetrics struct {
+	mu          sync.RWMutex
+	comparisons map[scoringShadowLabels]uint64
+	enabled     bool
+}
+
+func NewScoringShadowMetrics(engineEnabled bool) *ScoringShadowMetrics {
+	return &ScoringShadowMetrics{
+		comparisons: make(map[scoringShadowLabels]uint64),
+		enabled:     engineEnabled,
+	}
+}
+
+func (m *ScoringShadowMetrics) record(observation domain.ScoringShadowObservation) bool {
+	labels := scoringShadowLabels{
+		outcome:     observation.Outcome,
+		operation:   observation.Operation,
+		mode:        observation.Mode,
+		activityID:  observation.ActivityID,
+		scoreSource: observation.ScoreSource,
+	}
+	if !validScoringShadowLabels(labels) {
+		return false
+	}
+
+	m.mu.Lock()
+	m.comparisons[labels]++
+	m.mu.Unlock()
+	return true
+}
+
+func (m *ScoringShadowMetrics) ServeHTTP(response http.ResponseWriter, request *http.Request) {
+	if request.Method != http.MethodGet {
+		response.Header().Set("Allow", http.MethodGet)
+		http.Error(response, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	response.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+	m.mu.RLock()
+	labels := make([]scoringShadowLabels, 0, len(m.comparisons))
+	for label := range m.comparisons {
+		labels = append(labels, label)
+	}
+	sort.Slice(labels, func(i, j int) bool {
+		return metricLabelSortKey(labels[i]) < metricLabelSortKey(labels[j])
+	})
+
+	_, _ = fmt.Fprintln(response, "# HELP tadoku_scoring_shadow_comparisons_total Legacy-to-engine scoring comparisons.")
+	_, _ = fmt.Fprintln(response, "# TYPE tadoku_scoring_shadow_comparisons_total counter")
+	for _, label := range labels {
+		_, _ = fmt.Fprintf(
+			response,
+			"tadoku_scoring_shadow_comparisons_total{outcome=%q,operation=%q,mode=%q,activity_id=%q,score_source=%q} %d\n",
+			label.outcome,
+			label.operation,
+			label.mode,
+			strconv.FormatInt(int64(label.activityID), 10),
+			label.scoreSource,
+			m.comparisons[label],
+		)
+	}
+	_, _ = fmt.Fprintln(response, "# HELP tadoku_scoring_engine_enabled Whether the scoring engine is authoritative.")
+	_, _ = fmt.Fprintln(response, "# TYPE tadoku_scoring_engine_enabled gauge")
+	if m.enabled {
+		_, _ = fmt.Fprintln(response, "tadoku_scoring_engine_enabled 1")
+	} else {
+		_, _ = fmt.Fprintln(response, "tadoku_scoring_engine_enabled 0")
+	}
+	m.mu.RUnlock()
+}
+
+func validScoringShadowLabels(labels scoringShadowLabels) bool {
+	if labels.activityID < 1 || labels.activityID > 5 {
+		return false
+	}
+	switch labels.outcome {
+	case domain.ScoringShadowOutcomeMatch,
+		domain.ScoringShadowOutcomeMismatch,
+		domain.ScoringShadowOutcomeUnmatched,
+		domain.ScoringShadowOutcomeError:
+	default:
+		return false
+	}
+	switch labels.operation {
+	case domain.ScoringShadowOperationCreate, domain.ScoringShadowOperationUpdate:
+	default:
+		return false
+	}
+	switch labels.mode {
+	case domain.ScoringShadowModeShadow, domain.ScoringShadowModeAuthoritative:
+	default:
+		return false
+	}
+	switch labels.scoreSource {
+	case domain.ScoreSourceAmount, domain.ScoreSourceDurationMinutes:
+	default:
+		return false
+	}
+	return true
+}
+
+func metricLabelSortKey(labels scoringShadowLabels) string {
+	return string(labels.outcome) + "\x00" +
+		string(labels.operation) + "\x00" +
+		string(labels.mode) + "\x00" +
+		strconv.FormatInt(int64(labels.activityID), 10) + "\x00" +
+		string(labels.scoreSource)
+}
+
+type ScoringShadowObserver struct {
+	metrics *ScoringShadowMetrics
+	logger  *slog.Logger
+}
+
+func NewScoringShadowObserver(metrics *ScoringShadowMetrics, logger *slog.Logger) *ScoringShadowObserver {
+	return &ScoringShadowObserver{metrics: metrics, logger: logger}
+}
+
+func (o *ScoringShadowObserver) ObserveScoringShadow(ctx context.Context, observation domain.ScoringShadowObservation) {
+	if o.metrics == nil || !o.metrics.record(observation) {
+		return
+	}
+	if observation.Outcome == domain.ScoringShadowOutcomeMatch || o.logger == nil {
+		return
+	}
+
+	attributes := []slog.Attr{
+		slog.String("event", "scoring_shadow"),
+		slog.String("outcome", string(observation.Outcome)),
+		slog.String("operation", string(observation.Operation)),
+		slog.String("mode", string(observation.Mode)),
+		slog.Int64("activity_id", int64(observation.ActivityID)),
+		slog.String("unit_key", observation.UnitKey),
+		slog.String("language_code", observation.LanguageCode),
+		slog.String("score_source", string(observation.ScoreSource)),
+		slog.Float64("legacy_score", float64(observation.LegacyScore)),
+	}
+	if observation.EngineScore != nil {
+		attributes = append(attributes, slog.Float64("engine_score", float64(*observation.EngineScore)))
+	}
+	if observation.AbsoluteDelta != nil {
+		attributes = append(attributes, slog.Float64("absolute_delta", *observation.AbsoluteDelta))
+	}
+	if observation.RelativeDelta != nil {
+		attributes = append(attributes, slog.Float64("relative_delta", *observation.RelativeDelta))
+	}
+	if observation.RuleSetID != nil {
+		attributes = append(attributes, slog.String("rule_set_id", observation.RuleSetID.String()))
+	}
+	if len(observation.AppliedRuleIDs) > 0 {
+		limit := len(observation.AppliedRuleIDs)
+		if limit > maxAppliedRuleIDs {
+			limit = maxAppliedRuleIDs
+		}
+		ruleIDs := make([]string, limit)
+		for index := 0; index < limit; index++ {
+			ruleIDs[index] = observation.AppliedRuleIDs[index].String()
+		}
+		attributes = append(attributes, slog.Any("applied_rule_ids", ruleIDs))
+	}
+	if observation.ErrorType != "" {
+		attributes = append(attributes, slog.String("error_type", observation.ErrorType))
+	}
+
+	level := slog.LevelWarn
+	if observation.Outcome == domain.ScoringShadowOutcomeError {
+		level = slog.LevelError
+	}
+	o.logger.LogAttrs(ctx, level, "scoring comparison anomaly", attributes...)
+}

--- a/services/immersion-api/observability/scoring_shadow_test.go
+++ b/services/immersion-api/observability/scoring_shadow_test.go
@@ -1,0 +1,203 @@
+package observability
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tadoku/tadoku/services/immersion-api/domain"
+)
+
+func TestScoringShadowMetricsExportsBoundedLabelsAndExactCounts(t *testing.T) {
+	metrics := NewScoringShadowMetrics(true)
+	observer := NewScoringShadowObserver(metrics, nil)
+	observation := domain.ScoringShadowObservation{
+		Outcome:      domain.ScoringShadowOutcomeMatch,
+		Operation:    domain.ScoringShadowOperationCreate,
+		Mode:         domain.ScoringShadowModeAuthoritative,
+		ActivityID:   1,
+		ScoreSource:  domain.ScoreSourceAmount,
+		LegacyScore:  10,
+		LanguageCode: "jpn",
+	}
+
+	observer.ObserveScoringShadow(context.Background(), observation)
+	observer.ObserveScoringShadow(context.Background(), observation)
+	invalid := observation
+	invalid.ActivityID = 9001
+	invalid.ScoreSource = domain.ScoreSource("user-controlled-source")
+	observer.ObserveScoringShadow(context.Background(), invalid)
+
+	recorder := httptest.NewRecorder()
+	metrics.ServeHTTP(recorder, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := recorder.Body.String()
+
+	assert.Equal(t, http.StatusOK, recorder.Code)
+	assert.Equal(t, "text/plain; version=0.0.4; charset=utf-8", recorder.Header().Get("Content-Type"))
+	assert.Contains(t, body, `tadoku_scoring_shadow_comparisons_total{outcome="match",operation="create",mode="authoritative",activity_id="1",score_source="amount"} 2`)
+	assert.Equal(t, 1, strings.Count(body, "tadoku_scoring_shadow_comparisons_total{"))
+	assert.Contains(t, body, "tadoku_scoring_engine_enabled 1")
+	assert.NotContains(t, body, "language_code")
+	assert.NotContains(t, body, "unit_key")
+	assert.NotContains(t, body, "user-controlled-source")
+}
+
+func TestScoringShadowMetricsRejectsNonGETRequests(t *testing.T) {
+	metrics := NewScoringShadowMetrics(false)
+	recorder := httptest.NewRecorder()
+
+	metrics.ServeHTTP(recorder, httptest.NewRequest(http.MethodPost, "/metrics", nil))
+
+	assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
+	assert.Equal(t, http.MethodGet, recorder.Header().Get("Allow"))
+}
+
+func TestScoringShadowObserverWritesSanitizedBoundedJSONAnomalies(t *testing.T) {
+	metrics := NewScoringShadowMetrics(false)
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, nil))
+	observer := NewScoringShadowObserver(metrics, logger)
+	ruleSetID := uuid.New()
+	engineScore := float32(12)
+	absoluteDelta := float64(2)
+	relativeDelta := float64(1) / 6
+	ruleIDs := make([]uuid.UUID, maxAppliedRuleIDs+5)
+	for index := range ruleIDs {
+		ruleIDs[index] = uuid.New()
+	}
+
+	observer.ObserveScoringShadow(context.Background(), domain.ScoringShadowObservation{
+		Outcome:        domain.ScoringShadowOutcomeMismatch,
+		Operation:      domain.ScoringShadowOperationUpdate,
+		Mode:           domain.ScoringShadowModeShadow,
+		ActivityID:     2,
+		UnitKey:        domain.UnitKeyListeningMinute,
+		LanguageCode:   "jpn",
+		ScoreSource:    domain.ScoreSourceDurationMinutes,
+		LegacyScore:    10,
+		EngineScore:    &engineScore,
+		AbsoluteDelta:  &absoluteDelta,
+		RelativeDelta:  &relativeDelta,
+		RuleSetID:      &ruleSetID,
+		AppliedRuleIDs: ruleIDs,
+	})
+
+	var event map[string]any
+	require.NoError(t, json.Unmarshal(output.Bytes(), &event))
+	assert.Equal(t, "scoring_shadow", event["event"])
+	assert.Equal(t, "mismatch", event["outcome"])
+	assert.Equal(t, "update", event["operation"])
+	assert.Equal(t, "shadow", event["mode"])
+	assert.Equal(t, float64(2), event["activity_id"])
+	assert.Equal(t, domain.UnitKeyListeningMinute, event["unit_key"])
+	assert.Equal(t, "jpn", event["language_code"])
+	assert.Equal(t, "duration_minutes", event["score_source"])
+	assert.Equal(t, float64(10), event["legacy_score"])
+	assert.Equal(t, float64(12), event["engine_score"])
+	assert.Equal(t, ruleSetID.String(), event["rule_set_id"])
+	assert.Len(t, event["applied_rule_ids"], maxAppliedRuleIDs)
+
+	for _, prohibited := range []string{
+		"user_id",
+		"registration_id",
+		"log_id",
+		"tags",
+		"description",
+		"uri",
+		"headers",
+		"request_body",
+		"error",
+	} {
+		assert.NotContains(t, event, prohibited)
+	}
+}
+
+func TestScoringShadowObserverDoesNotLogMatchesOrRawErrors(t *testing.T) {
+	metrics := NewScoringShadowMetrics(false)
+	var output bytes.Buffer
+	observer := NewScoringShadowObserver(metrics, slog.New(slog.NewJSONHandler(&output, nil)))
+	base := domain.ScoringShadowObservation{
+		Operation:    domain.ScoringShadowOperationCreate,
+		Mode:         domain.ScoringShadowModeShadow,
+		ActivityID:   1,
+		ScoreSource:  domain.ScoreSourceAmount,
+		LanguageCode: "jpn",
+	}
+	match := base
+	match.Outcome = domain.ScoringShadowOutcomeMatch
+	observer.ObserveScoringShadow(context.Background(), match)
+	assert.Empty(t, output.String())
+
+	failure := base
+	failure.Outcome = domain.ScoringShadowOutcomeError
+	failure.ErrorType = "evaluation_failed"
+	observer.ObserveScoringShadow(context.Background(), failure)
+	assert.NotContains(t, output.String(), "password")
+	assert.NotContains(t, output.String(), "database")
+	assert.Contains(t, output.String(), `"error_type":"evaluation_failed"`)
+}
+
+func TestScoringShadowObservationPrivacyContractHasNoProhibitedFields(t *testing.T) {
+	typeOfObservation := reflect.TypeOf(domain.ScoringShadowObservation{})
+	fields := make([]string, 0, typeOfObservation.NumField())
+	for index := 0; index < typeOfObservation.NumField(); index++ {
+		fields = append(fields, strings.ToLower(typeOfObservation.Field(index).Name))
+	}
+	joined := strings.Join(fields, " ")
+
+	for _, prohibited := range []string{"userid", "registrationid", "logid", "tags", "description", "uri", "header", "requestbody", "rawerror"} {
+		assert.NotContains(t, joined, prohibited)
+	}
+}
+
+func TestMetricsServerStartsAndShutsDownGracefully(t *testing.T) {
+	requestStarted := make(chan struct{})
+	releaseRequest := make(chan struct{})
+	handler := http.HandlerFunc(func(response http.ResponseWriter, _ *http.Request) {
+		close(requestStarted)
+		<-releaseRequest
+		response.WriteHeader(http.StatusNoContent)
+	})
+	server := NewMetricsServer("127.0.0.1:0", handler)
+	require.NoError(t, server.Start())
+
+	requestDone := make(chan error, 1)
+	go func() {
+		response, err := http.Get("http://" + server.Addr())
+		if err == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			err = response.Body.Close()
+		}
+		requestDone <- err
+	}()
+	<-requestStarted
+
+	shutdownDone := make(chan error, 1)
+	shutdownContext, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	go func() {
+		shutdownDone <- server.Shutdown(shutdownContext)
+	}()
+
+	select {
+	case err := <-shutdownDone:
+		require.Failf(t, "shutdown returned before active request completed", "error: %v", err)
+	case <-time.After(25 * time.Millisecond):
+	}
+	close(releaseRequest)
+	require.NoError(t, <-requestDone)
+	require.NoError(t, <-shutdownDone)
+	_, err := http.Get("http://" + server.Addr())
+	assert.Error(t, err)
+}

--- a/services/immersion-api/observability/server.go
+++ b/services/immersion-api/observability/server.go
@@ -1,0 +1,63 @@
+package observability
+
+import (
+	"context"
+	"errors"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+)
+
+type MetricsServer struct {
+	server   *http.Server
+	mu       sync.RWMutex
+	listener net.Listener
+	errors   chan error
+}
+
+func NewMetricsServer(address string, handler http.Handler) *MetricsServer {
+	return &MetricsServer{
+		server: &http.Server{
+			Addr:              address,
+			Handler:           handler,
+			ReadHeaderTimeout: 5 * time.Second,
+			IdleTimeout:       30 * time.Second,
+		},
+		errors: make(chan error, 1),
+	}
+}
+
+func (s *MetricsServer) Start() error {
+	listener, err := net.Listen("tcp", s.server.Addr)
+	if err != nil {
+		return err
+	}
+
+	s.mu.Lock()
+	s.listener = listener
+	s.mu.Unlock()
+	go func() {
+		if serveErr := s.server.Serve(listener); serveErr != nil && !errors.Is(serveErr, http.ErrServerClosed) {
+			s.errors <- serveErr
+		}
+	}()
+	return nil
+}
+
+func (s *MetricsServer) Addr() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.listener == nil {
+		return ""
+	}
+	return s.listener.Addr().String()
+}
+
+func (s *MetricsServer) Errors() <-chan error {
+	return s.errors
+}
+
+func (s *MetricsServer) Shutdown(ctx context.Context) error {
+	return s.server.Shutdown(ctx)
+}


### PR DESCRIPTION
Adds exact-once scoring comparison observation in shadow and authoritative modes, bounded Prometheus metrics, sanitized anomaly events, and an internal metrics listener. Validated with Bazel build, all service tests, and Gazelle diff.