### PR TITLE
Fix estimated score previews

### DIFF
--- a/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/EditLogForm/Form.tsx
@@ -79,9 +79,7 @@ export const EditLogForm = ({ options, log }: Props) => {
   const previewPayload = previewPayloadJSON
     ? JSON.parse(previewPayloadJSON)
     : undefined
-  const scorePreview = useScorePreview(previewPayload, {
-    enabled: options.scoring_engine_enabled,
-  })
+  const scorePreview = useScorePreview(previewPayload)
 
   const router = useRouter()
   const updateLogMutation = useUpdateLog(updatedLog => {
@@ -178,7 +176,6 @@ export const EditLogForm = ({ options, log }: Props) => {
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
               <ScorePreviewEstimate
-                enabled={options.scoring_engine_enabled}
                 preview={scorePreview.data}
               />
             </div>

--- a/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogForm/Form.tsx
@@ -116,9 +116,7 @@ export const LogForm = ({
   const previewPayload = previewPayloadJSON
     ? JSON.parse(previewPayloadJSON)
     : undefined
-  const scorePreview = useScorePreview(previewPayload, {
-    enabled: options.scoring_engine_enabled,
-  })
+  const scorePreview = useScorePreview(previewPayload)
 
   const router = useRouter()
   const createLogMutation = useCreateLog(id => {
@@ -231,7 +229,6 @@ export const LogForm = ({
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
               <ScorePreviewEstimate
-                enabled={options.scoring_engine_enabled}
                 preview={scorePreview.data}
                 registrations={registrations}
               />

--- a/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
+++ b/frontend/apps/webv2/app/immersion/NewLogFormV2/Form.tsx
@@ -123,9 +123,7 @@ export const LogFormV2 = ({
   const previewPayload = previewPayloadJSON
     ? JSON.parse(previewPayloadJSON)
     : undefined
-  const scorePreview = useScorePreview(previewPayload, {
-    enabled: options.scoring_engine_enabled,
-  })
+  const scorePreview = useScorePreview(previewPayload)
 
   // Eagerly prefetch ongoing registrations (non-blocking)
   const registrations = useOngoingContestRegistrations()
@@ -275,7 +273,6 @@ export const LogFormV2 = ({
             </div>
             <div className="-mx-4 -mb-4 mt-4 px-4 py-2 md:-mx-7 md:-mb-7 md:px-7 md:py-2 bg-slate-500/5 text-center lg:text-right font-mono">
               <ScorePreviewEstimate
-                enabled={options.scoring_engine_enabled}
                 preview={scorePreview.data}
               />
             </div>

--- a/frontend/apps/webv2/app/immersion/components/ScorePreviewEstimate.tsx
+++ b/frontend/apps/webv2/app/immersion/components/ScorePreviewEstimate.tsx
@@ -5,13 +5,11 @@ import {
 } from '@app/immersion/api'
 
 interface Props {
-  enabled: boolean
   preview?: ScorePreview
   registrations?: ContestRegistrationView[]
 }
 
 export const ScorePreviewEstimate = ({
-  enabled,
   preview,
   registrations = [],
 }: Props) => {
@@ -24,19 +22,18 @@ export const ScorePreviewEstimate = ({
       <div>
         Estimated score:{' '}
         <strong>
-          {enabled && preview
+          {preview
             ? formatScore(preview.platform.score)
             : '-'}
         </strong>
       </div>
-      {enabled &&
-        preview?.contests.map(contest => (
-          <div key={contest.registration_id} className="text-sm">
-            {registrationsById.get(contest.registration_id)?.contest?.title ??
-              'Contest'}
-            : <strong>{formatScore(contest.estimate.score)}</strong>
-          </div>
-        ))}
+      {preview?.contests.map(contest => (
+        <div key={contest.registration_id} className="text-sm">
+          {registrationsById.get(contest.registration_id)?.contest?.title ??
+            'Contest'}
+          : <strong>{formatScore(contest.estimate.score)}</strong>
+        </div>
+      ))}
     </>
   )
 }


### PR DESCRIPTION
## What changed

- request score previews in log form v1, log form v2, and the edit form regardless of the authoritative scoring-engine rollout flag
- render any available preview response in the shared estimated-score component

## Why

`scoring_engine_enabled` controls whether the new scoring engine is authoritative for persisted scores. The frontend also used it to suppress the read-only preview query and display. Because the flag defaults to false, valid forms displayed `-` instead of an estimate.

This keeps the rollout flag scoped to authoritative scoring behavior while restoring estimated scores in both log forms.

## Validation

- `pnpm --filter webv2 exec tsc --noEmit`
- `pnpm --filter webv2 lint`
- `pnpm build`
- `git diff --check`