### PR TITLE
Remove PostgreSQL URL compatibility

### DIFF
--- a/docs/docs/database-migration-recovery.md
+++ b/docs/docs/database-migration-recovery.md
@@ -178,8 +178,8 @@ version `12`:
 
 Set `POSTGRES_HOST`, `POSTGRES_PORT`, `POSTGRES_DATABASE`, `POSTGRES_SSLMODE`,
 `POSTGRES_USER`, and `POSTGRES_PASSWORD` in the command environment. The
-deprecated `-database` URL flag exists only as a bounded operator escape hatch;
-do not use it in Kubernetes workload arguments or automation.
+command rejects both `POSTGRES_URL` and the removed `-database` URL flag so
+credentials cannot be supplied as a complete URL.
 
 The command refuses to run if:
 

--- a/services/common/migrate-recovery/main.go
+++ b/services/common/migrate-recovery/main.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"strconv"
-	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/tadoku/tadoku/services/common/postgresconfig"
@@ -43,7 +42,6 @@ func run(args []string, stdout, stderr io.Writer, factory migrationFactory) int 
 	flags.SetOutput(stderr)
 
 	sourceURL := flags.String("source", "", "migration source URL")
-	databaseURL := flags.String("database", "", "deprecated database URL escape hatch")
 	expectedVersion := flags.Int("expected-version", 0, "dirty version observed during inspection")
 	targetVersion := flags.Int("target-version", 0, "version matching the verified physical schema")
 	confirmation := flags.String("confirm-target-version", "", "repeat target version to confirm metadata repair")
@@ -101,24 +99,16 @@ func run(args []string, stdout, stderr io.Writer, factory migrationFactory) int 
 		}
 	}
 
-	var postgresConfig postgresconfig.Config
-	if *databaseURL == "" {
-		var err error
-		postgresConfig, err = postgresconfig.Load("POSTGRES", "POSTGRES_URL")
-		if err != nil {
-			fmt.Fprintf(stderr, "migrate-recovery: postgres configuration: %v\n", err)
-			return 2
-		}
-		*databaseURL = postgresConfig.URL()
+	postgresConfig, err := postgresconfig.Load("POSTGRES", "POSTGRES_URL")
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate-recovery: postgres configuration: %v\n", err)
+		return 2
 	}
+	databaseURL := postgresConfig.URL()
 	redact := func(value any) string {
-		result := postgresConfig.Redact(value)
-		if *databaseURL != "" {
-			result = strings.ReplaceAll(result, *databaseURL, "[REDACTED]")
-		}
-		return result
+		return postgresConfig.Redact(value)
 	}
-	runner, err := factory(*sourceURL, *databaseURL)
+	runner, err := factory(*sourceURL, databaseURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "migrate-recovery: initialize: %s\n", redact(err))
 		return 1

--- a/services/common/migrate-recovery/main_test.go
+++ b/services/common/migrate-recovery/main_test.go
@@ -49,6 +49,11 @@ func (m *fakeMigration) Close() (error, error) {
 
 func runWithFake(t *testing.T, args []string, runner *fakeMigration) (int, string, string) {
 	t.Helper()
+	t.Setenv("POSTGRES_HOST", "db")
+	t.Setenv("POSTGRES_DATABASE", "database")
+	t.Setenv("POSTGRES_USER", "user")
+	t.Setenv("POSTGRES_PASSWORD", "password")
+	t.Setenv("POSTGRES_SSLMODE", "require")
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
@@ -58,7 +63,7 @@ func runWithFake(t *testing.T, args []string, runner *fakeMigration) (int, strin
 		&stderr,
 		func(sourceURL, databaseURL string) (migration, error) {
 			assert.Equal(t, "file:///migrations", sourceURL)
-			assert.Equal(t, "postgres://database", databaseURL)
+			assert.Equal(t, "postgres://user:password@db:5432/database?sslmode=require", databaseURL)
 			return runner, nil
 		},
 	)
@@ -69,7 +74,7 @@ func TestInspectCleanVersion(t *testing.T) {
 	runner := &fakeMigration{version: 12}
 	exitCode, stdout, stderr := runWithFake(
 		t,
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		[]string{"-source", "file:///migrations", "inspect"},
 		runner,
 	)
 
@@ -83,7 +88,7 @@ func TestInspectDirtyVersion(t *testing.T) {
 	runner := &fakeMigration{version: 13, dirty: true}
 	exitCode, stdout, stderr := runWithFake(
 		t,
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		[]string{"-source", "file:///migrations", "inspect"},
 		runner,
 	)
 
@@ -96,7 +101,7 @@ func TestInspectDatabaseWithoutVersion(t *testing.T) {
 	runner := &fakeMigration{versionErr: migrate.ErrNilVersion}
 	exitCode, stdout, stderr := runWithFake(
 		t,
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		[]string{"-source", "file:///migrations", "inspect"},
 		runner,
 	)
 
@@ -111,7 +116,6 @@ func TestForceDirtyVersion(t *testing.T) {
 		t,
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"-confirm-target-version", "12",
@@ -134,7 +138,6 @@ func TestForceCanResetToNilVersion(t *testing.T) {
 		t,
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "1",
 			"-target-version", "-1",
 			"-confirm-target-version", "-1",
@@ -155,7 +158,6 @@ func TestForceRejectsCleanDatabase(t *testing.T) {
 		t,
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"-confirm-target-version", "12",
@@ -176,7 +178,6 @@ func TestForceRejectsUnexpectedDirtyVersion(t *testing.T) {
 		t,
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"-confirm-target-version", "12",
@@ -197,7 +198,6 @@ func TestForceRejectsConfirmationMismatchBeforeInitialization(t *testing.T) {
 	exitCode := run(
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"-confirm-target-version", "11",
@@ -221,7 +221,6 @@ func TestForceRequiresEveryGuard(t *testing.T) {
 	exitCode := run(
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"force",
@@ -242,7 +241,6 @@ func TestForceRejectsTargetBeyondDirtyVersion(t *testing.T) {
 	exitCode := run(
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "14",
 			"-confirm-target-version", "14",
@@ -267,7 +265,7 @@ func TestInspectReportsVersionAndCloseFailures(t *testing.T) {
 	}
 	exitCode, stdout, stderr := runWithFake(
 		t,
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "inspect"},
+		[]string{"-source", "file:///migrations", "inspect"},
 		runner,
 	)
 
@@ -288,7 +286,6 @@ func TestForceReportsFailureAndCloses(t *testing.T) {
 		t,
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"-confirm-target-version", "12",
@@ -313,7 +310,6 @@ func TestForceVerifiesUpdatedMetadata(t *testing.T) {
 		t,
 		[]string{
 			"-source", "file:///migrations",
-			"-database", "postgres://database",
 			"-expected-version", "13",
 			"-target-version", "12",
 			"-confirm-target-version", "12",
@@ -332,7 +328,7 @@ func TestRejectsUnsupportedCommandBeforeInitialization(t *testing.T) {
 	var stderr bytes.Buffer
 	factoryCalled := false
 	exitCode := run(
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "down"},
+		[]string{"-source", "file:///migrations", "down"},
 		&bytes.Buffer{},
 		&stderr,
 		func(string, string) (migration, error) {

--- a/services/common/migrate-runner/main.go
+++ b/services/common/migrate-runner/main.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strings"
 
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/tadoku/tadoku/services/common/postgresconfig"
@@ -30,7 +29,6 @@ func run(args []string, stdout, stderr io.Writer, factory migrationFactory) int 
 	flags.SetOutput(stderr)
 
 	sourceURL := flags.String("source", "", "migration source URL")
-	databaseURL := flags.String("database", "", "deprecated database URL escape hatch")
 
 	if err := flags.Parse(args); err != nil {
 		return 2
@@ -44,24 +42,16 @@ func run(args []string, stdout, stderr io.Writer, factory migrationFactory) int 
 		return 2
 	}
 
-	var postgresConfig postgresconfig.Config
-	if *databaseURL == "" {
-		var err error
-		postgresConfig, err = postgresconfig.Load("POSTGRES", "POSTGRES_URL")
-		if err != nil {
-			fmt.Fprintf(stderr, "migrate: postgres configuration: %v\n", err)
-			return 2
-		}
-		*databaseURL = postgresConfig.URL()
+	postgresConfig, err := postgresconfig.Load("POSTGRES", "POSTGRES_URL")
+	if err != nil {
+		fmt.Fprintf(stderr, "migrate: postgres configuration: %v\n", err)
+		return 2
 	}
+	databaseURL := postgresConfig.URL()
 	redact := func(value any) string {
-		result := postgresConfig.Redact(value)
-		if *databaseURL != "" {
-			result = strings.ReplaceAll(result, *databaseURL, "[REDACTED]")
-		}
-		return result
+		return postgresConfig.Redact(value)
 	}
-	runner, err := factory(*sourceURL, *databaseURL)
+	runner, err := factory(*sourceURL, databaseURL)
 	if err != nil {
 		fmt.Fprintf(stderr, "migrate: initialize: %s\n", redact(err))
 		return 1

--- a/services/common/migrate-runner/main_test.go
+++ b/services/common/migrate-runner/main_test.go
@@ -18,6 +18,15 @@ type fakeMigration struct {
 	closeCalled      bool
 }
 
+func setPostgresEnvironment(t *testing.T) {
+	t.Helper()
+	t.Setenv("POSTGRES_HOST", "db")
+	t.Setenv("POSTGRES_DATABASE", "database")
+	t.Setenv("POSTGRES_USER", "user")
+	t.Setenv("POSTGRES_PASSWORD", "password")
+	t.Setenv("POSTGRES_SSLMODE", "require")
+}
+
 func (m *fakeMigration) Up() error {
 	m.upCalled = true
 	return m.upErr
@@ -29,17 +38,18 @@ func (m *fakeMigration) Close() (error, error) {
 }
 
 func TestRunSuccessfulMigration(t *testing.T) {
+	setPostgresEnvironment(t)
 	runner := &fakeMigration{}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
 	exitCode := run(
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "up"},
+		[]string{"-source", "file:///migrations", "up"},
 		&stdout,
 		&stderr,
 		func(sourceURL, databaseURL string) (migration, error) {
 			assert.Equal(t, "file:///migrations", sourceURL)
-			assert.Equal(t, "postgres://database", databaseURL)
+			assert.Equal(t, "postgres://user:password@db:5432/database?sslmode=require", databaseURL)
 			return runner, nil
 		},
 	)
@@ -52,12 +62,13 @@ func TestRunSuccessfulMigration(t *testing.T) {
 }
 
 func TestRunNoChangeSucceeds(t *testing.T) {
+	setPostgresEnvironment(t)
 	runner := &fakeMigration{upErr: migrate.ErrNoChange}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
 	exitCode := run(
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "up"},
+		[]string{"-source", "file:///migrations", "up"},
 		&stdout,
 		&stderr,
 		func(string, string) (migration, error) {
@@ -72,12 +83,13 @@ func TestRunNoChangeSucceeds(t *testing.T) {
 }
 
 func TestRunMigrationFailureFailsAndCloses(t *testing.T) {
+	setPostgresEnvironment(t)
 	runner := &fakeMigration{upErr: errors.New("migration failed")}
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
 
 	exitCode := run(
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "up"},
+		[]string{"-source", "file:///migrations", "up"},
 		&stdout,
 		&stderr,
 		func(string, string) (migration, error) {
@@ -110,6 +122,19 @@ func TestRunRejectsInvalidArgumentsBeforeInitialization(t *testing.T) {
 	assert.Contains(t, stderr.String(), "expected command: up")
 }
 
+func TestRunRejectsRemovedDatabaseFlag(t *testing.T) {
+	var stderr bytes.Buffer
+	exitCode := run(
+		[]string{"-source", "file:///migrations", "-database", "postgres://database", "up"},
+		&bytes.Buffer{},
+		&stderr,
+		func(string, string) (migration, error) { return nil, nil },
+	)
+
+	assert.Equal(t, 2, exitCode)
+	assert.Contains(t, stderr.String(), "flag provided but not defined: -database")
+}
+
 func TestRunUsesIndividualPostgresEnvironment(t *testing.T) {
 	t.Setenv("POSTGRES_HOST", "db")
 	t.Setenv("POSTGRES_DATABASE", "database")
@@ -133,11 +158,12 @@ func TestRunUsesIndividualPostgresEnvironment(t *testing.T) {
 }
 
 func TestRunInitializationFailure(t *testing.T) {
+	setPostgresEnvironment(t)
 	var stderr bytes.Buffer
 	expectedErr := errors.New("cannot initialize")
 
 	exitCode := run(
-		[]string{"-source", "file:///migrations", "-database", "postgres://database", "up"},
+		[]string{"-source", "file:///migrations", "up"},
 		&bytes.Buffer{},
 		&stderr,
 		func(string, string) (migration, error) {

--- a/services/common/postgresconfig/config.go
+++ b/services/common/postgresconfig/config.go
@@ -23,30 +23,19 @@ var allowedSSLModes = map[string]bool{
 type Config struct {
 	Host, Database, User, Password, SSLMode string
 	Port                                    uint16
-	legacyURL                               string
 }
 
-// Load reads PREFIX_HOST, PORT, DATABASE, USER, PASSWORD, and SSLMODE. During
-// the compatibility release, legacyName is accepted only when no individual
-// field is present.
+// Load reads PREFIX_HOST, PORT, DATABASE, USER, PASSWORD, and SSLMODE. The
+// removed legacy URL variable is rejected explicitly so regressions fail closed.
 func Load(prefix, legacyName string) (Config, error) {
 	keys := []string{"HOST", "PORT", "DATABASE", "USER", "PASSWORD", "SSLMODE"}
 	values := make(map[string]string, len(keys))
-	individualPresent := false
 	for _, key := range keys {
-		value, present := os.LookupEnv(prefix + "_" + key)
-		values[key] = value
-		individualPresent = individualPresent || present
+		values[key] = os.Getenv(prefix + "_" + key)
 	}
-	legacy, legacyPresent := os.LookupEnv(legacyName)
-	if legacyPresent && individualPresent {
-		return Config{}, fmt.Errorf("postgres configuration mixes deprecated %s with individual fields", legacyName)
-	}
+	_, legacyPresent := os.LookupEnv(legacyName)
 	if legacyPresent {
-		if strings.TrimSpace(legacy) == "" {
-			return Config{}, fmt.Errorf("%s must not be empty", legacyName)
-		}
-		return Config{legacyURL: legacy}, nil
+		return Config{}, fmt.Errorf("%s is no longer supported; use individual postgres fields", legacyName)
 	}
 
 	missing := make([]string, 0)
@@ -73,9 +62,6 @@ func Load(prefix, legacyName string) (Config, error) {
 }
 
 func (c Config) URL() string {
-	if c.legacyURL != "" {
-		return c.legacyURL
-	}
 	u := &url.URL{Scheme: "postgres", User: url.UserPassword(c.User, c.Password), Host: net.JoinHostPort(c.Host, strconv.Itoa(int(c.Port))), Path: "/" + c.Database}
 	query := u.Query()
 	query.Set("sslmode", c.SSLMode)
@@ -95,14 +81,9 @@ func (c Config) String() string { return "postgres configuration (credentials re
 
 func (c Config) Redact(value any) string {
 	result := fmt.Sprint(value)
-	for _, secret := range []string{c.Password, c.legacyURL} {
+	for _, secret := range []string{c.Password} {
 		if secret != "" {
 			result = strings.ReplaceAll(result, secret, "[REDACTED]")
-		}
-	}
-	if parsed, err := url.Parse(c.legacyURL); err == nil && parsed.User != nil {
-		if password, ok := parsed.User.Password(); ok && password != "" {
-			result = strings.ReplaceAll(result, password, "[REDACTED]")
 		}
 	}
 	return result

--- a/services/common/postgresconfig/config_test.go
+++ b/services/common/postgresconfig/config_test.go
@@ -39,7 +39,7 @@ func TestLoadRejectsPartialMixedAndInvalid(t *testing.T) {
 		setIndividual(t)
 		t.Setenv("TEST_URL", "postgres://legacy")
 		_, err := Load("TEST", "TEST_URL")
-		assert.ErrorContains(t, err, "mixes deprecated")
+		assert.ErrorContains(t, err, "no longer supported")
 	})
 	t.Run("port", func(t *testing.T) {
 		setIndividual(t)
@@ -55,11 +55,9 @@ func TestLoadRejectsPartialMixedAndInvalid(t *testing.T) {
 	})
 }
 
-func TestLegacyAndRedaction(t *testing.T) {
+func TestLegacyIsRejected(t *testing.T) {
 	const legacy = "postgres://user:sentinel-secret@db/database?sslmode=require"
 	t.Setenv("TEST_URL", legacy)
-	cfg, err := Load("TEST", "TEST_URL")
-	require.NoError(t, err)
-	assert.Equal(t, legacy, cfg.URL())
-	assert.NotContains(t, cfg.Redact(fmt.Errorf("failed %s sentinel-secret", legacy)), "sentinel-secret")
+	_, err := Load("TEST", "TEST_URL")
+	assert.ErrorContains(t, err, "no longer supported")
 }


### PR DESCRIPTION
## Summary
- reject legacy PostgreSQL URL environment variables
- remove the migration tools’ complete-database-URL flag
- update tests and the recovery runbook for individual fields only

## Validation
- `bazel test //...`
- `bazel run //:gazelle`
- `git diff --check`